### PR TITLE
feat(gateway): Spring Cloud Gateway 라우팅 구성을 추가함

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ SeatLiberator 는 좌석 예약과 빈자리 알림, 게시판, 사용자 인증
 
 - `identity:identity-application`
   사용자 가입, 로그인, federated login, JWT 발급, JWKS 공개
-- `board:board-application`
-  게시판, 카테고리, 게시글 관리와 board 권한 규칙
 - `reservation:reservation-application`
   좌석 관리, 예약, 빈자리 알림 신청/취소
+- `board:board-application`
+  게시판, 카테고리, 게시글 관리와 board 권한 규칙
 - `notification:notification-application`
   사용자 알림 조회와 알림 생성 이벤트 소비
 
@@ -99,8 +99,8 @@ resource server 계열 앱은 공통 보안 기본값을 bootstrap 에서 받고
 
 ```sh
 ./gradlew :identity:identity-application:bootRun
-./gradlew :board:board-application:bootRun
 ./gradlew :reservation:reservation-application:bootRun
+./gradlew :board:board-application:bootRun
 ./gradlew :notification:notification-application:bootRun
 ```
 
@@ -109,8 +109,8 @@ resource server 계열 앱은 공통 보안 기본값을 bootstrap 에서 받고
 ## 모듈별 문서
 
 - [identity/identity-application/README.md](/home/lilamaris/IdeaProjects/SeatLiberator/identity/identity-application/README.md)
-- [board/board-application/README.md](/home/lilamaris/IdeaProjects/SeatLiberator/board/board-application/README.md)
 - [reservation/reservation-application/README.md](/home/lilamaris/IdeaProjects/SeatLiberator/reservation/reservation-application/README.md)
+- [board/board-application/README.md](/home/lilamaris/IdeaProjects/SeatLiberator/board/board-application/README.md)
 - [notification/notification-application/README.md](/home/lilamaris/IdeaProjects/SeatLiberator/notification/notification-application/README.md)
 - [identity/identity-client/README.md](/home/lilamaris/IdeaProjects/SeatLiberator/identity/identity-client/README.md)
 

--- a/board/board-application/src/main/resources/application-dev.yml
+++ b/board/board-application/src/main/resources/application-dev.yml
@@ -2,7 +2,7 @@ seatliberator:
   resource-server:
     security:
       authorize:
-        jwk-set-uri: ${JWKS_BASE_URL:http://localhost:9090}/.well-known/jwks.json
+        jwk-set-uri: ${JWKS_BASE_URL:http://localhost:8080}/.well-known/jwks.json
 
 spring:
   datasource:

--- a/board/board-application/src/main/resources/application-local.yml
+++ b/board/board-application/src/main/resources/application-local.yml
@@ -2,7 +2,7 @@ seatliberator:
   resource-server:
     security:
       authorize:
-        jwk-set-uri: ${LOCAL_JWKS_BASE_URL:http://localhost:9090}/.well-known/jwks.json
+        jwk-set-uri: ${LOCAL_JWKS_BASE_URL:http://localhost:8080}/.well-known/jwks.json
 
 spring:
   datasource:

--- a/board/board-application/src/main/resources/application.yml
+++ b/board/board-application/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: ${PORT:8080}
+  port: ${PORT:8083}
 
 spring:
   profiles:

--- a/build-include/README.md
+++ b/build-include/README.md
@@ -56,8 +56,8 @@ JWT resource server 계열 애플리케이션용 convention plugin 입니다.
 
 현재 이 플러그인을 사용하는 모듈:
 
-- `board:board-application`
 - `reservation:reservation-application`
+- `board:board-application`
 - `notification:notification-application`
 
 ## bootstrap 모듈과의 관계

--- a/gateway/build.gradle.kts
+++ b/gateway/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    id("base.seatliberator.spring-application-base")
+}
+
+group = "com.seatliberator.seatliberator"
+version = "0.0.1-SNAPSHOT"
+
+val springCloudVersion = "2025.1.1"
+
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:$springCloudVersion")
+    }
+}
+
+dependencies {
+    implementation("org.springframework.cloud:spring-cloud-starter-gateway-server-webflux")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation(project(":identity:identity-application"))
+    testImplementation(project(":reservation:reservation-application"))
+    testImplementation(project(":board:board-application"))
+    testImplementation(project(":notification:notification-application"))
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/gateway/src/main/java/com/seatliberator/seatliberator/GatewayApplication.java
+++ b/gateway/src/main/java/com/seatliberator/seatliberator/GatewayApplication.java
@@ -1,0 +1,11 @@
+package com.seatliberator.seatliberator;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class GatewayApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(GatewayApplication.class, args);
+    }
+}

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -1,0 +1,39 @@
+server:
+  port: 8080
+
+spring:
+  application:
+    name: gateway-service
+  main:
+    web-application-type: reactive
+
+  cloud:
+    gateway:
+      server:
+        webflux:
+          routes:
+            - id: identity-service-route
+              uri: http://localhost:8081
+              predicates:
+                - Path=/auth/**,/oauth2/**,/login/**,/.well-known/jwks.json
+
+            - id: reservation-service-route
+              uri: http://localhost:8082
+              predicates:
+                - Path=/api/v1/reservation/**,/api/v1/seat/**,/api/v1/rooms/**,/api/v1/vacancy-alert/**
+              filters:
+                - RewritePath=/api/v1/?(?<segment>.*), /$\{segment}
+
+            - id: board-service-route
+              uri: http://localhost:8083
+              predicates:
+                - Path=/api/v1/board/**
+              filters:
+                - RewritePath=/api/v1/?(?<segment>.*), /$\{segment}
+
+            - id: notification-service-route
+              uri: http://localhost:8084
+              predicates:
+                - Path=/api/v1/notification/**
+              filters:
+                - RewritePath=/api/v1/?(?<segment>.*), /$\{segment}

--- a/gateway/src/test/java/com/seatliberator/seatliberator/GatewayRouteAlignmentTest.java
+++ b/gateway/src/test/java/com/seatliberator/seatliberator/GatewayRouteAlignmentTest.java
@@ -1,0 +1,253 @@
+package com.seatliberator.seatliberator;
+
+import com.seatliberator.seatliberator.board.infrastructure.web.controller.BoardController;
+import com.seatliberator.seatliberator.board.infrastructure.web.controller.CategoryController;
+import com.seatliberator.seatliberator.board.infrastructure.web.controller.PostController;
+import com.seatliberator.seatliberator.jwks.infrastructure.web.controller.JwksController;
+import com.seatliberator.seatliberator.notification.infrastructure.web.controller.NotificationController;
+import com.seatliberator.seatliberator.reservation.availability.infrastructure.web.controller.SeatAvailabilityController;
+import com.seatliberator.seatliberator.reservation.book.infrastructure.web.controller.ReservationController;
+import com.seatliberator.seatliberator.reservation.book.infrastructure.web.controller.SeatController;
+import com.seatliberator.seatliberator.reservation.vacancy.infrastructure.web.controller.VacancyAlertRequestController;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.server.PathContainer;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.util.pattern.PathPattern;
+import org.springframework.web.util.pattern.PathPatternParser;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GatewayRouteAlignmentTest {
+    private static final PathPatternParser PATH_PATTERN_PARSER = new PathPatternParser();
+
+    @Test
+    void identityControllerEntrypointsAreCoveredByGatewayRoutes() throws IOException {
+        var patterns = gatewayPathPatterns();
+        assertCovered(patterns, controllerPaths(JwksController.class), false);
+    }
+
+    @Test
+    void reservationControllerEntrypointsAreCoveredByGatewayRoutes() throws IOException {
+        var patterns = gatewayPathPatterns();
+        assertCovered(
+                patterns,
+                controllerPaths(
+                        ReservationController.class,
+                        SeatController.class,
+                        SeatAvailabilityController.class,
+                        VacancyAlertRequestController.class
+                ),
+                true
+        );
+    }
+
+    @Test
+    void boardControllerEntrypointsAreCoveredByGatewayRoutes() throws IOException {
+        var patterns = gatewayPathPatterns();
+        assertCovered(
+                patterns,
+                controllerPaths(
+                        BoardController.class,
+                        CategoryController.class,
+                        PostController.class
+                ),
+                true
+        );
+    }
+
+    @Test
+    void notificationControllerEntrypointsAreCoveredByGatewayRoutes() throws IOException {
+        var patterns = gatewayPathPatterns();
+        assertCovered(patterns, controllerPaths(NotificationController.class), true);
+    }
+
+    private static void assertCovered(Set<String> gatewayPatterns, Set<String> downstreamPaths, boolean rewriteApiV1Prefix) {
+        for (var downstreamPath : downstreamPaths) {
+            var externalPath = rewriteApiV1Prefix ? "/api/v1" + downstreamPath : downstreamPath;
+
+            assertThat(gatewayPatterns)
+                    .withFailMessage("No gateway path pattern covers downstream path '%s' (external path '%s')", downstreamPath, externalPath)
+                    .anyMatch(pattern -> matches(pattern, externalPath));
+        }
+    }
+
+    private static boolean matches(String pattern, String path) {
+        PathPattern pathPattern = PATH_PATTERN_PARSER.parse(pattern);
+        return pathPattern.matches(PathContainer.parsePath(path));
+    }
+
+    private static Set<String> gatewayPathPatterns() throws IOException {
+        var resource = new ClassPathResource("application.yml");
+        var content = new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        var patterns = new LinkedHashSet<String>();
+
+        for (var line : content.split("\\R")) {
+            var trimmed = line.trim();
+            if (!trimmed.startsWith("- Path=")) continue;
+
+            var values = trimmed.substring("- Path=".length());
+            Arrays.stream(values.split(","))
+                    .map(String::trim)
+                    .filter(StringUtils::hasText)
+                    .forEach(patterns::add);
+        }
+
+        return patterns;
+    }
+
+    @SafeVarargs
+    private static Set<String> controllerPaths(Class<?>... controllerClasses) {
+        var paths = new LinkedHashSet<String>();
+        for (var controllerClass : controllerClasses) {
+            paths.addAll(controllerPaths(controllerClass));
+        }
+        return paths;
+    }
+
+    private static Set<String> controllerPaths(Class<?> controllerClass) {
+        var classLevelPaths = requestMappingPaths(controllerClass.getAnnotation(RequestMapping.class));
+        if (classLevelPaths.isEmpty()) {
+            classLevelPaths = List.of("");
+        }
+
+        var paths = new LinkedHashSet<String>();
+        for (var method : controllerClass.getDeclaredMethods()) {
+            var methodLevelPaths = methodPaths(method);
+            if (methodLevelPaths.isEmpty()) {
+                continue;
+            }
+
+            for (var classLevelPath : classLevelPaths) {
+                for (var methodLevelPath : methodLevelPaths) {
+                    paths.add(normalizePath(classLevelPath, methodLevelPath));
+                }
+            }
+        }
+        return paths;
+    }
+
+    private static List<String> methodPaths(java.lang.reflect.Method method) {
+        var paths = new ArrayList<String>();
+        paths.addAll(requestMappingPaths(method.getAnnotation(RequestMapping.class)));
+        paths.addAll(mappingPaths(method.getAnnotation(GetMapping.class)));
+        paths.addAll(mappingPaths(method.getAnnotation(PostMapping.class)));
+        paths.addAll(mappingPaths(method.getAnnotation(PutMapping.class)));
+        paths.addAll(mappingPaths(method.getAnnotation(PatchMapping.class)));
+        paths.addAll(mappingPaths(method.getAnnotation(DeleteMapping.class)));
+
+        if (paths.isEmpty()) {
+            return List.of();
+        }
+
+        if (paths.stream().allMatch(String::isEmpty)) {
+            return List.of("");
+        }
+
+        return paths;
+    }
+
+    private static List<String> requestMappingPaths(RequestMapping mapping) {
+        if (mapping == null) {
+            return List.of();
+        }
+
+        if (mapping.path().length > 0) {
+            return Arrays.asList(mapping.path());
+        }
+
+        if (mapping.value().length > 0) {
+            return Arrays.asList(mapping.value());
+        }
+
+        return List.of("");
+    }
+
+    private static List<String> mappingPaths(GetMapping mapping) {
+        if (mapping == null) {
+            return List.of();
+        }
+        return annotationPaths(mapping.path(), mapping.value());
+    }
+
+    private static List<String> mappingPaths(PostMapping mapping) {
+        if (mapping == null) {
+            return List.of();
+        }
+        return annotationPaths(mapping.path(), mapping.value());
+    }
+
+    private static List<String> mappingPaths(PutMapping mapping) {
+        if (mapping == null) {
+            return List.of();
+        }
+        return annotationPaths(mapping.path(), mapping.value());
+    }
+
+    private static List<String> mappingPaths(PatchMapping mapping) {
+        if (mapping == null) {
+            return List.of();
+        }
+        return annotationPaths(mapping.path(), mapping.value());
+    }
+
+    private static List<String> mappingPaths(DeleteMapping mapping) {
+        if (mapping == null) {
+            return List.of();
+        }
+        return annotationPaths(mapping.path(), mapping.value());
+    }
+
+    private static List<String> annotationPaths(String[] path, String[] value) {
+        if (path.length > 0) {
+            return Arrays.asList(path);
+        }
+
+        if (value.length > 0) {
+            return Arrays.asList(value);
+        }
+
+        return List.of("");
+    }
+
+    private static String normalizePath(String classLevelPath, String methodLevelPath) {
+        var classPath = StringUtils.hasText(classLevelPath) ? classLevelPath : "";
+        var methodPath = StringUtils.hasText(methodLevelPath) ? methodLevelPath : "";
+
+        if (!StringUtils.hasText(classPath) && !StringUtils.hasText(methodPath)) {
+            return "/";
+        }
+
+        if (!StringUtils.hasText(classPath)) {
+            return methodPath;
+        }
+
+        if (!StringUtils.hasText(methodPath)) {
+            return classPath;
+        }
+
+        if (classPath.endsWith("/") && methodPath.startsWith("/")) {
+            return classPath.substring(0, classPath.length() - 1) + methodPath;
+        }
+
+        if (!classPath.endsWith("/") && !methodPath.startsWith("/")) {
+            return classPath + "/" + methodPath;
+        }
+
+        return classPath + methodPath;
+    }
+}

--- a/identity/identity-application/src/main/resources/application.yml
+++ b/identity/identity-application/src/main/resources/application.yml
@@ -10,7 +10,7 @@ identity:
         public-key: "classpath:keys/key-20260308-214756/public.pem"
 
 server:
-  port: ${PORT:9090}
+  port: ${PORT:8081}
 
 spring:
   profiles:

--- a/notification/notification-application/src/main/resources/application-dev.yml
+++ b/notification/notification-application/src/main/resources/application-dev.yml
@@ -2,7 +2,7 @@ seatliberator:
   resource-server:
     security:
       authorize:
-        jwk-set-uri: ${JWKS_BASE_URL:http://localhost:9090}/.well-known/jwks.json
+        jwk-set-uri: ${JWKS_BASE_URL:http://localhost:8080}/.well-known/jwks.json
 
 spring:
   datasource:

--- a/notification/notification-application/src/main/resources/application-local.yml
+++ b/notification/notification-application/src/main/resources/application-local.yml
@@ -2,7 +2,7 @@ seatliberator:
   resource-server:
     security:
       authorize:
-        jwk-set-uri: ${LOCAL_JWKS_BASE_URL:http://localhost:9090}/.well-known/jwks.json
+        jwk-set-uri: ${LOCAL_JWKS_BASE_URL:http://localhost:8080}/.well-known/jwks.json
 
 spring:
   datasource:

--- a/notification/notification-application/src/main/resources/application.yml
+++ b/notification/notification-application/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: ${PORT:8080}
+  port: ${PORT:8084}
 
 spring:
   profiles:

--- a/reservation/reservation-application/src/main/resources/application-dev.yml
+++ b/reservation/reservation-application/src/main/resources/application-dev.yml
@@ -2,7 +2,7 @@ seatliberator:
   resource-server:
     security:
       authorize:
-        jwk-set-uri: ${JWKS_BASE_URL:http://localhost:9090}/.well-known/jwks.json
+        jwk-set-uri: ${JWKS_BASE_URL:http://localhost:8080}/.well-known/jwks.json
 
 spring:
   datasource:

--- a/reservation/reservation-application/src/main/resources/application-local.yml
+++ b/reservation/reservation-application/src/main/resources/application-local.yml
@@ -2,7 +2,7 @@ seatliberator:
   resource-server:
     security:
       authorize:
-        jwk-set-uri: ${LOCAL_JWKS_BASE_URL:http://localhost:9090}/.well-known/jwks.json
+        jwk-set-uri: ${LOCAL_JWKS_BASE_URL:http://localhost:8080}/.well-known/jwks.json
 
 spring:
   datasource:

--- a/reservation/reservation-application/src/main/resources/application.yml
+++ b/reservation/reservation-application/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: ${PORT:8080}
+  port: ${PORT:8082}
 
 spring:
   profiles:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,12 +32,14 @@ include("event-relay:event-relay-support-jpa")
 include("event-relay:event-relay-support-kafka")
 include("event-relay:event-relay-starter")
 
-include("board:board-api")
-include("board:board-application")
-
 include("reservation:reservation-api")
 include("reservation:reservation-application")
 include("reservation:reservation-domain")
 
+include("board:board-api")
+include("board:board-application")
+
 include("notification:notification-api")
 include("notification:notification-application")
+
+include("gateway")


### PR DESCRIPTION
## 관련 이슈

- 없음

## 변경 사항

Spring Cloud Gateway 모듈을 추가하고, 각 애플리케이션의 외부 진입 경로가 게이트웨이 라우트와 일관되게 맞물리도록 포트와 경로 구성을 정리했습니다.
이번 변경은 게이트웨이 자체를 도입하는 것뿐 아니라, downstream 애플리케이션의 기본 포트와 JWKS 참조 경로를 게이트웨이 기준으로 맞추고, 실제 컨트롤러 진입점이 라우트와 어긋나지 않는지 테스트로 고정하는 데 초점을 두었습니다.

### gateway 모듈 추가

- `gateway` 모듈에 Spring Cloud Gateway 애플리케이션을 추가했습니다.
- `/auth/**`, `/oauth2/**`, `/login/**`, `/.well-known/jwks.json` 경로를 identity 애플리케이션으로 연결했습니다.
- `/api/v1/reservation/**`, `/api/v1/seat/**`, `/api/v1/rooms/**`, `/api/v1/vacancy-alert/**` 경로를 reservation 애플리케이션으로 연결하고 `/api/v1` prefix를 제거하도록 구성했습니다.
- `/api/v1/board/**`, `/api/v1/notification/**` 경로도 각각 board, notification 애플리케이션으로 라우팅하도록 구성했습니다.

### 애플리케이션 포트 및 JWKS 경로 정리

- `identity`, `reservation`, `board`, `notification` 애플리케이션의 기본 포트를 게이트웨이 라우트에 맞춰 `8081`~`8084`로 분리했습니다.
- resource server 계열 애플리케이션의 기본 `jwk-set-uri`가 identity 앱 직통 포트가 아니라 게이트웨이 엔드포인트(`http://localhost:8080/.well-known/jwks.json`)를 보도록 정리했습니다.
- 루트 설정과 문서에서 애플리케이션 진입점 나열 순서도 gateway 라우트 순서에 맞춰 정리했습니다.

### 라우트 정합성 검증 추가

- gateway 테스트에서 각 애플리케이션 컨트롤러의 실제 진입 경로를 수집해 게이트웨이 `Path` 패턴이 모두 덮는지 검증하는 테스트를 추가했습니다.
- reservation, board, notification은 `/api/v1` rewrite 전제까지 포함해서 검사하고, identity는 직접 노출되는 JWKS 컨트롤러 경로를 기준으로 확인합니다.
- 이 테스트로 이후 컨트롤러 진입점이 바뀌어도 gateway 설정이 같이 유지되는지 회귀를 확인할 수 있습니다.

## 배경 및 의도

애플리케이션별 포트와 외부 진입 경로가 분산되어 있는 상태에서는 실제 외부 API 표면이 어디에서 어떻게 노출되는지 한눈에 확인하기 어려웠고, 게이트웨이 도입 이후에도 컨트롤러 경로와 라우트 설정이 쉽게 어긋날 수 있었습니다.
이번 변경은 외부 진입점을 gateway 중심으로 고정하고, downstream 애플리케이션의 내부 경로와 gateway의 외부 라우트 간 대응 관계를 설정과 테스트로 함께 명확히 하려는 목적입니다.

## 영향

- 외부 API 진입점이 gateway를 기준으로 일관되게 정리됩니다.
- resource server 계열 애플리케이션이 JWKS를 gateway 경유 경로로 조회하게 됩니다.
- 컨트롤러 경로 변경 시 gateway 라우트 누락 여부를 테스트에서 바로 확인할 수 있습니다.

## 검증

- `./gradlew :gateway:test`