### PR TITLE
Spring Actuator 기반 Prometheus metric 노출 설정

### DIFF
--- a/board/board-application/src/main/resources/application-local.yml
+++ b/board/board-application/src/main/resources/application-local.yml
@@ -25,7 +25,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: "health,info"
+        include: "health,info,prometheus"
   endpoint:
     health:
       roles: ADMIN

--- a/bootstrap/resource-application-starter/src/main/java/com/seatliberator/seatliberator/bootstrap/autoconfigure/ResourceServerAuthorizeProperties.java
+++ b/bootstrap/resource-application-starter/src/main/java/com/seatliberator/seatliberator/bootstrap/autoconfigure/ResourceServerAuthorizeProperties.java
@@ -18,7 +18,7 @@ public record ResourceServerAuthorizeProperties(
 
         URI jwkSetUri,
 
-        @DefaultValue({"/error", "/actuator/health", "/actuator/health/**"})
+        @DefaultValue({"/error", "/actuator/prometheus", "/actuator/health", "/actuator/health/**"})
         @NotEmpty
         List<@NotBlank String> permits,
 

--- a/bootstrap/web-application-starter/build.gradle.kts
+++ b/bootstrap/web-application-starter/build.gradle.kts
@@ -25,4 +25,5 @@ dependencies {
 
     // Observability
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    runtimeOnly("io.micrometer:micrometer-registry-prometheus")
 }

--- a/identity/identity-application/src/main/resources/application-local.yml
+++ b/identity/identity-application/src/main/resources/application-local.yml
@@ -19,7 +19,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: "health,info"
+        include: "health,info,prometheus"
   endpoint:
     health:
       show-details: never

--- a/notification/notification-application/src/main/resources/application-local.yml
+++ b/notification/notification-application/src/main/resources/application-local.yml
@@ -25,7 +25,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: "health,info"
+        include: "health,info,prometheus"
   endpoint:
     health:
       roles: ADMIN

--- a/reservation/reservation-application/src/main/resources/application-local.yml
+++ b/reservation/reservation-application/src/main/resources/application-local.yml
@@ -25,7 +25,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: "health,info"
+        include: "health,info,prometheus"
   endpoint:
     health:
       roles: ADMIN


### PR DESCRIPTION
## 관련 이슈

- Closes #70 

## 변경 사항

- Prometheus registry 의존성 추가
- 각 애플리케이션의 `application-local.yml`에서 `prometheus` 엔드포인트 노출 추가
- resource server 계열 애플리케이션에서 `prometheus`는 수집 가능하게 열어놓고, `health`는 최소 상태 확인만 가능하도록 permit 기본 값 수정

### Prometheus registry

- `bootstrap:web-application-starter`에 `io.micrometer:micrometer-registry-prometheus`를 runtime dependency로 추가
- Spring Actuator가 `/actuator/prometheus` 엔드포인트를 로컬 환경에서 노출 할 수 있도록 구성

### local actuator 엔드포인트

- `board`, `reservation`, `notification`, `identity`의 `application-local.yml`에서 `management.endpoints.web.exposure.include` 범위에 `prometheus`를 추가
- 기존 `health`, `info` 중심의 관측 엔드포엔티 구성에 metric 수집 경로를 같이 열도록 구성

### Resource server actuator 접근 기본 값 수정

- `bootstrap:resource-application-starter`의 permit 기본 값에 `/actuator/prometheus`를 추가
- `/actuator/health`, `/actuator/health/**`는 계속 permit 대상으로 유지해서 최소 health check는 열어놓음. (상세 정보 노출은 actuator의 `application.yml` 설정에서 `roles`, `show-details`, `show-components` 설정에 계속 맡기도록 함

## 검증

- `./gradlew :bootstrap:resource-application-starter:compileJava`