### PR TITLE
docs(reservation-app): 빈자리 알람 문서화 보강

### DIFF
--- a/reservation/reservation-application/README.md
+++ b/reservation/reservation-application/README.md
@@ -1,8 +1,8 @@
 # Reservation Application
 
-`reservation:reservation-application` 모듈은 좌석 예약, 빈자리 알림, 예약 검증 정책을 담당하는 Spring Boot 기반 애플리케이션입니다.
+`reservation:reservation-application` 모듈은 좌석 예약, 빈자리 알림, 예약 검증 정책과 예약 취소 이후의 빈자리 알림 생성 연계 흐름을 담당하는 Spring Boot 기반 애플리케이션입니다.
 
-패키지는 기능 단위로 `book`, `vacancy`, `verification` 으로 분리되어 있습니다.
+패키지는 기능 단위로 `book`, `vacancy`, `verification` 으로 분리되어 있고, 좌석/시간 범위와 이벤트 같은 공통 모델은 `shared` 패키지에서 재사용합니다.
 
 ## 개요
 
@@ -17,6 +17,7 @@
 | 패키지                                                        | 역할                                        |
 |------------------------------------------------------------|-------------------------------------------|
 | `com.seatliberator.seatliberator.reservation.book`         | `Seat`, `Reservation` 도메인과 예약/좌석 관리 유스케이스 |
+| `com.seatliberator.seatliberator.reservation.shared`       | `SeatLocator`, `TimeRange`, domain event 등 예약/알림 공통 모델 |
 | `com.seatliberator.seatliberator.reservation.vacancy`      | 빈자리 알림 요청 도메인과 알림 신청/취소 유스케이스             |
 | `com.seatliberator.seatliberator.reservation.verification` | 예약 조회/검증 권한 정책, 사용 처리 유스케이스               |
 
@@ -25,13 +26,38 @@
 - 한 사용자는 동시에 하나의 예약만 가질 수 있습니다. `Reservation.userId` 에 유니크 제약이 있습니다.
 - 같은 좌석의 예약 시간은 서로 겹칠 수 없습니다. 시간 구간은 `[startTime, endTime)` 규칙으로 처리됩니다.
 - 예약 생성/수정 시 대상 좌석은 반드시 존재해야 합니다.
+- 모든 REST API는 인증이 필요하며, 사용자 식별자는 JWT로부터 `ActorContextHolder` 에 바인딩된 actor subject를 사용합니다.
 - 예약 사용 처리 시 이미 사용된 예약은 다시 사용할 수 없고, 종료 시각 이후에는 `EXPIRED` 로 전이됩니다.
+- 예약 취소가 성공하면 `Reservation` 은 `CANCELED` 로 전이되고 `ReservationCanceled` 도메인 이벤트를 발행합니다.
 - 빈자리 알림은 동일한 `(userId, roomId, seatId, targetStartTime, targetEndTime)` 조합에 대해 `ACTIVE` 상태 중복 등록이 불가능합니다.
+- 예약 취소 이벤트를 받으면 같은 좌석이고 시간이 겹치는 `ACTIVE` 빈자리 알림 요청만 조회합니다.
+- 조회된 요청마다 `NOTIFICATION_CREATE_REQUEST` 이벤트를 발행하고, 해당 요청은 `FULFILLED` 로 전이됩니다.
 - 취소된 빈자리 알림은 동일 조건으로 다시 등록할 수 있습니다.
+
+## 빈자리 알림 생성 흐름
+
+예약 취소와 빈자리 알림 생성은 직접 결합하지 않고, `ReservationCanceled` 도메인 이벤트를 통해 연결합니다.
+
+| 단계           | 설명                                                                                                                                                                                  |
+|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1. 빈자리 알림 신청 | 사용자가 좌석/시간대 기준으로 `VacancyAlertRequest` 를 생성합니다. 초기 상태는 `ACTIVE` 입니다.                                                                                                                |
+| 2. 예약 취소     | 예약이 취소되면 `Reservation` 이 `CANCELED` 로 전이되고 `ReservationCanceled(locator, range, canceledAt)` 이벤트가 발생합니다.                                                                            |
+| 3. 대상자 조회    | `ReservationCanceledHandler` 가 같은 좌석이고 시간 구간이 겹치는 `ACTIVE` 요청만 조회합니다. 시간 겹침 판별은 `[start, end)` 기준으로 `request.start < reservation.end && request.end > reservation.start` 조건을 사용합니다. |
+| 4. 알림 생성 연결  | 각 요청에 대해 notification 모듈의 `NOTIFICATION_CREATE_REQUEST` 이벤트를 발행하고, 요청 상태를 `FULFILLED` 로 전이합니다.                                                                                      |
+
+현재 구현 기준으로 다음 요청은 알림 대상에서 제외됩니다.
+
+- 이미 `CANCELLED`, `EXPIRED`, `FULFILLED` 상태인 요청
+- 다른 좌석에 대한 요청
+- 시간대가 겹치지 않는 요청
+
+상세 시나리오와 도메인 정의는 [docs/VACANCY_ALERT_CANCEL_FLOW.md](docs/VACANCY_ALERT_CANCEL_FLOW.md) 에 정리되어 있습니다.
 
 ## API
 
 현재 이 모듈에는 `book`, `vacancy` 패키지에 대한 REST 컨트롤러만 존재합니다. `verification` 은 내부 애플리케이션 포트로만 노출됩니다.
+
+현재 `SecurityConfiguration` 기준으로 모든 API는 인증이 필요합니다.
 
 성공 응답은 컨트롤러에 명시되어 있지만, 예외 응답 형식은 이 모듈 내부에 별도 `@ControllerAdvice` 가 정의되어 있지 않습니다.
 
@@ -92,7 +118,7 @@
 |----------|-------------------------|-----------|
 | `POST`   | `/reservation`          | 예약 생성     |
 | `PUT`    | `/reservation`          | 예약 수정     |
-| `DELETE` | `/reservation/{userId}` | 사용자 예약 취소 |
+| `DELETE` | `/reservation`          | 현재 사용자 예약 취소 |
 
 시간 필드는 `Instant` 로 매핑되므로 요청 본문에는 UTC ISO-8601 문자열을 사용합니다.
 
@@ -100,11 +126,10 @@
 
 ```json
 {
-  "userId": "user-1",
   "roomId": "room-1",
   "seatId": "seat-1",
-  "startTime": "2025-06-01T01:00:00Z",
-  "endTime": "2025-06-01T02:00:00Z"
+  "startAt": "2025-06-01T01:00:00Z",
+  "endAt": "2025-06-01T02:00:00Z"
 }
 ```
 
@@ -112,7 +137,10 @@
 
 ```json
 {
-  "success": true
+  "reservationId": 1,
+  "actorId": "user-1",
+  "roomId": "room-1",
+  "seatId": "seat-1"
 }
 ```
 
@@ -120,11 +148,10 @@
 
 ```json
 {
-  "userId": "user-1",
   "roomId": "room-1",
   "seatId": "seat-2",
-  "startTime": "2025-06-01T01:30:00Z",
-  "endTime": "2025-06-01T02:30:00Z"
+  "startAt": "2025-06-01T01:30:00Z",
+  "endAt": "2025-06-01T02:30:00Z"
 }
 ```
 
@@ -132,27 +159,35 @@
 
 ```json
 {
-  "success": true
+  "reservationId": 1,
+  "actorId": "user-1",
+  "roomId": "room-1",
+  "seatId": "seat-2"
 }
 ```
 
-**`DELETE /reservation/{userId}`**
+**`DELETE /reservation`**
 
 성공 응답:
 
 ```json
 {
-  "success": true
+  "reservationId": 1,
+  "actorId": "user-1",
+  "roomId": "room-1",
+  "seatId": "seat-1"
 }
 ```
 
 설명:
 
-- 예약 생성은 동일 사용자의 기존 예약이 있으면 `false` 를 반환합니다.
-- 예약 생성/수정은 동일 좌석의 겹치는 시간대 예약이 있으면 `false` 를 반환합니다.
-- 예약 생성/수정은 `startTime < endTime` 이어야 합니다.
+- `userId` 는 요청 본문이 아니라 인증된 actor에서 가져옵니다.
+- 예약 생성은 동일 사용자의 기존 예약이 있으면 `BookApplicationException(RESERVATION_ALREADY_EXISTS)` 를 던집니다.
+- 예약 생성/수정은 동일 좌석의 겹치는 시간대 예약이 있으면 `BookApplicationException(RESERVATION_TIME_CONFLICT)` 를 던집니다.
+- 예약 생성/수정은 `startAt < endAt` 이어야 합니다.
 - 예약 생성/취소/수정 시 좌석 조회에는 비관적 락이 사용됩니다.
-- 예약 취소 대상이 없으면 예외가 발생합니다.
+- 예약 취소 대상이 없으면 `BookApplicationException(RESERVATION_NOT_FOUND)` 가 발생합니다.
+- 예약 취소가 성공하면 `ReservationCanceled` 이벤트가 발행되고 후속 빈자리 알림 생성 흐름이 연결될 수 있습니다.
 
 ### Vacancy API
 
@@ -165,11 +200,10 @@
 
 ```json
 {
-  "userId": "user-1",
   "roomId": "room-1",
   "seatId": "seat-1",
-  "targetStartTime": "2025-06-01T01:00:00Z",
-  "targetEndTime": "2025-06-01T02:00:00Z"
+  "startAt": "2025-06-01T01:00:00Z",
+  "endAt": "2025-06-01T02:00:00Z"
 }
 ```
 
@@ -180,20 +214,15 @@
 
 **`DELETE /vacancy-alert/{alertId}`**
 
-요청 헤더:
-
-```http
-userId: user-1
-```
-
 응답:
 
 - `204 No Content`
 
 설명:
 
-- 알림 신청 시 `targetStartTime < targetEndTime` 이어야 합니다.
-- 알림 신청 시 `targetStartTime` 은 요청 시각보다 미래여야 합니다.
+- `userId` 는 요청 본문이나 헤더가 아니라 인증된 actor에서 가져옵니다.
+- 알림 신청 시 `startAt < endAt` 이어야 합니다.
+- 알림 신청 시 `startAt` 은 요청 시각보다 미래여야 합니다.
 - 동일한 활성 알림을 중복 등록하면 `VacancyApplicationException(RVC001)` 이 발생합니다.
 - 알림 취소는 본인만 가능합니다.
 - 존재하지 않는 알림 취소 시 `VacancyApplicationException(RVC002)` 이 발생합니다.
@@ -230,6 +259,7 @@ userId: user-1
 
 - `RESERVED`: 생성 직후 상태
 - `USED`: 정상 사용 처리된 상태
+- `CANCELED`: 취소 처리된 상태. 이때 `ReservationCanceled` 이벤트가 발생할 수 있습니다.
 - `EXPIRED`: 종료 시각 이후 사용 시도 시 전이되는 상태
 
 ## ERD
@@ -256,8 +286,8 @@ erDiagram
         VARCHAR user_id UK
         VARCHAR room_id
         VARCHAR seat_id
-        TIMESTAMP start_time
-        TIMESTAMP end_time
+        TIMESTAMP target_start_at
+        TIMESTAMP target_end_at
         VARCHAR status
     }
 
@@ -283,10 +313,10 @@ erDiagram
     VACANCY_ALERT_REQUEST {
         UUID id PK
         VARCHAR user_id
-        VARCHAR room_id
-        VARCHAR seat_id
-        TIMESTAMP target_start_time
-        TIMESTAMP target_end_time
+        VARCHAR target_room_id
+        VARCHAR target_seat_id
+        TIMESTAMP target_start_at
+        TIMESTAMP target_end_at
         VARCHAR status
         TIMESTAMP requested_at
         TIMESTAMP cancelled_at

--- a/reservation/reservation-application/docs/VACANCY_ALERT_CANCEL_FLOW.md
+++ b/reservation/reservation-application/docs/VACANCY_ALERT_CANCEL_FLOW.md
@@ -1,0 +1,99 @@
+# 예약 취소와 빈자리 알림 생성 흐름
+
+## 목적
+
+이 문서는 이슈 [#26](https://github.com/seat-liberator/SeatLiberator/issues/26) 과 상위
+이슈 [#23](https://github.com/seat-liberator/SeatLiberator/issues/23) 에서 요구한 문서화 항목 중, 예약 취소와 빈자리 알림 생성 연계 흐름을 정리합니다.
+
+핵심 목표는 다음 세 가지입니다.
+
+- 예약 취소 시 빈자리 알림 대상자를 어떻게 찾는지 설명한다.
+- 유효한 신청자에게만 알림 생성 흐름이 연결되는 조건을 명시한다.
+- 예약 취소와 알림 생성을 직접 결합하지 않는 최소 연계 구조를 설명한다.
+
+## 관련 도메인
+
+| 구성요소                                    | 역할                                                                                |
+|-----------------------------------------|-----------------------------------------------------------------------------------|
+| `Reservation`                           | 좌석 예약 aggregate. 취소 시 `CANCELED` 로 전이되고 `ReservationCanceled` 이벤트를 발행한다.          |
+| `ReservationCanceled`                   | 취소된 예약의 좌석(`SeatLocator`)과 시간 범위(`TimeRange`), 취소 시각을 담는 도메인 이벤트                  |
+| `VacancyAlertRequest`                   | 특정 좌석/시간대에 대한 빈자리 알림 신청. 상태는 `ACTIVE`, `CANCELLED`, `EXPIRED`, `FULFILLED` 를 가진다. |
+| `ReservationCanceledHandler`            | 예약 취소 이벤트를 받아 빈자리 알림 대상 조회와 notification 생성 이벤트 발행을 담당한다.                         |
+| `NotificationCreateRequestEventPayload` | notification 모듈로 전달하는 생성 요청 payload                                               |
+
+## 시나리오
+
+### 1. 빈자리 알림 신청
+
+사용자는 특정 좌석과 시간대에 대해 빈자리 알림을 신청할 수 있습니다.
+
+- 식별 기준은 `(userId, roomId, seatId, targetStartAt, targetEndAt)` 입니다.
+- 같은 조합의 `ACTIVE` 요청은 중복 생성할 수 없습니다.
+- 생성 직후 상태는 `ACTIVE` 입니다.
+
+### 2. 예약 취소
+
+예약이 취소되면 `Reservation.cancel(canceledAt)` 이 호출됩니다.
+
+- 예약 상태는 `CANCELED` 로 전이됩니다.
+- 같은 트랜잭션 안에서 `ReservationCanceled(locator, range, canceledAt)` 이벤트가 등록됩니다.
+
+### 3. 빈자리 알림 대상 조회
+
+`ReservationCanceledHandler` 는 이벤트의 좌석과 시간 범위를 기준으로 `ACTIVE` 요청만 조회합니다.
+
+조회 조건은 다음과 같습니다.
+
+- 같은 `roomId`, `seatId`
+- 상태가 `ACTIVE`
+- 시간 구간이 겹침
+
+시간 구간은 반개구간 `[start, end)` 기준으로 판단합니다.
+
+```text
+request.start < reservation.end
+AND request.end > reservation.start
+```
+
+즉, 아래 요청은 대상에서 제외됩니다.
+
+- 이미 취소되었거나 만료되었거나 이미 처리 완료된 요청
+- 다른 좌석에 대한 요청
+- 시간이 맞닿기만 하고 실제로 겹치지 않는 요청
+
+### 4. 알림 생성 연계
+
+조회된 각 요청에 대해 handler는 두 가지를 수행합니다.
+
+1. notification 모듈로 `NOTIFICATION_CREATE_REQUEST` 이벤트를 발행합니다.
+2. 해당 `VacancyAlertRequest` 상태를 `FULFILLED` 로 전이합니다.
+
+이때 notification 본문에는 사용자에게 다시 확인할 좌석/시간대 정보가 포함됩니다.
+
+이 구조의 의도는 다음과 같습니다.
+
+- 예약 도메인은 "취소됨"이라는 사실만 발행한다.
+- 빈자리 알림 대상 판별은 vacancy 쪽 후속 처리에서 맡는다.
+- 실제 알림 저장/전달 채널 구현은 notification 모듈 이후 단계로 분리한다.
+
+## 검증 기준
+
+현재 구현은 통합 테스트로 아래 조건을 검증합니다.
+
+- 예약 취소 시 같은 좌석/시간대의 활성 요청에 대해서만 notification 생성 이벤트가 발행된다.
+- 미리 취소된 요청은 대상이 아니다.
+- 다른 좌석 요청은 대상이 아니다.
+- 실제 대상 요청만 `FULFILLED` 로 전이된다.
+
+관련 테스트:
+
+- `src/test/java/com/seatliberator/seatliberator/reservation/integration/ReservationCancelVacancyAlertFlowTest.java`
+
+## 남겨둔 범위
+
+이 문서는 현재 구현 범위를 기준으로 합니다. 다음 항목은 의도적으로 포함하지 않습니다.
+
+- 외부 메시지 브로커 연동
+- outbox / inbox / idempotency
+- 이메일, 푸시, SSE, WebSocket 같은 전달 채널 구현
+- 알림 문구/템플릿 고도화


### PR DESCRIPTION
## 관련 이슈

- closes #23
- follow-up for #26

## 변경 내용

PR 69에서 구현된 예약 취소 -> 빈자리 알림 생성 흐름을 저장소 문서 기준으로 마무리했습니다.

이번 PR은 크게 두 가지를 다룹니다.

- `reservation-application` README를 현재 코드 기준으로 최신화
- 예약 취소와 빈자리 알림 생성 흐름을 별도 문서로 정리

### reservation-application README

- 모듈 소개에 예약 취소 이후의 빈자리 알림 생성 연계 흐름을 반영했습니다.
- `shared` 패키지와 인증 기반 actor 식별 방식을 문서에 추가했습니다.
- `ReservationCanceled`, `NOTIFICATION_CREATE_REQUEST`, `FULFILLED` 상태 전이를 README에서 바로 파악할 수 있게 정리했습니다.
- PR 69 이후 달라진 reservation / vacancy API 요청 및 응답 형식을 실제 controller 기준으로 맞췄습니다.
- ERD와 상태 설명도 현재 엔티티 컬럼명과 상태값 기준으로 정리했습니다.

### docs

- `reservation/reservation-application/docs/VACANCY_ALERT_CANCEL_FLOW.md` 를 추가했습니다.
- 빈자리 알림 신청, 예약 취소, 대상 조회, 알림 생성 연계까지 핵심 시나리오를 단계별로 정리했습니다.
- 어떤 요청이 알림 대상이 되고 제외되는지, 시간 겹침 판별 규칙이 무엇인지 명시했습니다.
- reservation 과 notification 책임을 domain event로 느슨하게 연결한 이유와 현재 범위 밖 항목도 함께 정리했습니다.

## 기대 효과

- 상위 이슈 23의 완료 조건인 요구사항 / 핵심 시나리오 / 도메인 정의 문서화가 레포 안에서 바로 확인됩니다.
- PR 69 diff를 다시 추적하지 않아도 예약 취소와 빈자리 알림 생성 흐름을 이해할 수 있습니다.
- `reservation-application` README가 현재 코드와 어긋나지 않도록 정리됩니다.

## 검증

- `git diff --check`
- README / 신규 docs 내용을 controller, domain event handler, integration test 구현과 대조