### PR TITLE
feat(reservation): 가용 좌석 조회 API 추가

### DIFF
--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/application/model/AvailableSeats.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/application/model/AvailableSeats.java
@@ -1,0 +1,41 @@
+package com.seatliberator.seatliberator.reservation.availability.application.model;
+
+import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
+import com.seatliberator.seatliberator.reservation.domain.SimpleSeatLocator;
+import com.seatliberator.seatliberator.reservation.domain.persistence.Seat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class AvailableSeats {
+    private final List<Seat> seats;
+
+    private AvailableSeats(List<Seat> seats) {
+        this.seats = seats;
+    }
+
+    public static AvailableSeats from(List<Seat> seats, List<SeatLocator> reservedLocators) {
+        var occupied = reservedLocators.stream()
+                .map(SimpleSeatLocator::of)
+                .collect(Collectors.toSet());
+
+        var available = seats.stream()
+                .filter(seat -> !occupied.contains(SimpleSeatLocator.of(seat.getLocator())))
+                .toList();
+
+        return new AvailableSeats(available);
+    }
+
+    public List<Seat> toList() {
+        return seats;
+    }
+
+    public Stream<Seat> stream() {
+        return seats.stream();
+    }
+
+    public boolean isEmpty() {
+        return seats.isEmpty();
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/application/port/in/SeatAvailabilityReader.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/application/port/in/SeatAvailabilityReader.java
@@ -1,0 +1,10 @@
+package com.seatliberator.seatliberator.reservation.availability.application.port.in;
+
+import com.seatliberator.seatliberator.reservation.availability.application.port.in.entry.AvailabilitySeatEntry;
+import com.seatliberator.seatliberator.reservation.domain.TimeRange;
+
+import java.util.List;
+
+public interface SeatAvailabilityReader {
+    List<AvailabilitySeatEntry> findAvailabilitySeats(String roomId, TimeRange range);
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/application/port/in/entry/AvailabilitySeatEntry.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/application/port/in/entry/AvailabilitySeatEntry.java
@@ -1,0 +1,18 @@
+package com.seatliberator.seatliberator.reservation.availability.application.port.in.entry;
+
+import com.seatliberator.seatliberator.reservation.domain.persistence.Seat;
+
+public record AvailabilitySeatEntry(
+        Long id,
+        String roomId,
+        String seatId
+) {
+    public static AvailabilitySeatEntry from(Seat seat) {
+        var locator = seat.getLocator();
+        return new AvailabilitySeatEntry(
+                seat.getId(),
+                locator.roomId(),
+                locator.seatId()
+        );
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/application/service/DefaultSeatAvailabilityReader.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/application/service/DefaultSeatAvailabilityReader.java
@@ -26,6 +26,7 @@ public class DefaultSeatAvailabilityReader implements SeatAvailabilityReader {
         if (seats.isEmpty()) return List.of();
 
         var reservedLocators = reservationQuery.findAllOverlappingInRoom(roomId, range).stream()
+                .filter(r -> r.isReserved() || r.isUsed())
                 .<SeatLocator>map(Reservation::getLocator)
                 .toList();
 

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/application/service/DefaultSeatAvailabilityReader.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/application/service/DefaultSeatAvailabilityReader.java
@@ -1,0 +1,36 @@
+package com.seatliberator.seatliberator.reservation.availability.application.service;
+
+import com.seatliberator.seatliberator.reservation.availability.application.model.AvailableSeats;
+import com.seatliberator.seatliberator.reservation.availability.application.port.in.SeatAvailabilityReader;
+import com.seatliberator.seatliberator.reservation.availability.application.port.in.entry.AvailabilitySeatEntry;
+import com.seatliberator.seatliberator.reservation.book.application.port.out.ReservationQuery;
+import com.seatliberator.seatliberator.reservation.book.application.port.out.SeatQuery;
+import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
+import com.seatliberator.seatliberator.reservation.domain.TimeRange;
+import com.seatliberator.seatliberator.reservation.domain.persistence.Reservation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DefaultSeatAvailabilityReader implements SeatAvailabilityReader {
+    private final ReservationQuery reservationQuery;
+    private final SeatQuery seatQuery;
+
+    @Override
+    public List<AvailabilitySeatEntry> findAvailabilitySeats(String roomId, TimeRange range) {
+        var seats = seatQuery.findByRoomId(roomId);
+
+        if (seats.isEmpty()) return List.of();
+
+        var reservedLocators = reservationQuery.findAllOverlappingInRoom(roomId, range).stream()
+                .<SeatLocator>map(Reservation::getLocator)
+                .toList();
+
+        return AvailableSeats.from(seats, reservedLocators).stream()
+                .map(AvailabilitySeatEntry::from)
+                .toList();
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/infrastructure/web/controller/SeatAvailabilityController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/infrastructure/web/controller/SeatAvailabilityController.java
@@ -1,0 +1,28 @@
+package com.seatliberator.seatliberator.reservation.availability.infrastructure.web.controller;
+
+import com.seatliberator.seatliberator.reservation.availability.application.port.in.SeatAvailabilityReader;
+import com.seatliberator.seatliberator.reservation.domain.SimpleTimeRange;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Instant;
+
+@RestController
+@RequestMapping("/rooms")
+@RequiredArgsConstructor
+public class SeatAvailabilityController {
+    private final SeatAvailabilityReader reader;
+
+    @GetMapping("/{roomId}/available-seats")
+    public ResponseEntity<?> getAvailableSeats(
+            @PathVariable("roomId") String roomId,
+            @RequestParam(name = "start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant start,
+            @RequestParam(name = "end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant end
+    ) {
+        var range = SimpleTimeRange.from(start, end);
+        var result = reader.findAvailabilitySeats(roomId, range);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/in/SeatReader.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/in/SeatReader.java
@@ -1,0 +1,12 @@
+package com.seatliberator.seatliberator.reservation.book.application.port.in;
+
+import com.seatliberator.seatliberator.reservation.book.application.port.in.entry.SeatEntry;
+import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
+
+import java.util.List;
+
+public interface SeatReader {
+    SeatEntry read(SeatLocator locator);
+
+    List<SeatEntry> findAllByRoomId(String roomId);
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/in/entry/SeatEntry.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/in/entry/SeatEntry.java
@@ -1,0 +1,18 @@
+package com.seatliberator.seatliberator.reservation.book.application.port.in.entry;
+
+import com.seatliberator.seatliberator.reservation.domain.persistence.Seat;
+
+public record SeatEntry(
+        Long id,
+        String roomId,
+        String seatId
+) {
+    public static SeatEntry from(Seat seat) {
+        var locator = seat.getLocator();
+        return new SeatEntry(
+                seat.getId(),
+                locator.roomId(),
+                locator.seatId()
+        );
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/ReservationQuery.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/ReservationQuery.java
@@ -1,0 +1,26 @@
+package com.seatliberator.seatliberator.reservation.book.application.port.out;
+
+import com.seatliberator.seatliberator.reservation.book.application.port.out.criteria.ReservationCriteria;
+import com.seatliberator.seatliberator.reservation.book.application.port.out.criteria.ReservationExclusion;
+import com.seatliberator.seatliberator.reservation.book.application.port.out.criteria.ReservationTarget;
+import com.seatliberator.seatliberator.reservation.domain.TimeRange;
+import com.seatliberator.seatliberator.reservation.domain.persistence.Reservation;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ReservationQuery {
+    Optional<Reservation> findById(Long id);
+
+    Optional<Reservation> findByUserId(String userId);
+
+    Optional<Reservation> findOne(ReservationCriteria criteria);
+
+    boolean existsOverlapping(ReservationTarget target);
+
+    boolean existsOverlapping(ReservationTarget target, ReservationExclusion exclusion);
+
+    List<Reservation> findAllOverlapping(TimeRange range);
+
+    List<Reservation> findAllOverlappingInRoom(String roomId, TimeRange range);
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/SeatQuery.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/SeatQuery.java
@@ -1,0 +1,18 @@
+package com.seatliberator.seatliberator.reservation.book.application.port.out;
+
+import com.seatliberator.seatliberator.reservation.book.application.port.out.criteria.SeatExclusion;
+import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
+import com.seatliberator.seatliberator.reservation.domain.persistence.Seat;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SeatQuery {
+    Optional<Seat> findByLocator(SeatLocator locator);
+
+    List<Seat> findByRoomId(String roomId);
+
+    boolean existsByLocator(SeatLocator locator);
+
+    boolean existsByLocator(SeatLocator locator, SeatExclusion exclusion);
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/SeatStore.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/SeatStore.java
@@ -4,6 +4,7 @@ import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
 import com.seatliberator.seatliberator.reservation.domain.persistence.Seat;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface SeatStore {
@@ -15,6 +16,8 @@ public interface SeatStore {
     Optional<Seat> findByLocator(SeatLocator locator);
 
     Optional<Seat> findForUpdate(String roomId, String seatId);
+
+    List<Seat> findByRoomId(String roomId);
 
     void deleteByRoomIdAndSeatId(String roomId, String seatId);
 

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/SeatStore.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/SeatStore.java
@@ -3,8 +3,6 @@ package com.seatliberator.seatliberator.reservation.book.application.port.out;
 import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
 import com.seatliberator.seatliberator.reservation.domain.persistence.Seat;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 
 public interface SeatStore {
@@ -13,22 +11,7 @@ public interface SeatStore {
 
     Optional<Seat> findByRoomIdAndSeatId(String roomId, String seatId);
 
-    Optional<Seat> findByLocator(SeatLocator locator);
-
     Optional<Seat> findForUpdate(String roomId, String seatId);
 
-    List<Seat> findByRoomId(String roomId);
-
-    void deleteByRoomIdAndSeatId(String roomId, String seatId);
-
     void deleteByLocator(SeatLocator locator);
-
-    boolean existsSeatConflict(String roomId, String seatId);
-
-    boolean existsByLocator(SeatLocator locator);
-
-    boolean existsSeatConflictExcept(Long id, String roomId, String seatId);
-
-    boolean existsByLocatorWithExcludeIds(SeatLocator locator, Collection<Long> ids);
-
 }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/ReservationCriteria.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/ReservationCriteria.java
@@ -1,0 +1,27 @@
+package com.seatliberator.seatliberator.reservation.book.application.port.out.criteria;
+
+import com.seatliberator.seatliberator.reservation.domain.ReservationStatus;
+import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
+import com.seatliberator.seatliberator.reservation.domain.TimeRange;
+
+import java.util.Objects;
+
+public record ReservationCriteria(
+        SeatLocator locator,
+        TimeRange range,
+        ReservationStatus status
+) {
+    public ReservationCriteria {
+        Objects.requireNonNull(locator);
+        Objects.requireNonNull(range);
+        Objects.requireNonNull(status);
+    }
+
+    public static ReservationCriteria of(
+            SeatLocator locator,
+            TimeRange range,
+            ReservationStatus status
+    ) {
+        return new ReservationCriteria(locator, range, status);
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/ReservationExclusion.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/ReservationExclusion.java
@@ -1,0 +1,22 @@
+package com.seatliberator.seatliberator.reservation.book.application.port.out.criteria;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+public record ReservationExclusion(
+        Set<Long> ids
+) {
+    public ReservationExclusion {
+        Objects.requireNonNull(ids);
+    }
+
+    public static ReservationExclusion of(Collection<Long> ids) {
+        return new ReservationExclusion(new HashSet<>(ids));
+    }
+
+    public boolean isEmpty() {
+        return ids.isEmpty();
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/ReservationTarget.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/ReservationTarget.java
@@ -1,0 +1,20 @@
+package com.seatliberator.seatliberator.reservation.book.application.port.out.criteria;
+
+import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
+import com.seatliberator.seatliberator.reservation.domain.TimeRange;
+
+import java.util.Objects;
+
+public record ReservationTarget(
+        SeatLocator locator,
+        TimeRange ranga
+) {
+    public ReservationTarget {
+        Objects.requireNonNull(locator);
+        Objects.requireNonNull(ranga);
+    }
+
+    public static ReservationTarget of(SeatLocator locator, TimeRange range) {
+        return new ReservationTarget(locator, range);
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/SeatExclusion.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/SeatExclusion.java
@@ -1,0 +1,22 @@
+package com.seatliberator.seatliberator.reservation.book.application.port.out.criteria;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+public record SeatExclusion(
+        Set<Long> ids
+) {
+    public SeatExclusion {
+        Objects.requireNonNull(ids);
+    }
+
+    public static SeatExclusion of(Collection<Long> ids) {
+        return new SeatExclusion(new HashSet<>(ids));
+    }
+
+    public boolean isEmpty() {
+        return ids.isEmpty();
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/service/SeatService.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/service/SeatService.java
@@ -47,11 +47,12 @@ public class SeatService implements SeatManager, SeatReader {
     @Override
     public boolean update(SeatUpdateCommand command) {
         var oldLocator = SimpleSeatLocator.from(command.oldRoomId(), command.oldSeatId());
+        var newLocator = SimpleSeatLocator.from(command.newRoomId(), command.newSeatId());
         var oldSeat = query.findByLocator(oldLocator)
                 .orElseThrow(() -> new ReservationApplicationException(ReservationApplicationErrorCode.SEAT_NOT_FOUND));
 
         var exclude = SeatExclusion.of(List.of(oldSeat.getId()));
-        var conflict = query.existsByLocator(oldLocator, exclude);
+        var conflict = query.existsByLocator(newLocator, exclude);
         if (conflict) return false;
 
         oldSeat.update(command.newRoomId(), command.newSeatId());

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/service/SeatService.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/service/SeatService.java
@@ -5,8 +5,11 @@ import com.seatliberator.seatliberator.reservation.book.application.port.in.Seat
 import com.seatliberator.seatliberator.reservation.book.application.port.in.command.SeatCreateCommand;
 import com.seatliberator.seatliberator.reservation.book.application.port.in.command.SeatUpdateCommand;
 import com.seatliberator.seatliberator.reservation.book.application.port.in.entry.SeatEntry;
+import com.seatliberator.seatliberator.reservation.book.application.port.out.SeatQuery;
 import com.seatliberator.seatliberator.reservation.book.application.port.out.SeatStore;
+import com.seatliberator.seatliberator.reservation.book.application.port.out.criteria.SeatExclusion;
 import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
+import com.seatliberator.seatliberator.reservation.domain.SimpleSeatLocator;
 import com.seatliberator.seatliberator.reservation.domain.persistence.Seat;
 import com.seatliberator.seatliberator.reservation.shared.application.exception.ReservationApplicationErrorCode;
 import com.seatliberator.seatliberator.reservation.shared.application.exception.ReservationApplicationException;
@@ -21,59 +24,59 @@ import java.util.List;
 @Transactional
 public class SeatService implements SeatManager, SeatReader {
 
-    private final SeatStore seatStore;
+    private final SeatStore store;
+    private final SeatQuery query;
 
     @Override
     public boolean create(SeatCreateCommand command) {
+        var locator = SimpleSeatLocator.from(command.roomId(), command.seatId());
 
-        if (seatStore.existsSeatConflict(
-                command.roomId(),
-                command.seatId()
-        )) {
-            return false;
-        }
+        var conflict = query.existsByLocator(locator);
+        if (conflict) return false;
 
         Seat seat = Seat.create(
                 command.roomId(),
                 command.seatId()
         );
 
-        seatStore.save(seat);
+        store.save(seat);
 
         return true;
     }
 
     @Override
     public boolean update(SeatUpdateCommand command) {
-        Seat seat = seatStore.findByRoomIdAndSeatId(command.oldRoomId(), command.oldSeatId()).orElseThrow();
+        var oldLocator = SimpleSeatLocator.from(command.oldRoomId(), command.oldSeatId());
+        var oldSeat = query.findByLocator(oldLocator)
+                .orElseThrow(() -> new ReservationApplicationException(ReservationApplicationErrorCode.SEAT_NOT_FOUND));
 
-        if (seatStore.existsSeatConflictExcept(seat.getId(), command.newRoomId(), command.newSeatId())) {
-            return false;
-        }
+        var exclude = SeatExclusion.of(List.of(oldSeat.getId()));
+        var conflict = query.existsByLocator(oldLocator, exclude);
+        if (conflict) return false;
 
-        seat.update(command.newRoomId(), command.newSeatId());
+        oldSeat.update(command.newRoomId(), command.newSeatId());
 
         return true;
     }
 
     @Override
     public boolean delete(String roomId, String seatId) {
-
-        seatStore.deleteByRoomIdAndSeatId(roomId, seatId);
+        var locator = SimpleSeatLocator.from(roomId, seatId);
+        store.deleteByLocator(locator);
 
         return true;
     }
 
     @Override
     public SeatEntry read(SeatLocator locator) {
-        return seatStore.findByLocator(locator)
+        return query.findByLocator(locator)
                 .map(SeatEntry::from)
                 .orElseThrow(() -> new ReservationApplicationException(ReservationApplicationErrorCode.SEAT_NOT_FOUND));
     }
 
     @Override
     public List<SeatEntry> findAllByRoomId(String roomId) {
-        return seatStore.findByRoomId(roomId).stream()
+        return query.findByRoomId(roomId).stream()
                 .map(SeatEntry::from)
                 .toList();
     }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/service/SeatService.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/service/SeatService.java
@@ -1,18 +1,25 @@
 package com.seatliberator.seatliberator.reservation.book.application.service;
 
 import com.seatliberator.seatliberator.reservation.book.application.port.in.SeatManager;
+import com.seatliberator.seatliberator.reservation.book.application.port.in.SeatReader;
 import com.seatliberator.seatliberator.reservation.book.application.port.in.command.SeatCreateCommand;
 import com.seatliberator.seatliberator.reservation.book.application.port.in.command.SeatUpdateCommand;
+import com.seatliberator.seatliberator.reservation.book.application.port.in.entry.SeatEntry;
 import com.seatliberator.seatliberator.reservation.book.application.port.out.SeatStore;
+import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
 import com.seatliberator.seatliberator.reservation.domain.persistence.Seat;
+import com.seatliberator.seatliberator.reservation.shared.application.exception.ReservationApplicationErrorCode;
+import com.seatliberator.seatliberator.reservation.shared.application.exception.ReservationApplicationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class SeatService implements SeatManager {
+public class SeatService implements SeatManager, SeatReader {
 
     private final SeatStore seatStore;
 
@@ -55,5 +62,19 @@ public class SeatService implements SeatManager {
         seatStore.deleteByRoomIdAndSeatId(roomId, seatId);
 
         return true;
+    }
+
+    @Override
+    public SeatEntry read(SeatLocator locator) {
+        return seatStore.findByLocator(locator)
+                .map(SeatEntry::from)
+                .orElseThrow(() -> new ReservationApplicationException(ReservationApplicationErrorCode.SEAT_NOT_FOUND));
+    }
+
+    @Override
+    public List<SeatEntry> findAllByRoomId(String roomId) {
+        return seatStore.findByRoomId(roomId).stream()
+                .map(SeatEntry::from)
+                .toList();
     }
 }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/persistence/jpa/JpaReservationStore.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/persistence/jpa/JpaReservationStore.java
@@ -1,6 +1,10 @@
 package com.seatliberator.seatliberator.reservation.book.infrastructure.persistence.jpa;
 
+import com.seatliberator.seatliberator.reservation.book.application.port.out.ReservationQuery;
 import com.seatliberator.seatliberator.reservation.book.application.port.out.ReservationStore;
+import com.seatliberator.seatliberator.reservation.book.application.port.out.criteria.ReservationCriteria;
+import com.seatliberator.seatliberator.reservation.book.application.port.out.criteria.ReservationExclusion;
+import com.seatliberator.seatliberator.reservation.book.application.port.out.criteria.ReservationTarget;
 import com.seatliberator.seatliberator.reservation.book.infrastructure.persistence.jpa.repository.ReservationRepository;
 import com.seatliberator.seatliberator.reservation.domain.ReservationStatus;
 import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
@@ -15,11 +19,12 @@ import org.springframework.stereotype.Component;
 
 import java.time.Instant;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
-public class JpaReservationStore implements ReservationStore {
+public class JpaReservationStore implements ReservationStore, ReservationQuery {
 
     private final ReservationRepository repository;
 
@@ -36,6 +41,41 @@ public class JpaReservationStore implements ReservationStore {
     @Override
     public Optional<Reservation> findByUserId(String userId) {
         return repository.findByUserId(userId);
+    }
+
+    @Override
+    public Optional<Reservation> findOne(ReservationCriteria criteria) {
+        var spec = createLocatorAndRangeSpecification(criteria.locator(), criteria.range())
+                .and(CommonPredicates.eq(criteria.status(), from -> from.get("status")));
+        return repository.findOne(spec);
+    }
+
+    @Override
+    public boolean existsOverlapping(ReservationTarget target) {
+        var spec = createLocatorAndRangeSpecification(target.locator(), target.ranga());
+        return repository.exists(spec);
+    }
+
+    @Override
+    public boolean existsOverlapping(ReservationTarget target, ReservationExclusion exclusion) {
+        var spec = createLocatorAndRangeSpecification(target.locator(), target.ranga())
+                .and(CommonPredicates.excludeIn(exclusion.ids(), from -> from.get("id")));
+        return repository.exists(spec);
+    }
+
+    @Override
+    public List<Reservation> findAllOverlapping(TimeRange range) {
+        var spec = Specification.<Reservation>unrestricted()
+                .and(TimeRangePredicates.overlap(range, TimeRangePredicates.defaultRangePathFunction()));
+        return repository.findAll(spec);
+    }
+
+    @Override
+    public List<Reservation> findAllOverlappingInRoom(String roomId, TimeRange range) {
+        var spec = Specification.<Reservation>unrestricted()
+                .and(TimeRangePredicates.overlap(range, TimeRangePredicates.defaultRangePathFunction()))
+                .and(CommonPredicates.eq(roomId, from -> from.get("locator").get("roomId")));
+        return repository.findAll(spec);
     }
 
     @Override

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/persistence/jpa/JpaReservationStore.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/persistence/jpa/JpaReservationStore.java
@@ -71,6 +71,6 @@ public class JpaReservationStore implements ReservationStore {
     private Specification<Reservation> createLocatorAndRangeSpecification(SeatLocator locator, TimeRange range) {
         return Specification.<Reservation>unrestricted()
                 .and(SeatLocatorPredicates.eq(locator, SeatLocatorPredicates.defaultLocatorPathFunction()))
-                .and(TimeRangePredicates.withIn(range, TimeRangePredicates.defaultRangePathFunction()));
+                .and(TimeRangePredicates.overlap(range, TimeRangePredicates.defaultRangePathFunction()));
     }
 }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/persistence/jpa/JpaSeatStore.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/persistence/jpa/JpaSeatStore.java
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @Component
@@ -38,6 +39,11 @@ public class JpaSeatStore implements SeatStore {
     @Override
     public Optional<Seat> findForUpdate(String roomId, String seatId) {
         return repository.findForUpdate(roomId, seatId);
+    }
+
+    @Override
+    public List<Seat> findByRoomId(String roomId) {
+        return repository.findByLocator_RoomId(roomId);
     }
 
     @Override

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/persistence/jpa/JpaSeatStore.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/persistence/jpa/JpaSeatStore.java
@@ -1,6 +1,8 @@
 package com.seatliberator.seatliberator.reservation.book.infrastructure.persistence.jpa;
 
+import com.seatliberator.seatliberator.reservation.book.application.port.out.SeatQuery;
 import com.seatliberator.seatliberator.reservation.book.application.port.out.SeatStore;
+import com.seatliberator.seatliberator.reservation.book.application.port.out.criteria.SeatExclusion;
 import com.seatliberator.seatliberator.reservation.book.infrastructure.persistence.jpa.repository.SeatRepository;
 import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
 import com.seatliberator.seatliberator.reservation.domain.persistence.Seat;
@@ -11,13 +13,12 @@ import org.springframework.data.jpa.domain.DeleteSpecification;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
-public class JpaSeatStore implements SeatStore {
+public class JpaSeatStore implements SeatStore, SeatQuery {
 
     private final SeatRepository repository;
 
@@ -47,19 +48,9 @@ public class JpaSeatStore implements SeatStore {
     }
 
     @Override
-    public void deleteByRoomIdAndSeatId(String roomId, String seatId) {
-        repository.deleteByLocator_RoomIdAndLocator_SeatId(roomId, seatId);
-    }
-
-    @Override
     public void deleteByLocator(SeatLocator locator) {
         var spec = createLocatorDeleteSpecification(locator);
         repository.delete(spec);
-    }
-
-    @Override
-    public boolean existsSeatConflict(String roomId, String seatId) {
-        return repository.existsSeatConflict(roomId, seatId);
     }
 
     @Override
@@ -69,14 +60,9 @@ public class JpaSeatStore implements SeatStore {
     }
 
     @Override
-    public boolean existsSeatConflictExcept(Long id, String roomId, String seatId) {
-        return repository.existsSeatConflictExcept(id, roomId, seatId);
-    }
-
-    @Override
-    public boolean existsByLocatorWithExcludeIds(SeatLocator locator, Collection<Long> ids) {
+    public boolean existsByLocator(SeatLocator locator, SeatExclusion exclusion) {
         var spec = createLocatorSpecification(locator)
-                .and(CommonPredicates.excludeIn(ids, from -> from.get("id")));
+                .and(CommonPredicates.excludeIn(exclusion.ids(), from -> from.get("id")));
         return repository.exists(spec);
     }
 

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/persistence/jpa/repository/SeatRepository.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/persistence/jpa/repository/SeatRepository.java
@@ -7,11 +7,14 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SeatRepository extends JpaRepository<Seat, Long>, JpaSpecificationExecutor<Seat> {
 
     Optional<Seat> findByLocator_RoomIdAndLocator_SeatId(String roomId, String seatId);
+
+    List<Seat> findByLocator_RoomId(String roomId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/shared/application/exception/ReservationApplicationErrorCode.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/shared/application/exception/ReservationApplicationErrorCode.java
@@ -11,6 +11,7 @@ public enum ReservationApplicationErrorCode implements ErrorCode {
     SEAT_NOT_FOUND("RS002", "좌석 정보가 존재하지 않습니다."),
     RESERVATION_ALREADY_EXISTS("RS003", "예약은 두 개 이상 할 수 없습니다."),
     RESERVATION_TIME_CONFLICT("RS004", "다른 예약과 겹치는 시간으로 예약할 수 없습니다."),
+    SEAT_ALREADY_EXISTS("RS005", "좌석이 이미 존재합니다."),
 
     RESERVATION_READ_FORBIDDEN("RS100", "조회할 수 없는 예약입니다."),
     RESERVATION_VERIFY_FORBIDDEN("RS101", "사용 처리 할 수 없는 예약입니다."),

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/shared/application/seed/SeatSeedService.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/shared/application/seed/SeatSeedService.java
@@ -1,5 +1,6 @@
 package com.seatliberator.seatliberator.reservation.shared.application.seed;
 
+import com.seatliberator.seatliberator.reservation.book.application.port.out.SeatQuery;
 import com.seatliberator.seatliberator.reservation.book.application.port.out.SeatStore;
 import com.seatliberator.seatliberator.reservation.domain.persistence.Seat;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class SeatSeedService {
     private final SeatStore store;
+    private final SeatQuery query;
 
     public void seed() {
         var seats = DevFixture.createSeats();
@@ -23,7 +25,7 @@ public class SeatSeedService {
     }
 
     private boolean createIfNotExists(Seat seat) {
-        if (store.findByLocator(seat.getLocator()).isPresent()) {
+        if (query.findByLocator(seat.getLocator()).isPresent()) {
             return false;
         }
         store.save(seat);

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/shared/infrastructure/persistence/jpa/specification/TimeRangePredicates.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/shared/infrastructure/persistence/jpa/specification/TimeRangePredicates.java
@@ -24,7 +24,7 @@ public class TimeRangePredicates {
         };
     }
 
-    public static <T> PredicateSpecification<T> withIn(
+    public static <T> PredicateSpecification<T> overlap(
             TimeRange range,
             Function<From<?, T>, Path<EmbeddableTimeRange>> pathFunction
     ) {
@@ -38,6 +38,34 @@ public class TimeRangePredicates {
         };
     }
 
+    public static <T> PredicateSpecification<T> containedBy(
+            TimeRange range,
+            Function<From<?, T>, Path<EmbeddableTimeRange>> pathFunction
+    ) {
+        return (from, cb) -> {
+            var path = pathFunction.apply(from);
+
+            return cb.and(
+                    cb.greaterThanOrEqualTo(path.get("startAt"), range.startAt()),
+                    cb.lessThanOrEqualTo(path.get("endAt"), range.endAt())
+            );
+        };
+    }
+
+    public static <T> PredicateSpecification<T> contains(
+            TimeRange range,
+            Function<From<?, T>, Path<EmbeddableTimeRange>> pathFunction
+    ) {
+        return (from, cb) -> {
+            var path = pathFunction.apply(from);
+
+            return cb.and(
+                    cb.lessThanOrEqualTo(path.get("startAt"), range.startAt()),
+                    cb.greaterThanOrEqualTo(path.get("endAt"), range.endAt())
+            );
+        };
+    }
+
     public static <T> PredicateSpecification<T> contain(
             Instant at,
             Function<From<?, T>, Path<EmbeddableTimeRange>> pathFunction
@@ -46,8 +74,8 @@ public class TimeRangePredicates {
             var path = pathFunction.apply(from);
 
             return cb.and(
-                    cb.lessThan(path.get("startAt"), at),
-                    cb.greaterThan(path.get("endAt"), at)
+                    cb.lessThanOrEqualTo(path.get("startAt"), at),
+                    cb.greaterThanOrEqualTo(path.get("endAt"), at)
             );
         };
     }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/shared/infrastructure/security/ReservationCapability.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/shared/infrastructure/security/ReservationCapability.java
@@ -1,0 +1,29 @@
+package com.seatliberator.seatliberator.reservation.shared.infrastructure.security;
+
+import com.seatliberator.seatliberator.identity.client.role.Capability;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ReservationCapability implements Capability {
+    SEAT_LIST("seat.list", "자리 목록 조회"),
+    SEAT_READ("seat.read", "자리 조회"),
+    SEAT_MANAGE("seat.manage", "자리 관리"),
+
+    BOOKING_CREATE("booking.create", "예약 생성"),
+    OWNED_BOOKING_CANCEL("owned.booking.cancel", "예약 취소"),
+    OWNED_BOOKING_UPDATE("owned.booking.update", "예약 수정"),
+    BOOKING_MANAGE("booking.manage", "예약 관리");
+
+    private final String scope;
+    private final String description;
+
+    @Override
+    public String scope() {
+        return scope;
+    }
+
+    @Override
+    public String description() {
+        return description;
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/shared/infrastructure/security/ReservationRoleCapabilityConfiguration.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/shared/infrastructure/security/ReservationRoleCapabilityConfiguration.java
@@ -1,0 +1,43 @@
+package com.seatliberator.seatliberator.reservation.shared.infrastructure.security;
+
+import com.seatliberator.seatliberator.identity.client.role.RoleCapabilities;
+import com.seatliberator.seatliberator.identity.core.role.Role;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Set;
+
+import static com.seatliberator.seatliberator.reservation.shared.infrastructure.security.ReservationCapability.*;
+
+@Configuration
+public class ReservationRoleCapabilityConfiguration {
+    @Bean
+    RoleCapabilities guestRoleCapabilities() {
+        return new RoleCapabilities(Role.GUEST, Set.of(
+                SEAT_LIST
+        ));
+    }
+
+    @Bean
+    RoleCapabilities userRoleCapabilities() {
+        return new RoleCapabilities(Role.USER, Set.of(
+                SEAT_READ,
+                BOOKING_CREATE,
+                OWNED_BOOKING_UPDATE,
+                OWNED_BOOKING_CANCEL
+        ));
+    }
+
+    @Bean
+    RoleCapabilities maintainerRoleCapabilities() {
+        return new RoleCapabilities(Role.MAINTAINER, Set.of(
+                SEAT_MANAGE,
+                BOOKING_MANAGE
+        ));
+    }
+
+    @Bean
+    RoleCapabilities adminRoleCapabilities() {
+        return new RoleCapabilities(Role.ADMIN, Set.of());
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/vacancy/infrastructure/persistence/jpa/JpaVacancyAlertRequestStore.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/vacancy/infrastructure/persistence/jpa/JpaVacancyAlertRequestStore.java
@@ -61,6 +61,6 @@ public class JpaVacancyAlertRequestStore implements
     private Specification<VacancyAlertRequest> createLocatorAndRangeSpecification(SeatLocator locator, TimeRange range) {
         return Specification.<VacancyAlertRequest>unrestricted()
                 .and(SeatLocatorPredicates.eq(locator, from -> from.get("locator")))
-                .and(TimeRangePredicates.withIn(range, from -> from.get("range")));
+                .and(TimeRangePredicates.overlap(range, from -> from.get("range")));
     }
 }

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/availability/application/model/AvailableSeatsTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/availability/application/model/AvailableSeatsTest.java
@@ -1,0 +1,97 @@
+package com.seatliberator.seatliberator.reservation.availability.application.model;
+
+import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
+import com.seatliberator.seatliberator.reservation.domain.SimpleSeatLocator;
+import com.seatliberator.seatliberator.reservation.domain.persistence.Seat;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Application.model: AvailableSeats")
+public class AvailableSeatsTest {
+    @Test
+    @DisplayName("예약된 좌석 locator를 제외한 좌석만 남긴다")
+    void exclude_reserved_seats() {
+        // given
+        var seatA = Seat.create("room-1", "A");
+        var seatB = Seat.create("room-1", "B");
+        var seatC = Seat.create("room-1", "C");
+
+        var reservedLocators = List.<SeatLocator>of(
+                SimpleSeatLocator.from("room-1", "A"),
+                SimpleSeatLocator.from("room-1", "C")
+        );
+
+        // when
+        var result = AvailableSeats.from(List.of(seatA, seatB, seatC), reservedLocators);
+
+        assertThat(result.toList())
+                .extracting(seat -> seat.getLocator().seatId())
+                .containsExactly("B");
+    }
+
+    @Test
+    @DisplayName("예약된 좌석이 없으면 모든 좌석을 가용 좌석으로 본다")
+    void keep_all_seats_when_reserved_locator_is_empty() {
+        var seatA = Seat.create("room-1", "A");
+        var seatB = Seat.create("room-1", "B");
+
+        var result = AvailableSeats.from(
+                List.of(seatA, seatB),
+                List.of()
+        );
+
+        assertThat(result.toList())
+                .extracting(seat -> seat.getLocator().seatId())
+                .containsExactly("A", "B");
+    }
+
+    @Test
+    @DisplayName("모든 좌석이 예약됐으면 빈 가용 좌석 컬렉션을 반환한다")
+    void return_empty_when_all_seats_are_reserved() {
+        // given
+        var seatA = Seat.create("room-1", "A");
+        var seatB = Seat.create("room-1", "B");
+
+        var reservedLocators = List.<SeatLocator>of(
+                SimpleSeatLocator.from("room-1", "A"),
+                SimpleSeatLocator.from("room-1", "B")
+        );
+
+        // when
+        var result = AvailableSeats.from(
+                List.of(seatA, seatB),
+                reservedLocators
+        );
+
+        // then
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("예약 locator가 중복되어 있어도 결과는 한 번만 제외된 것처럼 동작한다")
+    void handle_duplicate_reserved_locators() {
+        // given
+        var seatA = Seat.create("room-1", "A");
+        var seatB = Seat.create("room-1", "B");
+
+        var reservedLocators = List.<SeatLocator>of(
+                SimpleSeatLocator.from("room-1", "A"),
+                SimpleSeatLocator.from("room-1", "A")
+        );
+
+        // when
+        var result = AvailableSeats.from(
+                List.of(seatA, seatB),
+                reservedLocators
+        );
+
+        // then
+        assertThat(result.toList())
+                .extracting(seat -> seat.getLocator().seatId())
+                .containsExactly("B");
+    }
+}

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/availability/application/service/DefaultSeatAvailabilityReaderTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/availability/application/service/DefaultSeatAvailabilityReaderTest.java
@@ -1,0 +1,97 @@
+package com.seatliberator.seatliberator.reservation.availability.application.service;
+
+import com.seatliberator.seatliberator.reservation.availability.application.port.in.entry.AvailabilitySeatEntry;
+import com.seatliberator.seatliberator.reservation.book.application.port.out.ReservationQuery;
+import com.seatliberator.seatliberator.reservation.book.application.port.out.SeatQuery;
+import com.seatliberator.seatliberator.reservation.domain.SimpleSeatLocator;
+import com.seatliberator.seatliberator.reservation.domain.SimpleTimeRange;
+import com.seatliberator.seatliberator.reservation.domain.persistence.Reservation;
+import com.seatliberator.seatliberator.reservation.domain.persistence.Seat;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static com.seatliberator.seatliberator.reservation.domain.fixture.TestSupport.fixedClock;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Application.service: DefaultSeatAvailabilityReader")
+public class DefaultSeatAvailabilityReaderTest {
+    @Mock
+    SeatQuery seatQuery;
+
+    @Mock
+    ReservationQuery reservationQuery;
+
+    @InjectMocks
+    DefaultSeatAvailabilityReader reader;
+
+    @Test
+    @DisplayName("특정 시간 및 방에서 예약할 수 있는 좌석을 반환한다")
+    void return_available_seats() {
+        var now = fixedClock.instant();
+        var roomId = "room-1";
+        var range = SimpleTimeRange.from(
+                now,
+                now.plusSeconds(60)
+        );
+        var seatALocator = SimpleSeatLocator.from(roomId, "A");
+        var seatBLocator = SimpleSeatLocator.from(roomId, "B");
+        var seatCLocator = SimpleSeatLocator.from(roomId, "C");
+
+        var seatA = Seat.create(seatALocator);
+        var seatB = Seat.create(seatBLocator);
+        var seatC = Seat.create(seatCLocator);
+
+        when(seatQuery.findByRoomId(roomId))
+                .thenReturn(List.of(seatA, seatB, seatC));
+
+        var reservationA = Reservation.create(
+                "user-1",
+                seatALocator.roomId(),
+                seatALocator.seatId(),
+                range.startAt(),
+                range.endAt()
+        );
+
+        when(reservationQuery.findAllOverlappingInRoom(roomId, range))
+                .thenReturn(List.of(reservationA));
+
+        var result = reader.findAvailabilitySeats(roomId, range);
+
+        assertThat(result)
+                .extracting(AvailabilitySeatEntry::seatId)
+                .containsExactlyInAnyOrder("B", "C");
+
+        verify(seatQuery).findByRoomId(roomId);
+        verify(reservationQuery).findAllOverlappingInRoom(roomId, range);
+    }
+
+    @Test
+    @DisplayName("방에 좌석이 없으면 빈 리스트를 반환하고 예약은 조회하지 않는다")
+    void return_empty_seats_and_skip_reservation_query_when_no_seats_exists_in_room() {
+
+        var now = fixedClock.instant();
+        var roomId = "room-1";
+        var range = SimpleTimeRange.from(
+                now,
+                now.plusSeconds(60)
+        );
+
+        when(seatQuery.findByRoomId(roomId))
+                .thenReturn(List.of());
+
+        var result = reader.findAvailabilitySeats(roomId, range);
+
+        assertThat(result).isEmpty();
+
+        verify(seatQuery).findByRoomId(roomId);
+        verify(reservationQuery, never()).findAllOverlappingInRoom(roomId, range);
+    }
+}

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/availability/application/service/DefaultSeatAvailabilityReaderTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/availability/application/service/DefaultSeatAvailabilityReaderTest.java
@@ -3,6 +3,7 @@ package com.seatliberator.seatliberator.reservation.availability.application.ser
 import com.seatliberator.seatliberator.reservation.availability.application.port.in.entry.AvailabilitySeatEntry;
 import com.seatliberator.seatliberator.reservation.book.application.port.out.ReservationQuery;
 import com.seatliberator.seatliberator.reservation.book.application.port.out.SeatQuery;
+import com.seatliberator.seatliberator.reservation.domain.ReservationStatus;
 import com.seatliberator.seatliberator.reservation.domain.SimpleSeatLocator;
 import com.seatliberator.seatliberator.reservation.domain.SimpleTimeRange;
 import com.seatliberator.seatliberator.reservation.domain.persistence.Reservation;
@@ -93,5 +94,77 @@ public class DefaultSeatAvailabilityReaderTest {
 
         verify(seatQuery).findByRoomId(roomId);
         verify(reservationQuery, never()).findAllOverlappingInRoom(roomId, range);
+    }
+
+    @Test
+    @DisplayName("취소된 예약은 가용 좌석 계산에서 제외한다")
+    void ignore_canceled_reservation_when_calculating_available_seats() {
+        var now = fixedClock.instant();
+        var roomId = "room-1";
+        var range = SimpleTimeRange.from(now, now.plusSeconds(60));
+        var seatALocator = SimpleSeatLocator.from(roomId, "A");
+        var seatA = Seat.create(seatALocator);
+
+        when(seatQuery.findByRoomId(roomId))
+                .thenReturn(List.of(seatA));
+        when(reservationQuery.findAllOverlappingInRoom(roomId, range))
+                .thenReturn(List.of(createReservation(seatALocator, range, ReservationStatus.CANCELED)));
+
+        var result = reader.findAvailabilitySeats(roomId, range);
+
+        assertThat(result)
+                .extracting(AvailabilitySeatEntry::seatId)
+                .containsExactly("A");
+    }
+
+    @Test
+    @DisplayName("만료된 예약은 가용 좌석 계산에서 제외한다")
+    void ignore_expired_reservation_when_calculating_available_seats() {
+        var now = fixedClock.instant();
+        var roomId = "room-1";
+        var range = SimpleTimeRange.from(now, now.plusSeconds(60));
+        var seatALocator = SimpleSeatLocator.from(roomId, "A");
+        var seatA = Seat.create(seatALocator);
+
+        when(seatQuery.findByRoomId(roomId))
+                .thenReturn(List.of(seatA));
+        when(reservationQuery.findAllOverlappingInRoom(roomId, range))
+                .thenReturn(List.of(createReservation(seatALocator, range, ReservationStatus.EXPIRED)));
+
+        var result = reader.findAvailabilitySeats(roomId, range);
+
+        assertThat(result)
+                .extracting(AvailabilitySeatEntry::seatId)
+                .containsExactly("A");
+    }
+
+    @Test
+    @DisplayName("사용된 예약은 여전히 점유 좌석으로 본다")
+    void treat_used_reservation_as_occupied_seat() {
+        var now = fixedClock.instant();
+        var roomId = "room-1";
+        var range = SimpleTimeRange.from(now, now.plusSeconds(60));
+        var seatALocator = SimpleSeatLocator.from(roomId, "A");
+        var seatA = Seat.create(seatALocator);
+
+        when(seatQuery.findByRoomId(roomId))
+                .thenReturn(List.of(seatA));
+        when(reservationQuery.findAllOverlappingInRoom(roomId, range))
+                .thenReturn(List.of(createReservation(seatALocator, range, ReservationStatus.USED)));
+
+        var result = reader.findAvailabilitySeats(roomId, range);
+
+        assertThat(result).isEmpty();
+    }
+
+    private Reservation createReservation(SimpleSeatLocator locator, SimpleTimeRange range, ReservationStatus status) {
+        return Reservation.create(
+                "user-1",
+                locator.roomId(),
+                locator.seatId(),
+                range.startAt(),
+                range.endAt(),
+                status
+        );
     }
 }

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/integration/ReservationServiceTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/integration/ReservationServiceTest.java
@@ -3,9 +3,11 @@ package com.seatliberator.seatliberator.reservation.integration;
 import com.seatliberator.seatliberator.reservation.book.application.port.in.command.ReservationCreateCommand;
 import com.seatliberator.seatliberator.reservation.book.application.port.in.command.SeatCreateCommand;
 import com.seatliberator.seatliberator.reservation.book.application.port.out.ReservationStore;
+import com.seatliberator.seatliberator.reservation.book.application.port.out.SeatQuery;
 import com.seatliberator.seatliberator.reservation.book.application.port.out.SeatStore;
 import com.seatliberator.seatliberator.reservation.book.application.service.ReservationService;
 import com.seatliberator.seatliberator.reservation.book.application.service.SeatService;
+import com.seatliberator.seatliberator.reservation.domain.SimpleSeatLocator;
 import com.seatliberator.seatliberator.reservation.domain.persistence.Reservation;
 import com.seatliberator.seatliberator.reservation.domain.persistence.Seat;
 import org.junit.jupiter.api.DisplayName;
@@ -30,6 +32,8 @@ public class ReservationServiceTest extends ReservationDatabaseCleanupSupport {
     @Autowired
     SeatStore seatStore;
     @Autowired
+    SeatQuery seatQuery;
+    @Autowired
     ReservationStore reservationStore;
 
 
@@ -38,6 +42,7 @@ public class ReservationServiceTest extends ReservationDatabaseCleanupSupport {
     void return_true_when_seat_is_created() {
         var givenRoomId = "room-1";
         var givenSeatId = "seat-1";
+        var locator = SimpleSeatLocator.from(givenRoomId, givenSeatId);
 
         var seatCreateCommand = new SeatCreateCommand(
                 givenRoomId,
@@ -47,10 +52,7 @@ public class ReservationServiceTest extends ReservationDatabaseCleanupSupport {
         // Then
         boolean result = seatService.create(seatCreateCommand);
 
-        Optional<Seat> optStoreSeat = seatStore.findByRoomIdAndSeatId(
-                givenRoomId,
-                givenSeatId
-        );
+        Optional<Seat> optStoreSeat = seatQuery.findByLocator(locator);
 
         assertThat(optStoreSeat.isPresent()).isTrue();
 


### PR DESCRIPTION
## 관련 이슈

- Closes #87

## 변경 사항

방과 시간 구간 기준으로 예약 가능한 좌석을 조회할 수 있도록 가용 좌석 조회 경로를 추가했습니다.
또한 예약 상태를 기준으로 실제 점유 좌석만 계산하도록 가용 좌석 계산 정책을 보강했습니다.

### 가용 좌석 조회 경로

- `SeatAvailabilityReader`와 `DefaultSeatAvailabilityReader`를 추가해 방/시간 구간 기준 가용 좌석 조회 흐름을 구성했습니다.
- `SeatAvailabilityController`에 `/rooms/{roomId}/available-seats` 조회 경로를 추가했습니다.
- 방에 좌석이 없는 경우에는 예약 조회를 생략하고 빈 리스트를 반환하도록 처리했습니다.

### 예약 상태 기반 가용 좌석 계산

- 겹치는 예약 중 `RESERVED`, `USED` 상태만 점유 좌석으로 간주하도록 조정했습니다.
- `CANCELED`, `EXPIRED` 상태의 예약은 가용 좌석 계산에서 제외하도록 보정했습니다.

### 테스트

- `DefaultSeatAvailabilityReaderTest`를 추가해 기본 가용 좌석 계산 시나리오를 검증했습니다.
- 좌석이 없는 방 조회와 예약 상태별(`CANCELED`, `EXPIRED`, `USED`) 가용 좌석 정책을 테스트로 보강했습니다.

## 검증

- `./gradlew :reservation:reservation-application:test --tests com.seatliberator.seatliberator.reservation.availability.application.service.DefaultSeatAvailabilityReaderTest`