### PR TITLE
SeatLocator canonical key 도입 및 AvailableSeats 비교 기준 정리

### DIFF
--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/application/model/AvailableSeats.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/application/model/AvailableSeats.java
@@ -1,7 +1,6 @@
 package com.seatliberator.seatliberator.reservation.availability.application.model;
 
 import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
-import com.seatliberator.seatliberator.reservation.domain.SimpleSeatLocator;
 import com.seatliberator.seatliberator.reservation.domain.persistence.Seat;
 
 import java.util.List;
@@ -17,11 +16,11 @@ public class AvailableSeats {
 
     public static AvailableSeats from(List<Seat> seats, List<SeatLocator> reservedLocators) {
         var occupied = reservedLocators.stream()
-                .map(SimpleSeatLocator::of)
+                .map(SeatLocator::key)
                 .collect(Collectors.toSet());
 
         var available = seats.stream()
-                .filter(seat -> !occupied.contains(SimpleSeatLocator.of(seat.getLocator())))
+                .filter(seat -> !occupied.contains(seat.getLocator().key()))
                 .toList();
 
         return new AvailableSeats(available);

--- a/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/SeatLocator.java
+++ b/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/SeatLocator.java
@@ -5,7 +5,11 @@ public interface SeatLocator {
 
     String seatId();
 
+    default SeatLocatorKey key() {
+        return SeatLocatorKey.from(this);
+    }
+
     default boolean isSame(SeatLocator other) {
-        return roomId().equals(other.roomId()) && seatId().equals(other.seatId());
+        return key().equals(other.key());
     }
 }

--- a/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/SeatLocatorKey.java
+++ b/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/SeatLocatorKey.java
@@ -1,0 +1,19 @@
+package com.seatliberator.seatliberator.reservation.domain;
+
+public record SeatLocatorKey(String roomId, String seatId) implements Comparable<SeatLocatorKey> {
+    public SeatLocatorKey {
+        if (roomId.isBlank()) throw new IllegalArgumentException("roomId must not be blank.");
+        if (seatId.isBlank()) throw new IllegalArgumentException("seatId must not be blank.");
+    }
+
+    public static SeatLocatorKey from(SeatLocator locator) {
+        return new SeatLocatorKey(locator.roomId(), locator.seatId());
+    }
+
+    @Override
+    public int compareTo(SeatLocatorKey other) {
+        int roomCompare = roomId.compareTo(other.roomId);
+        if (roomCompare != 0) return roomCompare;
+        return seatId.compareTo(other.seatId);
+    }
+}

--- a/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/EmbeddableSeatLocatorTest.java
+++ b/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/EmbeddableSeatLocatorTest.java
@@ -1,117 +1,21 @@
 package com.seatliberator.seatliberator.reservation.domain;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("Domain: Embeddable Seat Locator")
-public class EmbeddableSeatLocatorTest {
-
-    String roomId = "room-1";
-    String seatId = "seat-1";
-
-    @Nested
-    @DisplayName("Creation")
-    class Creation {
-        @Test
-        @DisplayName("정상적인 좌석 위치로 생성할 수 있다")
-        void create_locator_when_arguments_are_valid() {
-            var locator = new EmbeddableSeatLocator(roomId, seatId);
-
-            assertThat(locator.roomId()).isEqualTo(roomId);
-            assertThat(locator.seatId()).isEqualTo(seatId);
-        }
-
-        @Test
-        @DisplayName("roomId가 null이면 예외를 던진다")
-        void throw_exception_when_room_id_is_null() {
-            assertThatThrownBy(() -> new EmbeddableSeatLocator(null, seatId))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("roomId must not be null or blank.");
-        }
-
-        @Test
-        @DisplayName("seatId가 비어 있으면 예외를 던진다")
-        void throw_exception_when_seat_id_is_blank() {
-            assertThatThrownBy(() -> new EmbeddableSeatLocator(roomId, " "))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("seatId must not be null or blank.");
-        }
-
-        @Test
-        @DisplayName("of 팩토리로 다른 SeatLocator를 복사할 수 있다")
-        void copy_locator_with_of_factory() {
-            var source = SimpleSeatLocator.from(roomId, seatId);
-
-            var copied = EmbeddableSeatLocator.of(source);
-
-            Assertions.assertThat(copied.roomId()).isEqualTo(roomId);
-            Assertions.assertThat(copied.seatId()).isEqualTo(seatId);
-        }
+public class EmbeddableSeatLocatorTest implements SeatLocatorContractTest<EmbeddableSeatLocator> {
+    @Override
+    public EmbeddableSeatLocator create(String roomId, String seatId) {
+        return EmbeddableSeatLocator.from(roomId, seatId);
     }
 
-    @Nested
-    @DisplayName("Update")
-    class Update {
-        @Test
-        @DisplayName("setLocate로 좌석 위치를 변경할 수 있다")
-        void update_locator_with_set_locate() {
-            var locator = new EmbeddableSeatLocator(roomId, seatId);
-            var newRoomId = "room-2";
-            var newSeatId = "seat-2";
-
-            locator.setLocate(newRoomId, newSeatId);
-
-            assertThat(locator.roomId()).isEqualTo(newRoomId);
-            assertThat(locator.seatId()).isEqualTo(newSeatId);
-        }
+    @Override
+    public String getRoomId() {
+        return "room-1";
     }
 
-    @Nested
-    @DisplayName("Equality")
-    class Equality {
-        @Test
-        @DisplayName("같은 값, 같은 타입끼리는 인터페이스의 동등성 검사 통과")
-        void is_equal_with_same_value_and_type() {
-            var locator = EmbeddableSeatLocator.from(roomId, seatId);
-            var other = EmbeddableSeatLocator.from(roomId, seatId);
-
-            Assertions.assertThat(locator).isNotEqualTo(other);
-            Assertions.assertThat(locator.isSame(other)).isTrue();
-        }
-
-        @Test
-        @DisplayName("같은 값, 다른 타입끼리도 인터페이스의 동등성 검사 통과")
-        void is_equal_with_same_value_and_diff_type() {
-            var locator = EmbeddableSeatLocator.from(roomId, seatId);
-            var other = SimpleSeatLocator.from(roomId, seatId);
-
-            Assertions.assertThat(locator).isNotEqualTo(other);
-            Assertions.assertThat(locator.isSame(other)).isTrue();
-        }
-
-        @Test
-        @DisplayName("다른 값, 같은 타입끼리는 인터페이스의 동등성 검사 실패")
-        void is_not_equal_with_diff_value_and_same_type() {
-            var locator = EmbeddableSeatLocator.from(roomId, seatId);
-            var other = EmbeddableSeatLocator.from("other-" + roomId, "other" + seatId);
-
-            Assertions.assertThat(locator).isNotEqualTo(other);
-            Assertions.assertThat(locator.isSame(other)).isFalse();
-        }
-
-        @Test
-        @DisplayName("다른 값, 다른 타입끼리는 인터페이스의 동등성 검사 실패")
-        void is_not_equal_with_diff_value_and_diff_type() {
-            var locator = EmbeddableSeatLocator.from(roomId, seatId);
-            var other = SimpleSeatLocator.from("other-" + roomId, "other" + seatId);
-
-            Assertions.assertThat(locator).isNotEqualTo(other);
-            Assertions.assertThat(locator.isSame(other)).isFalse();
-        }
+    @Override
+    public String getSeatId() {
+        return "seat-1";
     }
 }

--- a/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/SeatLocatorContractTest.java
+++ b/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/SeatLocatorContractTest.java
@@ -3,6 +3,8 @@ package com.seatliberator.seatliberator.reservation.domain;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -85,5 +87,160 @@ public interface SeatLocatorContractTest<T extends SeatLocator> {
         var other = create("other-" + roomId, "other-" + seatId);
 
         assertThat(locator.isSame(other)).isFalse();
+    }
+
+    @Test
+    @DisplayName("정상적인 roomId와 seatId로 SeatLocatorKey 생성 가능")
+    default void create_key_when_args_are_valid() {
+        var roomId = getRoomId();
+        var seatId = getSeatId();
+        var key = new SeatLocatorKey(roomId, seatId);
+
+        assertThat(key.roomId()).isEqualTo(roomId);
+        assertThat(key.seatId()).isEqualTo(seatId);
+    }
+
+    @Test
+    @DisplayName("SeatLocatorKey의 roomId가 비어있으면 예외")
+    default void throw_exception_when_room_id_of_key_is_blank() {
+        var seatId = getSeatId();
+
+        assertThatThrownBy(() -> new SeatLocatorKey(" ", seatId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("roomId must not be blank.");
+    }
+
+    @Test
+    @DisplayName("SeatLocatorKey의 seatId가 비어있으면 예외")
+    default void throw_exception_when_seat_id_of_key_is_blank() {
+        var roomId = getRoomId();
+
+        assertThatThrownBy(() -> new SeatLocatorKey(roomId, " "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("seatId must not be blank.");
+    }
+
+    @Test
+    @DisplayName("SeatLocator로부터 생성 가능")
+    default void create_from_seat_locator() {
+        var roomId = getRoomId();
+        var seatId = getSeatId();
+        var locator = create(roomId, seatId);
+
+        var key = SeatLocatorKey.from(locator);
+
+        assertThat(key.roomId()).isEqualTo(roomId);
+        assertThat(key.seatId()).isEqualTo(seatId);
+    }
+
+    @Test
+    @DisplayName("SeatLocatorKey가 같은 roomId, seatId면 동등하다")
+    default void equal_when_same_value() {
+        var roomId = getRoomId();
+        var seatId = getSeatId();
+        var key1 = new SeatLocatorKey(roomId, seatId);
+        var key2 = new SeatLocatorKey(roomId, seatId);
+
+        assertThat(key1).isEqualTo(key2);
+        assertThat(key1.hashCode()).isEqualTo(key2.hashCode());
+    }
+
+    @Test
+    @DisplayName("SeatLocatorKey의 roomId 또는 seatId가 다르면 동등하지 않다")
+    default void not_equal_when_diff_value() {
+        var roomId = getRoomId();
+        var seatId = getSeatId();
+        var key1 = new SeatLocatorKey(roomId, seatId);
+        var key2 = new SeatLocatorKey("other-" + roomId, "other-" + seatId);
+
+        assertThat(key1).isNotEqualTo(key2);
+    }
+
+    @Test
+    @DisplayName("roomId 가 다르면 roomId 사전순으로 비교")
+    default void compare_by_room_id_first() {
+        var smaller = new SeatLocatorKey("room-1", "seat-9");
+        var larger = new SeatLocatorKey("room-2", "seat-1");
+
+        assertThat(smaller.compareTo(larger)).isNegative();
+        assertThat(larger.compareTo(smaller)).isPositive();
+    }
+
+    @Test
+    @DisplayName("roomId가 같으면 seatId 사전순으로 비교")
+    default void compare_by_seat_id_when_room_id_is_same() {
+        var smaller = new SeatLocatorKey("room-1", "seat-1");
+        var larger = new SeatLocatorKey("room-1", "seat-2");
+
+        assertThat(smaller.compareTo(larger)).isNegative();
+        assertThat(larger.compareTo(smaller)).isPositive();
+    }
+
+    @Test
+    @DisplayName("같은 값이면 compareTo 결과는 0이다")
+    default void compare_zero_when_same_value() {
+        var key1 = new SeatLocatorKey("room-1", "seat-1");
+        var key2 = new SeatLocatorKey("room-1", "seat-1");
+
+        assertThat(key1.compareTo(key2)).isZero();
+    }
+
+    @Test
+    @DisplayName("SeatLocator의 key()는 동일한 SeatLocatorKey를 반환한다")
+    default void return_key_from_locator_default_method() {
+        SeatLocator locator = SimpleSeatLocator.from("room-1", "seat-1");
+
+        var key = locator.key();
+
+        assertThat(key).isEqualTo(new SeatLocatorKey("room-1", "seat-1"));
+    }
+
+    @Test
+    @DisplayName("서로 다른 SeatLocator 구현체라도 같은 값이면 같은 key를 만든다")
+    default void create_same_key_across_different_implementations() {
+        SeatLocator simple = SimpleSeatLocator.from("room-1", "seat-1");
+        SeatLocator embeddable = EmbeddableSeatLocator.from("room-1", "seat-1");
+
+        assertThat(simple.key()).isEqualTo(embeddable.key());
+    }
+
+    @Test
+    @DisplayName("컬렉션에서 같은 key를 찾을 수 있다")
+    default void same_locator_can_found_in_collection_when_compared_by_key() {
+        var keys = Set.of(
+                EmbeddableSeatLocator.from("room-1", "seat-1").key()
+        );
+
+        assertThat(keys).contains(
+                SimpleSeatLocator.from("room-1", "seat-1").key()
+        );
+    }
+
+    @Test
+    @DisplayName("compareTo가 0이면 equals도 true다")
+    default void compare_to_zero_and_equals_are_consistent() {
+        var key1 = new SeatLocatorKey("room-1", "seat-1");
+        var key2 = new SeatLocatorKey("room-1", "seat-1");
+
+        assertThat(key1.compareTo(key2)).isZero();
+        assertThat(key1).isEqualTo(key2);
+    }
+
+    @Test
+    @DisplayName("정렬 시 roomId, seatId 순으로 오름차순 정렬된다")
+    default void sort_in_natural_order() {
+        var keys = java.util.List.of(
+                new SeatLocatorKey("room-2", "seat-1"),
+                new SeatLocatorKey("room-1", "seat-2"),
+                new SeatLocatorKey("room-1", "seat-1")
+        );
+
+        var sorted = keys.stream().sorted().toList();
+
+        assertThat(sorted).containsExactly(
+                new SeatLocatorKey("room-1", "seat-1"),
+                new SeatLocatorKey("room-1", "seat-2"),
+                new SeatLocatorKey("room-2", "seat-1")
+        );
     }
 }

--- a/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/SeatLocatorContractTest.java
+++ b/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/SeatLocatorContractTest.java
@@ -1,0 +1,89 @@
+package com.seatliberator.seatliberator.reservation.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public interface SeatLocatorContractTest<T extends SeatLocator> {
+
+    T create(String roomId, String seatId);
+
+    String getRoomId();
+
+    String getSeatId();
+
+    @Test
+    @DisplayName("문자열 Room Id 및 Seat Id를 넘겨서 Locator를 만들 수 있다")
+    default void create_locator_when_arguments_are_valid() {
+        var roomId = getRoomId();
+        var seatId = getSeatId();
+        var locator = create(roomId, seatId);
+
+        assertThat(locator.roomId()).isEqualTo(roomId);
+        assertThat(locator.seatId()).isEqualTo(seatId);
+    }
+
+    @Test
+    @DisplayName("roomId가 비어 있으면 예외를 던진다")
+    default void throw_exception_when_room_id_is_blank() {
+        assertThatThrownBy(() -> new SimpleSeatLocator(" ", getSeatId()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("roomId must not be null or blank.");
+    }
+
+    @Test
+    @DisplayName("seatId가 비어 있으면 예외를 던진다")
+    default void throw_exception_when_seat_id_is_blank() {
+        assertThatThrownBy(() -> new SimpleSeatLocator(getRoomId(), " "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("seatId must not be null or blank.");
+    }
+
+    @Test
+    @DisplayName("from 팩토리로 생성할 수 있다")
+    default void create_locator_with_from_factory() {
+        var roomId = getRoomId();
+        var seatId = getSeatId();
+        var locator = SimpleSeatLocator.from(roomId, seatId);
+
+        assertThat(locator.roomId()).isEqualTo(roomId);
+        assertThat(locator.seatId()).isEqualTo(seatId);
+    }
+
+    @Test
+    @DisplayName("of 팩토리로 다른 SeatLocator를 복사할 수 있다")
+    default void copy_locator_with_of_factory() {
+        var roomId = getRoomId();
+        var seatId = getSeatId();
+        var source = SimpleSeatLocator.from(roomId, seatId);
+
+        var copied = SimpleSeatLocator.of(source);
+
+        assertThat(copied.roomId()).isEqualTo(roomId);
+        assertThat(copied.seatId()).isEqualTo(seatId);
+    }
+
+    @Test
+    @DisplayName("동일한 값이면 isSame은 true")
+    default void is_same_with_same_value() {
+        var roomId = getRoomId();
+        var seatId = getSeatId();
+        var locator = create(roomId, seatId);
+        var other = create(roomId, seatId);
+
+        assertThat(locator.isSame(other)).isTrue();
+    }
+
+    @Test
+    @DisplayName("다른 값이면 isSame은 false다")
+    default void is_not_same_with_diff_value() {
+        var roomId = getRoomId();
+        var seatId = getSeatId();
+        var locator = create(roomId, seatId);
+        var other = create("other-" + roomId, "other-" + seatId);
+
+        assertThat(locator.isSame(other)).isFalse();
+    }
+}

--- a/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/SimpleSeatLocatorTest.java
+++ b/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/SimpleSeatLocatorTest.java
@@ -1,88 +1,21 @@
 package com.seatliberator.seatliberator.reservation.domain;
 
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("Domain: Simple Seat Locator")
-public class SimpleSeatLocatorTest {
+public class SimpleSeatLocatorTest implements SeatLocatorContractTest<SimpleSeatLocator> {
+    @Override
+    public SimpleSeatLocator create(String roomId, String seatId) {
+        return SimpleSeatLocator.from(roomId, seatId);
+   }
 
-    String roomId = "room-1";
-    String seatId = "seat-1";
-
-    @Nested
-    @DisplayName("Creation")
-    class Creation {
-        @Test
-        @DisplayName("정상적인 좌석 위치로 생성할 수 있다")
-        void create_locator_when_arguments_are_valid() {
-            var locator = new SimpleSeatLocator(roomId, seatId);
-
-            assertThat(locator.roomId()).isEqualTo(roomId);
-            assertThat(locator.seatId()).isEqualTo(seatId);
-        }
-
-        @Test
-        @DisplayName("roomId가 비어 있으면 예외를 던진다")
-        void throw_exception_when_room_id_is_blank() {
-            assertThatThrownBy(() -> new SimpleSeatLocator(" ", seatId))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("roomId must not be null or blank.");
-        }
-
-        @Test
-        @DisplayName("seatId가 비어 있으면 예외를 던진다")
-        void throw_exception_when_seat_id_is_blank() {
-            assertThatThrownBy(() -> new SimpleSeatLocator(roomId, " "))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("seatId must not be null or blank.");
-        }
-
-        @Test
-        @DisplayName("from 팩토리로 생성할 수 있다")
-        void create_locator_with_from_factory() {
-            var locator = SimpleSeatLocator.from(roomId, seatId);
-
-            assertThat(locator.roomId()).isEqualTo(roomId);
-            assertThat(locator.seatId()).isEqualTo(seatId);
-        }
-
-        @Test
-        @DisplayName("of 팩토리로 다른 SeatLocator를 복사할 수 있다")
-        void copy_locator_with_of_factory() {
-            var source = SimpleSeatLocator.from(roomId, seatId);
-
-            var copied = SimpleSeatLocator.of(source);
-
-            assertThat(copied.roomId()).isEqualTo(roomId);
-            assertThat(copied.seatId()).isEqualTo(seatId);
-        }
+    @Override
+    public String getRoomId() {
+        return "room-1";
     }
 
-    @Nested
-    @DisplayName("Equality")
-    class Equality {
-        @Test
-        @DisplayName("같은 값, 같은 타입끼리는 인터페이스의 동등성 검사 통과")
-        void is_equal_with_same_type_and_value() {
-            var locator = SimpleSeatLocator.from(roomId, seatId);
-            var other = SimpleSeatLocator.from(roomId, seatId);
-
-            assertThat(locator).isEqualTo(other);
-            assertThat(locator.isSame(other)).isTrue();
-        }
-
-        @Test
-        @DisplayName("다른 값, 같은 타입끼리는 인터페이스의 동등성 검사 실패")
-        void is_not_equal_with_same_type_and_diff_value() {
-            var locator = SimpleSeatLocator.from(roomId, seatId);
-            var other = SimpleSeatLocator.from("other-" + roomId, "other-" + seatId);
-
-            assertThat(locator).isNotEqualTo(other);
-            assertThat(locator.isSame(other)).isFalse();
-        }
+    @Override
+    public String getSeatId() {
+        return "seat-1";
     }
 }


### PR DESCRIPTION
## 관련 이슈
- Refs #91

## 변경 내용

- `SeatLocator` 값 비교를 위한 canonical key 객체 `SeatLocatorKey`를 도입했습니다.
- `SeatLocator`가 `key()`를 통해 canonical key로 정규화되고, `isSame()`도 동일 기준을 사용하도록 정리했습니다.
- `AvailableSeats`에서 reserved locator 비교를 구현체의 `equals/hashCode`가 아니라 `SeatLocatorKey` 기반 집합 비교로 변경했습니다.
- 서로 다른 `SeatLocator` 구현체 간에도 동일한 좌석이면 같은 key로 비교된다는 점을 검증하는 테스트를 보강했습니다.

## 배경 및 의도

`SeatLocator` 구현체가 달라도 `roomId`, `seatId`가 같으면 같은 좌석으로 취급되어야 하지만, 컬렉션 연산은 구현체별 `equals/hashCode`에 의존해 비교가 어긋날 수 있었습니다. 이번 변경은 비교 기준을 canonical key로 고정해서 구현체 종류와 무관하게 일관된 값 동등성을 사용할 수 있게 하려는 목적입니다.

## 영향
 
- locator 기반 컬렉션 비교가 구현체 종류에 덜 민감해집니다.
- `AvailableSeats`의 reserved 좌석 필터링이 canonical key 기준으로 동작합니다.
- 이후 locator 비교가 필요한 다른 흐름에도 동일한 비교 기준을 재사용할 수 있습니다.

## 검증

- `./gradlew :reservation:reservation-domain:test :reservation:reservation-application:test`