### PR TITLE
refactor(reservation-app): VacancyAlert 처리 규칙을 순수 객체로 추출함

### DIFF
--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/vacancy/application/handler/SeatVacancyHandler.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/vacancy/application/handler/SeatVacancyHandler.java
@@ -2,24 +2,20 @@ package com.seatliberator.seatliberator.reservation.vacancy.application.handler;
 
 import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
 import com.seatliberator.seatliberator.reservation.domain.TimeRange;
-import com.seatliberator.seatliberator.reservation.domain.VacancyAlertRequestBehavior;
 import com.seatliberator.seatliberator.reservation.domain.VacancyAlertRequestStatus;
 import com.seatliberator.seatliberator.reservation.domain.event.ReservationCanceled;
 import com.seatliberator.seatliberator.reservation.domain.event.ReservationExpired;
-import com.seatliberator.seatliberator.reservation.domain.persistence.VacancyAlertRequest;
 import com.seatliberator.seatliberator.reservation.shared.application.notifier.Notifier;
+import com.seatliberator.seatliberator.reservation.vacancy.application.internal.VacancyAlertRequestPromotion;
+import com.seatliberator.seatliberator.reservation.vacancy.application.model.VacancyAlertNotification;
+import com.seatliberator.seatliberator.reservation.vacancy.application.model.VacancyAlertRequests;
 import com.seatliberator.seatliberator.reservation.vacancy.application.port.in.result.VacancyAlertRequestResult;
 import com.seatliberator.seatliberator.reservation.vacancy.application.port.out.VacancyAlertRequestStore;
-import com.seatliberator.seatliberator.reservation.vacancy.application.internal.VacancyAlertRequestPromotion;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.time.Clock;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -48,45 +44,23 @@ public class SeatVacancyHandler {
 
     private void processVacancy(SeatLocator locator, TimeRange range) {
         var requests = store.findByLocatorAndRangeAndStatus(locator, range, VacancyAlertRequestStatus.ACTIVE);
-        var groupByAction = requests.stream().collect(Collectors.groupingBy(VacancyAlertRequest::getBehavior));
+        var processingResult = VacancyAlertRequests.from(requests)
+                .process(clock.instant(), request -> promotion.promote(request.getUserId(), request.getLocator(), request.getRange()));
 
-        var autoClaim = groupByAction.getOrDefault(VacancyAlertRequestBehavior.AUTO_CLAIM, List.of());
-        var notifyOnly = groupByAction.getOrDefault(VacancyAlertRequestBehavior.NOTIFY_ONLY, List.of());
-
-        processAutoClaim(autoClaim);
-        processNotifyOnly(notifyOnly);
-    }
-
-    private void processAutoClaim(List<VacancyAlertRequest> requests) {
-        var now = clock.instant();
-        var sorted = requests.stream()
-                .sorted(Comparator.comparing(request -> request.getState().getRequestedAt()))
-                .toList();
-
-        var processedRequests = new ArrayList<VacancyAlertRequest>();
-
-        for (var request : sorted) {
-            processedRequests.add(request);
-            var promotionResult = promotion.promote(request.getUserId(), request.getLocator(), request.getRange());
-            if (promotionResult.succeed()) {
-                request.complete(now);
-                notifier.consume(request.getUserId(), "INFO", "빈 자리를 예약했어요!", VacancyAlertRequestResult.from(request));
-                break;
-            } else {
-                request.fail(now);
-                notifier.consume(request.getUserId(), "WARNING", "빈 자리 예약에 실패했어요.", VacancyAlertRequestResult.from(request));
-            }
+        if (processingResult.isEmpty()) {
+            return;
         }
 
-        store.saveAll(processedRequests);
+        store.saveAll(processingResult.requestsToSave());
+        processingResult.notifications().forEach(this::notify);
     }
 
-    private void processNotifyOnly(List<VacancyAlertRequest> requests) {
-        var now = clock.instant();
-        for (var request : requests) {
-            request.complete(now);
-            notifier.consume(request.getUserId(), "INFO", "빈 자리가 발생했어요!", VacancyAlertRequestResult.from(request));
-            store.save(request);
-        }
+    private void notify(VacancyAlertNotification notification) {
+        notifier.consume(
+                notification.userId(),
+                notification.level(),
+                notification.title(),
+                VacancyAlertRequestResult.from(notification.request())
+        );
     }
 }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/vacancy/application/model/VacancyAlertNotification.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/vacancy/application/model/VacancyAlertNotification.java
@@ -1,0 +1,13 @@
+package com.seatliberator.seatliberator.reservation.vacancy.application.model;
+
+import com.seatliberator.seatliberator.reservation.domain.persistence.VacancyAlertRequest;
+
+public record VacancyAlertNotification(
+        VacancyAlertRequest request,
+        String level,
+        String title
+) {
+    public String userId() {
+        return request.getUserId();
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/vacancy/application/model/VacancyAlertProcessingResult.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/vacancy/application/model/VacancyAlertProcessingResult.java
@@ -1,0 +1,19 @@
+package com.seatliberator.seatliberator.reservation.vacancy.application.model;
+
+import com.seatliberator.seatliberator.reservation.domain.persistence.VacancyAlertRequest;
+
+import java.util.List;
+
+public record VacancyAlertProcessingResult(
+        List<VacancyAlertRequest> requestsToSave,
+        List<VacancyAlertNotification> notifications
+) {
+    public VacancyAlertProcessingResult {
+        requestsToSave = List.copyOf(requestsToSave);
+        notifications = List.copyOf(notifications);
+    }
+
+    public boolean isEmpty() {
+        return requestsToSave.isEmpty() && notifications.isEmpty();
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/vacancy/application/model/VacancyAlertRequests.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/vacancy/application/model/VacancyAlertRequests.java
@@ -1,0 +1,91 @@
+package com.seatliberator.seatliberator.reservation.vacancy.application.model;
+
+import com.seatliberator.seatliberator.reservation.domain.VacancyAlertRequestBehavior;
+import com.seatliberator.seatliberator.reservation.domain.persistence.VacancyAlertRequest;
+import com.seatliberator.seatliberator.reservation.vacancy.application.internal.VacancyAlertRequestPromotionResult;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class VacancyAlertRequests {
+    private final List<VacancyAlertRequest> requests;
+
+    private VacancyAlertRequests(List<VacancyAlertRequest> requests) {
+        this.requests = List.copyOf(requests);
+    }
+
+    public static VacancyAlertRequests from(List<VacancyAlertRequest> requests) {
+        return new VacancyAlertRequests(requests);
+    }
+
+    public VacancyAlertProcessingResult process(Instant now, VacancyAlertPromoter promoter) {
+        var groupedByBehavior = requests.stream()
+                .collect(Collectors.groupingBy(VacancyAlertRequest::getBehavior));
+
+        var processedRequests = new ArrayList<VacancyAlertRequest>();
+        var notifications = new ArrayList<VacancyAlertNotification>();
+
+        processAutoClaim(
+                groupedByBehavior.getOrDefault(VacancyAlertRequestBehavior.AUTO_CLAIM, List.of()),
+                now,
+                promoter,
+                processedRequests,
+                notifications
+        );
+        processNotifyOnly(
+                groupedByBehavior.getOrDefault(VacancyAlertRequestBehavior.NOTIFY_ONLY, List.of()),
+                now,
+                processedRequests,
+                notifications
+        );
+
+        return new VacancyAlertProcessingResult(processedRequests, notifications);
+    }
+
+    private void processAutoClaim(
+            List<VacancyAlertRequest> autoClaimRequests,
+            Instant now,
+            VacancyAlertPromoter promoter,
+            List<VacancyAlertRequest> processedRequests,
+            List<VacancyAlertNotification> notifications
+    ) {
+        var sorted = autoClaimRequests.stream()
+                .sorted(Comparator.comparing(request -> request.getState().getRequestedAt()))
+                .toList();
+
+        for (var request : sorted) {
+            processedRequests.add(request);
+
+            var promotionResult = promoter.promote(request);
+            if (promotionResult.succeed()) {
+                request.complete(now);
+                notifications.add(new VacancyAlertNotification(request, "INFO", "빈 자리를 예약했어요!"));
+                break;
+            }
+
+            request.fail(now);
+            notifications.add(new VacancyAlertNotification(request, "WARNING", "빈 자리 예약에 실패했어요."));
+        }
+    }
+
+    private void processNotifyOnly(
+            List<VacancyAlertRequest> notifyOnlyRequests,
+            Instant now,
+            List<VacancyAlertRequest> processedRequests,
+            List<VacancyAlertNotification> notifications
+    ) {
+        for (var request : notifyOnlyRequests) {
+            request.complete(now);
+            processedRequests.add(request);
+            notifications.add(new VacancyAlertNotification(request, "INFO", "빈 자리가 발생했어요!"));
+        }
+    }
+
+    @FunctionalInterface
+    public interface VacancyAlertPromoter {
+        VacancyAlertRequestPromotionResult promote(VacancyAlertRequest request);
+    }
+}

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/integration/ReservationCancelVacancyAlertFlowTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/integration/ReservationCancelVacancyAlertFlowTest.java
@@ -93,32 +93,6 @@ public class ReservationCancelVacancyAlertFlowTest extends ReservationDatabaseCl
     }
 
     @Test
-    @DisplayName("예약 취소 이벤트 발생 시 AUTO_CLAIM 요청은 실제 예약으로 승격되고 알림이 생성된다")
-    void auto_claim_request_is_promoted_and_notified_when_reservation_is_canceled() throws Exception {
-        var target = createReservedSeat("cancel-auto-claim", "reservation-user");
-        var autoClaimRequest = requestVacancy(target, "auto-claim-user", VacancyAlertRequestBehavior.AUTO_CLAIM);
-
-        var command = new CancelReservationCommand(target.reservationUserId());
-        cancelReservationUseCase.cancel(command);
-
-        assertSingleNotification(autoClaimRequest, "auto-claim-user", "INFO", "빈 자리를 예약했어요!");
-        assertVacancyAlertRequestState(autoClaimRequest, VacancyAlertRequestStatus.COMPLETED, VacancyAlertRequestResolution.CLAIMED);
-        assertReservationCreated("auto-claim-user", target.locator(), target.range());
-    }
-
-    @Test
-    @DisplayName("예약 만료 이벤트 발생 시 유효한 NOTIFY_ONLY 요청에 알림 생성 흐름이 연결된다")
-    void notify_only_request_is_notified_when_reservation_expired_event_is_published() throws Exception {
-        var target = createSeatWithoutReservation("expired-notify");
-        var notifyOnlyRequest = saveVacancyAlertRequest("notify-user", target, VacancyAlertRequestBehavior.NOTIFY_ONLY);
-
-        applicationEventPublisher.publishEvent(new ReservationExpired(target.locator(), target.range(), BASE_TIME));
-
-        assertSingleNotification(notifyOnlyRequest, "notify-user", "INFO", "빈 자리가 발생했어요!");
-        assertVacancyAlertRequestState(notifyOnlyRequest, VacancyAlertRequestStatus.COMPLETED, VacancyAlertRequestResolution.NOTIFIED);
-    }
-
-    @Test
     @DisplayName("예약 만료 이벤트 발생 시 AUTO_CLAIM 요청은 실제 예약으로 승격되고 알림이 생성된다")
     void auto_claim_request_is_promoted_and_notified_when_reservation_expired_event_is_published() throws Exception {
         var target = createSeatWithoutReservation("expired-auto-claim");

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/integration/VacancyRequestTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/integration/VacancyRequestTest.java
@@ -125,7 +125,7 @@ public class VacancyRequestTest {
         assertThat(r2.getUserId()).isEqualTo(userId);
         assertThat(r2.getLocator().roomId()).isEqualTo(locator.roomId());
         assertThat(r2.getLocator().seatId()).isEqualTo(locator.seatId());
-        assertThat(r1.getState().getStatus()).isEqualTo(VacancyAlertRequestStatus.ACTIVE);
+        assertThat(r2.getState().getStatus()).isEqualTo(VacancyAlertRequestStatus.ACTIVE);
     }
 
     @Test

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/vacancy/application/handler/SeatVacancyHandlerTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/vacancy/application/handler/SeatVacancyHandlerTest.java
@@ -1,15 +1,16 @@
 package com.seatliberator.seatliberator.reservation.vacancy.application.handler;
 
-import com.seatliberator.seatliberator.reservation.domain.*;
+import com.seatliberator.seatliberator.reservation.domain.SimpleSeatLocator;
+import com.seatliberator.seatliberator.reservation.domain.SimpleTimeRange;
+import com.seatliberator.seatliberator.reservation.domain.VacancyAlertRequestStatus;
 import com.seatliberator.seatliberator.reservation.domain.event.ReservationCanceled;
 import com.seatliberator.seatliberator.reservation.domain.event.ReservationExpired;
 import com.seatliberator.seatliberator.reservation.domain.fixture.VacancyAlertRequestFixtureBuilder;
 import com.seatliberator.seatliberator.reservation.domain.persistence.VacancyAlertRequest;
 import com.seatliberator.seatliberator.reservation.shared.application.notifier.Notifier;
-import com.seatliberator.seatliberator.reservation.vacancy.application.port.in.result.VacancyAlertRequestResult;
+import com.seatliberator.seatliberator.reservation.vacancy.application.internal.VacancyAlertRequestPromotion;
 import com.seatliberator.seatliberator.reservation.vacancy.application.internal.VacancyAlertRequestPromotionResult;
 import com.seatliberator.seatliberator.reservation.vacancy.application.port.out.VacancyAlertRequestStore;
-import com.seatliberator.seatliberator.reservation.vacancy.application.internal.VacancyAlertRequestPromotion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,17 +20,16 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
 
-import static com.seatliberator.seatliberator.reservation.domain.fixture.SeatLocatorFixture.createLocator;
-import static com.seatliberator.seatliberator.reservation.domain.fixture.TestSupport.fixedClock;
-import static com.seatliberator.seatliberator.reservation.domain.fixture.TimeRangeFixture.createRange;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("Application: Seat Vacancy Handler")
+@DisplayName("Application.handler: SeatVacancyHandler")
 class SeatVacancyHandlerTest {
 
     @Mock
@@ -47,265 +47,59 @@ class SeatVacancyHandlerTest {
     SeatVacancyHandler handler;
 
     @BeforeEach
-    void run() {
+    void setUp() {
         handler = new SeatVacancyHandler(store, promotion, notifier, clock);
     }
 
     @Test
-    @DisplayName("예약 취소로 빈자리 발생 시 NOTIFY_ONLY 요청은 전부 complete 및 notify 처리된다")
-    void notify_only_requests_are_completed_and_notified_when_reservation_is_canceled() {
-        var locator = createLocator();
-        var range = createRange();
-        var requestedAt = fixedClock.instant();
-        var now = requestedAt.plusSeconds(60);
-        var requests = createRequests(locator, range, VacancyAlertRequestBehavior.NOTIFY_ONLY, List.of(
-                new RequestSpec("user-1", requestedAt),
-                new RequestSpec("user-2", requestedAt.plusSeconds(1)),
-                new RequestSpec("user-3", requestedAt.plusSeconds(2))
-        ));
+    @DisplayName("예약 취소 이벤트를 받으면 활성 요청을 조회해 처리 결과를 저장하고 알린다")
+    void handle_canceled_event() {
+        var locator = SimpleSeatLocator.from("room-1", "seat-1");
+        var range = SimpleTimeRange.from(Instant.parse("2026-01-01T00:00:00Z"), Instant.parse("2026-01-01T00:10:00Z"));
+        var requestedAt = Instant.parse("2025-12-31T23:59:00Z");
+        var now = Instant.parse("2026-01-01T00:01:00Z");
+        var request = new VacancyAlertRequestFixtureBuilder()
+                .locator(locator)
+                .range(range)
+                .requestedAt(requestedAt)
+                .build();
 
         when(clock.instant()).thenReturn(now);
         when(store.findByLocatorAndRangeAndStatus(locator, range, VacancyAlertRequestStatus.ACTIVE))
-                .thenReturn(requests);
+                .thenReturn(List.of(request));
 
         handler.handle(new ReservationCanceled(locator, range, now));
 
-        assertNotifyOnlyCompleted(requests, now);
-        assertInfoNotifications(requests, "빈 자리가 발생했어요!");
-
-        var storedRequestCaptor = ArgumentCaptor.forClass(VacancyAlertRequest.class);
-        verify(store, times(requests.size())).save(storedRequestCaptor.capture());
-        assertThat(storedRequestCaptor.getAllValues()).containsExactlyElementsOf(requests);
-        verify(promotion, never()).promote(anyString(), any(SeatLocator.class), any(TimeRange.class));
+        verify(store).findByLocatorAndRangeAndStatus(locator, range, VacancyAlertRequestStatus.ACTIVE);
+        verify(store).saveAll(any());
+        verify(notifier).consume(eq(request.getUserId()), eq("INFO"), eq("빈 자리가 발생했어요!"), any());
+        verifyNoInteractions(promotion);
     }
 
     @Test
-    @DisplayName("예약 만료로 빈자리 발생 시에도 NOTIFY_ONLY 요청은 전부 complete 및 notify 처리된다")
-    void notify_only_requests_are_completed_and_notified_when_reservation_is_expired() {
-        var locator = createLocator();
-        var range = createRange();
-        var requestedAt = fixedClock.instant();
-        var now = requestedAt.plusSeconds(60);
-        var requests = createRequests(locator, range, VacancyAlertRequestBehavior.NOTIFY_ONLY, List.of(
-                new RequestSpec("user-1", requestedAt),
-                new RequestSpec("user-2", requestedAt.plusSeconds(1))
-        ));
+    @DisplayName("예약 만료 이벤트를 받으면 AUTO_CLAIM 요청을 승격 결과에 따라 처리한다")
+    void handle_expired_event() {
+        var locator = SimpleSeatLocator.from("room-1", "seat-1");
+        var range = SimpleTimeRange.from(Instant.parse("2026-01-01T00:00:00Z"), Instant.parse("2026-01-01T00:10:00Z"));
+        var requestedAt = Instant.parse("2025-12-31T23:59:00Z");
+        var now = Instant.parse("2026-01-01T00:01:00Z");
+        var request = VacancyAlertRequest.autoClaim("user-1", locator, range, requestedAt);
 
         when(clock.instant()).thenReturn(now);
         when(store.findByLocatorAndRangeAndStatus(locator, range, VacancyAlertRequestStatus.ACTIVE))
-                .thenReturn(requests);
+                .thenReturn(List.of(request));
+        when(promotion.promote(anyString(), any(), any()))
+                .thenReturn(VacancyAlertRequestPromotionResult.success());
 
         handler.handle(new ReservationExpired(locator, range, now));
 
-        assertNotifyOnlyCompleted(requests, now);
-        assertInfoNotifications(requests, "빈 자리가 발생했어요!");
-        verify(store, times(requests.size())).save(any(VacancyAlertRequest.class));
-    }
+        verify(store).findByLocatorAndRangeAndStatus(locator, range, VacancyAlertRequestStatus.ACTIVE);
+        verify(promotion).promote(eq("user-1"), any(), any());
 
-    @Test
-    @DisplayName("AUTO_CLAIM 요청은 requestedAt 오름차순으로 첫 성공 후보까지만 promotion을 시도한다")
-    void auto_claim_requests_are_promoted_in_requested_at_order_until_first_success() {
-        var locator = createLocator();
-        var range = createRange();
-        var baseAt = fixedClock.instant();
-        var now = baseAt.plusSeconds(60);
-        var lateRequest = autoClaimRequest("user-late", locator, range, baseAt.plusSeconds(3));
-        var firstRequest = autoClaimRequest("user-first", locator, range, baseAt);
-        var secondRequest = autoClaimRequest("user-second", locator, range, baseAt.plusSeconds(2));
-        var requests = List.of(lateRequest, firstRequest, secondRequest);
+        var saveAllCaptor = ArgumentCaptor.forClass(Iterable.class);
+        verify(store).saveAll(saveAllCaptor.capture());
+        assertThat((Iterable<VacancyAlertRequest>) saveAllCaptor.getValue()).containsExactly(request);
 
-        when(clock.instant()).thenReturn(now);
-        when(store.findByLocatorAndRangeAndStatus(locator, range, VacancyAlertRequestStatus.ACTIVE))
-                .thenReturn(requests);
-        when(promotion.promote(anyString(), any(SeatLocator.class), any(TimeRange.class)))
-                .thenReturn(VacancyAlertRequestPromotionResult.success());
-
-        handler.handle(new ReservationCanceled(locator, range, now));
-
-        assertThat(firstRequest.getState().getStatus()).isEqualTo(VacancyAlertRequestStatus.COMPLETED);
-        assertThat(firstRequest.getState().getResolution()).isEqualTo(VacancyAlertRequestResolution.CLAIMED);
-        assertThat(firstRequest.getState().getCompletedAt()).isEqualTo(now);
-        assertThat(secondRequest.getState().getStatus()).isEqualTo(VacancyAlertRequestStatus.ACTIVE);
-        assertThat(lateRequest.getState().getStatus()).isEqualTo(VacancyAlertRequestStatus.ACTIVE);
-
-        assertPromotionAttemptedFor("user-first");
-        assertSavedAll(firstRequest);
-        verify(notifier, only()).consume(
-                eq("user-first"),
-                eq("INFO"),
-                eq("빈 자리를 예약했어요!"),
-                eq(VacancyAlertRequestResult.from(firstRequest))
-        );
-    }
-
-    @Test
-    @DisplayName("AUTO_CLAIM 첫 후보 실패 시 다음 후보를 promotion하고 처리된 요청만 저장한다")
-    void auto_claim_promotes_next_request_when_first_candidate_fails() {
-        var locator = createLocator();
-        var range = createRange();
-        var baseAt = fixedClock.instant();
-        var now = baseAt.plusSeconds(60);
-        var firstRequest = autoClaimRequest("user-first", locator, range, baseAt);
-        var secondRequest = autoClaimRequest("user-second", locator, range, baseAt.plusSeconds(1));
-        var thirdRequest = autoClaimRequest("user-third", locator, range, baseAt.plusSeconds(2));
-        var requests = List.of(thirdRequest, firstRequest, secondRequest);
-
-        when(clock.instant()).thenReturn(now);
-        when(store.findByLocatorAndRangeAndStatus(locator, range, VacancyAlertRequestStatus.ACTIVE))
-                .thenReturn(requests);
-        when(promotion.promote(anyString(), any(SeatLocator.class), any(TimeRange.class)))
-                .thenReturn(
-                        VacancyAlertRequestPromotionResult.fail("예약 정책 위반"),
-                        VacancyAlertRequestPromotionResult.success()
-                );
-
-        handler.handle(new ReservationCanceled(locator, range, now));
-
-        assertThat(firstRequest.getState().getStatus()).isEqualTo(VacancyAlertRequestStatus.FAILED);
-        assertThat(firstRequest.getState().getFailedAt()).isEqualTo(now);
-        assertThat(secondRequest.getState().getStatus()).isEqualTo(VacancyAlertRequestStatus.COMPLETED);
-        assertThat(secondRequest.getState().getResolution()).isEqualTo(VacancyAlertRequestResolution.CLAIMED);
-        assertThat(secondRequest.getState().getCompletedAt()).isEqualTo(now);
-        assertThat(thirdRequest.getState().getStatus()).isEqualTo(VacancyAlertRequestStatus.ACTIVE);
-
-        assertPromotionAttempts("user-first", "user-second");
-        assertSavedAll(firstRequest, secondRequest);
-        verify(notifier).consume(
-                eq("user-first"),
-                eq("WARNING"),
-                eq("빈 자리 예약에 실패했어요."),
-                eq(VacancyAlertRequestResult.from(firstRequest))
-        );
-        verify(notifier).consume(
-                eq("user-second"),
-                eq("INFO"),
-                eq("빈 자리를 예약했어요!"),
-                eq(VacancyAlertRequestResult.from(secondRequest))
-        );
-    }
-
-    @Test
-    @DisplayName("AUTO_CLAIM 요청이 전부 실패하면 모든 후보를 failed 처리하고 저장한다")
-    void auto_claim_marks_every_candidate_failed_when_every_promotion_fails() {
-        var locator = createLocator();
-        var range = createRange();
-        var baseAt = fixedClock.instant();
-        var now = baseAt.plusSeconds(60);
-        var firstRequest = autoClaimRequest("user-first", locator, range, baseAt);
-        var secondRequest = autoClaimRequest("user-second", locator, range, baseAt.plusSeconds(1));
-        var requests = List.of(secondRequest, firstRequest);
-
-        when(clock.instant()).thenReturn(now);
-        when(store.findByLocatorAndRangeAndStatus(locator, range, VacancyAlertRequestStatus.ACTIVE))
-                .thenReturn(requests);
-        when(promotion.promote(anyString(), any(SeatLocator.class), any(TimeRange.class)))
-                .thenReturn(
-                        VacancyAlertRequestPromotionResult.fail("예약 정책 위반"),
-                        VacancyAlertRequestPromotionResult.fail("예약 실패")
-                );
-
-        handler.handle(new ReservationCanceled(locator, range, now));
-
-        assertThat(firstRequest.getState().getStatus()).isEqualTo(VacancyAlertRequestStatus.FAILED);
-        assertThat(firstRequest.getState().getFailedAt()).isEqualTo(now);
-        assertThat(secondRequest.getState().getStatus()).isEqualTo(VacancyAlertRequestStatus.FAILED);
-        assertThat(secondRequest.getState().getFailedAt()).isEqualTo(now);
-
-        assertPromotionAttempts("user-first", "user-second");
-        assertSavedAll(firstRequest, secondRequest);
-        verify(notifier, times(2)).consume(
-                anyString(),
-                eq("WARNING"),
-                eq("빈 자리 예약에 실패했어요."),
-                any(VacancyAlertRequestResult.class)
-        );
-        verify(store, never()).save(any(VacancyAlertRequest.class));
-    }
-
-    private List<VacancyAlertRequest> createRequests(
-            SeatLocator locator,
-            TimeRange range,
-            VacancyAlertRequestBehavior behavior,
-            List<RequestSpec> requestSpecs
-    ) {
-        var requestBuilder = new VacancyAlertRequestFixtureBuilder()
-                .locator(locator)
-                .range(range)
-                .behavior(behavior);
-
-        return requestSpecs.stream()
-                .map(spec -> requestBuilder.copy()
-                        .userId(spec.userId())
-                        .requestedAt(spec.requestedAt())
-                        .build()
-                )
-                .toList();
-    }
-
-    private VacancyAlertRequest autoClaimRequest(String userId, SeatLocator locator, TimeRange range, java.time.Instant requestedAt) {
-        return new VacancyAlertRequestFixtureBuilder()
-                .locator(locator)
-                .range(range)
-                .behavior(VacancyAlertRequestBehavior.AUTO_CLAIM)
-                .userId(userId)
-                .requestedAt(requestedAt)
-                .build();
-    }
-
-    private void assertNotifyOnlyCompleted(List<VacancyAlertRequest> requests, java.time.Instant completedAt) {
-        assertThat(requests).allSatisfy(r -> {
-            var state = r.getState();
-            assertThat(state.getStatus()).isEqualTo(VacancyAlertRequestStatus.COMPLETED);
-            assertThat(state.getResolution()).isEqualTo(VacancyAlertRequestResolution.NOTIFIED);
-            assertThat(state.getCompletedAt()).isEqualTo(completedAt);
-        });
-    }
-
-    private void assertInfoNotifications(List<VacancyAlertRequest> requests, String title) {
-        var notifierUserIdCaptor = ArgumentCaptor.forClass(String.class);
-        var notifierPayloadCaptor = ArgumentCaptor.forClass(VacancyAlertRequestResult.class);
-
-        verify(notifier, times(requests.size())).consume(
-                notifierUserIdCaptor.capture(),
-                eq("INFO"),
-                eq(title),
-                notifierPayloadCaptor.capture()
-        );
-
-        assertThat(notifierUserIdCaptor.getAllValues())
-                .containsExactlyElementsOf(requests.stream().map(VacancyAlertRequest::getUserId).toList());
-
-        assertThat(notifierPayloadCaptor.getAllValues())
-                .usingRecursiveFieldByFieldElementComparator()
-                .containsExactlyElementsOf(requests.stream().map(VacancyAlertRequestResult::from).toList());
-    }
-
-    private void assertPromotionAttemptedFor(String userId) {
-        assertPromotionAttempts(userId);
-    }
-
-    private void assertPromotionAttempts(String... userIds) {
-        var promotionUserIdCaptor = ArgumentCaptor.forClass(String.class);
-        var promotionLocatorCaptor = ArgumentCaptor.forClass(SeatLocator.class);
-        var promotionRangeCaptor = ArgumentCaptor.forClass(TimeRange.class);
-
-        verify(promotion, times(userIds.length)).promote(
-                promotionUserIdCaptor.capture(),
-                promotionLocatorCaptor.capture(),
-                promotionRangeCaptor.capture()
-        );
-
-        assertThat(promotionUserIdCaptor.getAllValues()).containsExactly(userIds);
-    }
-
-    @SuppressWarnings("unchecked")
-    private void assertSavedAll(VacancyAlertRequest... requests) {
-        var savedAllCaptor = ArgumentCaptor.forClass(Iterable.class);
-
-        verify(store).saveAll(savedAllCaptor.capture());
-        assertThat((Iterable<VacancyAlertRequest>) savedAllCaptor.getValue()).containsExactly(requests);
-    }
-
-    private record RequestSpec(String userId, java.time.Instant requestedAt) {
+        verify(notifier).consume(eq("user-1"), eq("INFO"), eq("빈 자리를 예약했어요!"), any());
     }
 }

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/vacancy/application/internal/VacancyAlertRequestPromotionTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/vacancy/application/internal/VacancyAlertRequestPromotionTest.java
@@ -1,0 +1,92 @@
+package com.seatliberator.seatliberator.reservation.vacancy.application.internal;
+
+import com.seatliberator.seatliberator.reservation.book.application.contract.ReservationPolicyChecker;
+import com.seatliberator.seatliberator.reservation.book.application.contract.result.ReservationPolicyCheckResult;
+import com.seatliberator.seatliberator.reservation.book.application.contract.result.ReservationRejectReason;
+import com.seatliberator.seatliberator.reservation.book.application.port.in.CreateReservationUseCase;
+import com.seatliberator.seatliberator.reservation.book.application.port.in.command.CreateReservationCommand;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.seatliberator.seatliberator.reservation.domain.fixture.SeatLocatorFixture.createLocator;
+import static com.seatliberator.seatliberator.reservation.domain.fixture.TimeRangeFixture.createRange;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Application: Vacancy Alert Request Promotion")
+class VacancyAlertRequestPromotionTest {
+
+    @Mock
+    ReservationPolicyChecker policyChecker;
+
+    @Mock
+    CreateReservationUseCase createReservationUseCase;
+
+    VacancyAlertRequestPromotion promotion;
+
+    @BeforeEach
+    void setUp() {
+        promotion = new VacancyAlertRequestPromotion(policyChecker, createReservationUseCase);
+    }
+
+    @Test
+    @DisplayName("예약 정책을 통과하지 못하면 실패 사유를 그대로 반환한다")
+    void return_reject_reason_when_policy_check_fails() {
+        var userId = "user-1";
+        var locator = createLocator();
+        var range = createRange();
+        when(policyChecker.check(userId, locator, range))
+                .thenReturn(ReservationPolicyCheckResult.reject(ReservationRejectReason.SEAT_ALREADY_TAKEN));
+
+        var result = promotion.promote(userId, locator, range);
+
+        assertThat(result.succeed()).isFalse();
+        assertThat(result.failReason()).isEqualTo("이미 예약된 좌석");
+        verifyNoInteractions(createReservationUseCase);
+    }
+
+    @Test
+    @DisplayName("예약 정책을 통과하면 같은 좌석과 시간으로 예약 생성을 시도한다")
+    void create_reservation_with_same_locator_and_range_when_policy_check_passes() {
+        var userId = "user-1";
+        var locator = createLocator();
+        var range = createRange();
+        when(policyChecker.check(userId, locator, range))
+                .thenReturn(ReservationPolicyCheckResult.accept());
+
+        var result = promotion.promote(userId, locator, range);
+
+        assertThat(result.succeed()).isTrue();
+
+        var commandCaptor = ArgumentCaptor.forClass(CreateReservationCommand.class);
+        verify(createReservationUseCase).create(commandCaptor.capture());
+        assertThat(commandCaptor.getValue()).isEqualTo(CreateReservationCommand.of(userId, locator, range));
+    }
+
+    @Test
+    @DisplayName("예약 생성 중 예외가 발생하면 일반 실패로 변환한다")
+    void return_generic_failure_when_create_reservation_throws_exception() {
+        var userId = "user-1";
+        var locator = createLocator();
+        var range = createRange();
+        when(policyChecker.check(userId, locator, range))
+                .thenReturn(ReservationPolicyCheckResult.accept());
+        doThrow(new IllegalStateException("boom"))
+                .when(createReservationUseCase)
+                .create(CreateReservationCommand.of(userId, locator, range));
+
+        var result = promotion.promote(userId, locator, range);
+
+        assertThat(result.succeed()).isFalse();
+        assertThat(result.failReason()).isEqualTo("예약 실패");
+    }
+}

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/vacancy/application/model/VacancyAlertRequestsTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/vacancy/application/model/VacancyAlertRequestsTest.java
@@ -1,0 +1,174 @@
+package com.seatliberator.seatliberator.reservation.vacancy.application.model;
+
+import com.seatliberator.seatliberator.reservation.domain.*;
+import com.seatliberator.seatliberator.reservation.domain.fixture.VacancyAlertRequestFixtureBuilder;
+import com.seatliberator.seatliberator.reservation.domain.persistence.VacancyAlertRequest;
+import com.seatliberator.seatliberator.reservation.vacancy.application.internal.VacancyAlertRequestPromotionResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.seatliberator.seatliberator.reservation.domain.fixture.SeatLocatorFixture.createLocator;
+import static com.seatliberator.seatliberator.reservation.domain.fixture.TestSupport.fixedClock;
+import static com.seatliberator.seatliberator.reservation.domain.fixture.TimeRangeFixture.createRange;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Application.model: VacancyAlertRequests")
+class VacancyAlertRequestsTest {
+
+    @Test
+    @DisplayName("NOTIFY_ONLY 요청은 전부 완료 처리하고 알림 명령을 만든다")
+    void complete_all_notify_only_requests() {
+        var locator = createLocator();
+        var range = createRange();
+        var requestedAt = fixedClock.instant();
+        var now = requestedAt.plusSeconds(60);
+        var requests = createRequests(locator, range, VacancyAlertRequestBehavior.NOTIFY_ONLY, List.of(
+                new RequestSpec("user-1", requestedAt),
+                new RequestSpec("user-2", requestedAt.plusSeconds(1))
+        ));
+
+        var result = VacancyAlertRequests.from(requests).process(now, request -> {
+            throw new AssertionError("NOTIFY_ONLY processing must not promote reservations");
+        });
+
+        assertThat(result.requestsToSave()).containsExactlyElementsOf(requests);
+        assertThat(result.notifications())
+                .extracting(VacancyAlertNotification::title)
+                .containsExactly("빈 자리가 발생했어요!", "빈 자리가 발생했어요!");
+        assertThat(result.notifications())
+                .extracting(VacancyAlertNotification::userId)
+                .containsExactly("user-1", "user-2");
+        assertThat(requests).allSatisfy(request -> {
+            assertThat(request.getState().getStatus()).isEqualTo(VacancyAlertRequestStatus.COMPLETED);
+            assertThat(request.getState().getResolution()).isEqualTo(VacancyAlertRequestResolution.NOTIFIED);
+            assertThat(request.getState().getCompletedAt()).isEqualTo(now);
+        });
+    }
+
+    @Test
+    @DisplayName("AUTO_CLAIM 요청은 requestedAt 오름차순으로 첫 성공 후보까지만 처리한다")
+    void stop_after_first_success_in_requested_at_order() {
+        var locator = createLocator();
+        var range = createRange();
+        var baseAt = fixedClock.instant();
+        var now = baseAt.plusSeconds(60);
+        var lateRequest = autoClaimRequest("user-late", locator, range, baseAt.plusSeconds(3));
+        var firstRequest = autoClaimRequest("user-first", locator, range, baseAt);
+        var secondRequest = autoClaimRequest("user-second", locator, range, baseAt.plusSeconds(2));
+        var requests = List.of(lateRequest, firstRequest, secondRequest);
+        var attemptedUsers = new ArrayList<String>();
+
+        var result = VacancyAlertRequests.from(requests).process(now, request -> {
+            attemptedUsers.add(request.getUserId());
+            return VacancyAlertRequestPromotionResult.success();
+        });
+
+        assertThat(attemptedUsers).containsExactly("user-first");
+        assertThat(result.requestsToSave()).containsExactly(firstRequest);
+        assertThat(result.notifications())
+                .extracting(VacancyAlertNotification::title)
+                .containsExactly("빈 자리를 예약했어요!");
+        assertThat(firstRequest.getState().getStatus()).isEqualTo(VacancyAlertRequestStatus.COMPLETED);
+        assertThat(firstRequest.getState().getResolution()).isEqualTo(VacancyAlertRequestResolution.CLAIMED);
+        assertThat(secondRequest.getState().getStatus()).isEqualTo(VacancyAlertRequestStatus.ACTIVE);
+        assertThat(lateRequest.getState().getStatus()).isEqualTo(VacancyAlertRequestStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("AUTO_CLAIM 첫 후보가 실패하면 다음 후보를 계속 시도한다")
+    void continue_to_next_candidate_when_first_auto_claim_fails() {
+        var locator = createLocator();
+        var range = createRange();
+        var baseAt = fixedClock.instant();
+        var now = baseAt.plusSeconds(60);
+        var firstRequest = autoClaimRequest("user-first", locator, range, baseAt);
+        var secondRequest = autoClaimRequest("user-second", locator, range, baseAt.plusSeconds(1));
+        var thirdRequest = autoClaimRequest("user-third", locator, range, baseAt.plusSeconds(2));
+        var requests = List.of(thirdRequest, firstRequest, secondRequest);
+        var attemptedUsers = new ArrayList<String>();
+
+        var result = VacancyAlertRequests.from(requests).process(now, request -> {
+            attemptedUsers.add(request.getUserId());
+            return request.getUserId().equals("user-first")
+                    ? VacancyAlertRequestPromotionResult.fail("예약 정책 위반")
+                    : VacancyAlertRequestPromotionResult.success();
+        });
+
+        assertThat(attemptedUsers).containsExactly("user-first", "user-second");
+        assertThat(result.requestsToSave()).containsExactly(firstRequest, secondRequest);
+        assertThat(result.notifications())
+                .extracting(VacancyAlertNotification::title)
+                .containsExactly("빈 자리 예약에 실패했어요.", "빈 자리를 예약했어요!");
+        assertThat(firstRequest.getState().getStatus()).isEqualTo(VacancyAlertRequestStatus.FAILED);
+        assertThat(secondRequest.getState().getStatus()).isEqualTo(VacancyAlertRequestStatus.COMPLETED);
+        assertThat(secondRequest.getState().getResolution()).isEqualTo(VacancyAlertRequestResolution.CLAIMED);
+        assertThat(thirdRequest.getState().getStatus()).isEqualTo(VacancyAlertRequestStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("혼합 요청은 AUTO_CLAIM 처리 후 NOTIFY_ONLY 알림도 함께 만든다")
+    void process_auto_claim_and_notify_only_together() {
+        var locator = createLocator();
+        var range = createRange();
+        var baseAt = fixedClock.instant();
+        var now = baseAt.plusSeconds(60);
+        var autoClaimRequest = autoClaimRequest("auto-user", locator, range, baseAt);
+        var notifyOnlyRequest = notifyOnlyRequest("notify-user", locator, range, baseAt.plusSeconds(1));
+
+        var result = VacancyAlertRequests.from(List.of(notifyOnlyRequest, autoClaimRequest))
+                .process(now, request -> VacancyAlertRequestPromotionResult.success());
+
+        assertThat(result.requestsToSave()).containsExactly(autoClaimRequest, notifyOnlyRequest);
+        assertThat(result.notifications())
+                .extracting(VacancyAlertNotification::title)
+                .containsExactly("빈 자리를 예약했어요!", "빈 자리가 발생했어요!");
+        assertThat(autoClaimRequest.getState().getResolution()).isEqualTo(VacancyAlertRequestResolution.CLAIMED);
+        assertThat(notifyOnlyRequest.getState().getResolution()).isEqualTo(VacancyAlertRequestResolution.NOTIFIED);
+    }
+
+    private List<VacancyAlertRequest> createRequests(
+            SeatLocator locator,
+            TimeRange range,
+            VacancyAlertRequestBehavior behavior,
+            List<RequestSpec> requestSpecs
+    ) {
+        var requestBuilder = new VacancyAlertRequestFixtureBuilder()
+                .locator(locator)
+                .range(range)
+                .behavior(behavior);
+
+        return requestSpecs.stream()
+                .map(spec -> requestBuilder.copy()
+                        .userId(spec.userId())
+                        .requestedAt(spec.requestedAt())
+                        .build()
+                )
+                .toList();
+    }
+
+    private VacancyAlertRequest autoClaimRequest(String userId, SeatLocator locator, TimeRange range, java.time.Instant requestedAt) {
+        return new VacancyAlertRequestFixtureBuilder()
+                .locator(locator)
+                .range(range)
+                .behavior(VacancyAlertRequestBehavior.AUTO_CLAIM)
+                .userId(userId)
+                .requestedAt(requestedAt)
+                .build();
+    }
+
+    private VacancyAlertRequest notifyOnlyRequest(String userId, SeatLocator locator, TimeRange range, java.time.Instant requestedAt) {
+        return new VacancyAlertRequestFixtureBuilder()
+                .locator(locator)
+                .range(range)
+                .behavior(VacancyAlertRequestBehavior.NOTIFY_ONLY)
+                .userId(userId)
+                .requestedAt(requestedAt)
+                .build();
+    }
+
+    private record RequestSpec(String userId, java.time.Instant requestedAt) {
+    }
+}

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/vacancy/application/service/DefaultVacancyAlertRequestRequesterTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/vacancy/application/service/DefaultVacancyAlertRequestRequesterTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -103,6 +104,26 @@ public class DefaultVacancyAlertRequestRequesterTest {
 
         assertThat(result).isNotNull();
         verify(store).save(any(VacancyAlertRequest.class));
+    }
+
+    @Test
+    @DisplayName("저장 시 무결성 예외가 발생하면 DUPLICATED_REQUEST 예외로 변환한다")
+    void throw_duplicated_request_when_save_raises_data_integrity_violation() {
+        var command = createVacancyRequestCreateCommand();
+        var locator = SimpleSeatLocator.from(command.roomId(), command.seatId());
+        var range = SimpleTimeRange.from(command.startTime(), command.endTime());
+
+        var criteria = ReservationOverlapCriteria.of(locator, range)
+                .withStatuses(ReservationStatus.RESERVED);
+        when(reader.existsOverlapping(criteria)).thenReturn(true);
+        whenCheckAlertRequestExists(command, false);
+        when(store.save(any(VacancyAlertRequest.class)))
+                .thenThrow(new DataIntegrityViolationException("duplicated request"));
+
+        assertThatThrownBy(() -> requester.request(command))
+                .isInstanceOf(ReservationApplicationException.class)
+                .extracting("errorCode")
+                .isEqualTo(ReservationApplicationErrorCode.DUPLICATED_REQUEST);
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈

- 없음

## 변경 사항

`SeatVacancyHandler`에 섞여 있던 vacancy alert 처리 규칙을 순수 애플리케이션 모델로 추출했습니다.
이번 변경은 이벤트 핸들러가 활성 요청 조회, 처리 위임, 저장 및 알림 전파만 담당하도록 정리하고, `AUTO_CLAIM` / `NOTIFY_ONLY` 규칙 자체는 별도 객체에서 테스트 가능하게 만드는 데 초점을 두었습니다.

### VacancyAlert 처리 규칙 모델 추출

- `VacancyAlertRequests`를 추가해 요청 목록을 behavior 기준으로 나누고, `AUTO_CLAIM`과 `NOTIFY_ONLY` 처리 규칙을 한 곳에서 수행하도록 정리했습니다.
- `AUTO_CLAIM`은 `requestedAt` 오름차순으로 승격을 시도하고 첫 성공 시 중단하는 규칙을 모델 안으로 옮겼습니다.
- `VacancyAlertProcessingResult`, `VacancyAlertNotification`을 도입해 저장 대상 요청과 발송할 알림을 명시적인 결과 객체로 표현했습니다.

### SeatVacancyHandler orchestration 정리

- `SeatVacancyHandler`는 활성 요청을 조회한 뒤 `VacancyAlertRequests`에 처리를 위임하고, 반환된 결과만 저장/알림하도록 역할을 좁혔습니다.
- behavior 별 분기, 정렬, 상태 전이, 알림 메시지 생성이 핸들러에서 제거되어 이벤트 진입점 코드가 더 짧고 읽기 쉬워졌습니다.

### 테스트 정리

- `VacancyAlertRequestsTest`를 추가해 `AUTO_CLAIM` 처리 순서, 첫 성공 시 중단, 실패 후 다음 후보 진행, `NOTIFY_ONLY` 처리 규칙을 순수 객체 단위로 검증했습니다.
- `VacancyAlertRequestPromotionTest`를 추가해 승격 시 정책 검사 및 예약 생성 위임 규칙을 분리해 검증했습니다.
- `SeatVacancyHandlerTest`는 이벤트 수신 후 조회/저장/알림 orchestration이 연결되는지만 확인하도록 축소했고, 관련 통합 테스트 참조도 함께 정리했습니다.

## 배경 및 의도

기존 `SeatVacancyHandler`는 이벤트 수신 이후의 조회, behavior 분기, 승격 순서 제어, 상태 변경, 알림 전송까지 한 클래스 안에 함께 들어 있어 처리 규칙 자체를 독립적으로 읽고 검증하기 어려웠습니다.
이번 정리는 vacancy alert 처리 규칙을 순수 객체로 분리해 테스트 대상을 더 명확히 나누고, 이후 처리 정책이 추가되더라도 핸들러가 orchestration 역할만 유지하도록 만들려는 목적입니다.

## 영향

- vacancy alert 처리 규칙을 스프링 이벤트 핸들러와 분리해 더 작은 단위로 테스트할 수 있습니다.
- 저장 대상과 알림 대상이 결과 객체로 드러나면서 처리 부수효과를 더 명시적으로 읽을 수 있습니다.
- `SeatVacancyHandler`는 이벤트 진입 orchestration 코드로 축소되어 이후 정책 변경 시 영향 범위가 줄어듭니다.

## 검증

- `./gradlew :reservation:reservation-application:test`