### PR TITLE
fix(build): java-library 적용 및 identity-client 의존성 노출 정리

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
 	java
+	`java-library`
 	id("org.springframework.boot") version "4.0.2" apply false
 	id("io.spring.dependency-management") version "1.1.7"
 }
@@ -22,6 +23,7 @@ configurations {
 
 subprojects {
 	apply(plugin = "java")
+	apply(plugin = "java-library")
 	apply(plugin = "org.springframework.boot")
 	apply(plugin = "io.spring.dependency-management")
 

--- a/identity/identity-client/build.gradle.kts
+++ b/identity/identity-client/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation(project(":identity:identity-core"))
+    api(project(":identity:identity-core"))
 
     // Validation
     implementation("org.springframework.boot:spring-boot-starter-validation")


### PR DESCRIPTION
## 관련 이슈

- closes #13 

## 변경 사항

- 하위 모듈에 `java-library` 플러그인 적용 방식 정리
- `identity-client`에서 `identity-core` 의존성을 `api`로 변경