### PR TITLE
feat(reservation-app): 전역 예외 응답을 ProblemDetail로 정리

### DIFF
--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/shared/infrastructure/web/advice/ReservationGlobalControllerAdvice.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/shared/infrastructure/web/advice/ReservationGlobalControllerAdvice.java
@@ -1,0 +1,118 @@
+package com.seatliberator.seatliberator.reservation.shared.infrastructure.web.advice;
+
+import com.seatliberator.seatliberator.reservation.shared.application.exception.ReservationApplicationException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.net.URI;
+
+@Slf4j
+@RestControllerAdvice(basePackages = "com.seatliberator.seatliberator.reservation")
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class ReservationGlobalControllerAdvice {
+
+    @ExceptionHandler(ReservationApplicationException.class)
+    public ProblemDetail handleReservationApplicationException(
+            ReservationApplicationException exception,
+            HttpServletRequest request
+    ) {
+        var errorCode = exception.getErrorCode();
+        var status = resolveStatus(errorCode);
+
+        log.warn("Reservation application error. code={}, path={}", errorCode, request.getRequestURI());
+
+        var problem = ProblemDetail.forStatusAndDetail(status, errorCode.getMessage());
+        problem.setTitle(errorCode.name());
+        problem.setType(URI.create("https://seatliberator/errors/" + errorCode.name().toLowerCase()));
+        problem.setProperty("code", errorCode.name());
+        return problem;
+    }
+
+    @ExceptionHandler({
+            MethodArgumentNotValidException.class,
+            BindException.class,
+            ConstraintViolationException.class,
+            HttpMessageNotReadableException.class,
+            MethodArgumentTypeMismatchException.class
+    })
+    public ProblemDetail handleBadRequest(Exception exception, HttpServletRequest request) {
+        log.warn("Bad request. type={}, path={}, message={}",
+                exception.getClass().getSimpleName(),
+                request.getRequestURI(),
+                exception.getMessage());
+
+        var problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.");
+        problem.setTitle("BAD_REQUEST");
+        problem.setType(URI.create("https://seatliberator/errors/bad-request"));
+        problem.setProperty("code", "BAD_REQUEST");
+        return problem;
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ProblemDetail handleIllegalArgument(
+            IllegalArgumentException exception,
+            HttpServletRequest request
+    ) {
+        log.warn("Illegal argument. path={}, message={}", request.getRequestURI(), exception.getMessage());
+
+        var problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "요청 값이 올바르지 않습니다.");
+        problem.setTitle("INVALID_ARGUMENT");
+        problem.setType(URI.create("https://seatliberator/errors/invalid-argument"));
+        problem.setProperty("code", "INVALID_ARGUMENT");
+        return problem;
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ProblemDetail handleIllegalState(
+            IllegalStateException exception,
+            HttpServletRequest request
+    ) {
+        log.error("Illegal state. path={}", request.getRequestURI(), exception);
+
+        var problem = ProblemDetail.forStatusAndDetail(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "요청 처리 중 오류가 발생했습니다."
+        );
+        problem.setTitle("INTERNAL_SERVER_ERROR");
+        problem.setType(URI.create("https://seatliberator/errors/internal-server-error"));
+        problem.setProperty("code", "INTERNAL_SERVER_ERROR");
+        return problem;
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ProblemDetail handleUnhandled(
+            Exception exception,
+            HttpServletRequest request
+    ) {
+        log.error("Unhandled exception. path={}", request.getRequestURI(), exception);
+
+        var problem = ProblemDetail.forStatusAndDetail(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "알 수 없는 오류가 발생했습니다."
+        );
+        problem.setTitle("UNEXPECTED_ERROR");
+        problem.setType(URI.create("https://seatliberator/errors/unexpected-error"));
+        problem.setProperty("code", "UNEXPECTED_ERROR");
+        return problem;
+    }
+
+    private HttpStatus resolveStatus(Enum<?> errorCode) {
+        return switch (errorCode.name()) {
+            case "RESERVATION_NOT_FOUND", "SEAT_NOT_FOUND" -> HttpStatus.NOT_FOUND;
+            case "RESERVATION_ALREADY_EXISTS", "RESERVATION_TIME_CONFLICT" -> HttpStatus.CONFLICT;
+            case "RESERVATION_READ_FORBIDDEN", "RESERVATION_VERIFY_FORBIDDEN" -> HttpStatus.FORBIDDEN;
+            default -> HttpStatus.BAD_REQUEST;
+        };
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- 없음

## 변경 사항

reservation 모듈의 웹 계층 예외 응답을 전역 ControllerAdvice 하나로 수렴했습니다.
이번 변경은 `ReservationApplicationException`에 대한 에러 코드별 HTTP status 매핑을 정리하고, 요청 바인딩/검증 오류와 예상치 못한 예외도 `ProblemDetail` 기반 응답으로 일관되게 반환하는 데 초점을 두었습니다.

### reservation 전역 예외 처리 추가

- `ReservationGlobalControllerAdvice`를 추가하고 reservation 패키지 전반에 적용되도록 `@RestControllerAdvice` 범위를 설정했습니다.
- `ReservationApplicationException` 처리 시 error code 이름과 메시지를 `ProblemDetail`의 `title`, `detail`, `code` 속성으로 노출하도록 구성했습니다.
- 에러 코드별로 `404`, `409`, `403`, 그 외 `400`으로 내려가도록 상태 매핑을 정리했습니다.

### 요청 오류 응답 정리

- validation, binding, request body parse, type mismatch 예외를 한곳에서 처리해 `BAD_REQUEST` 코드와 공통 메시지로 응답하도록 했습니다.
- `IllegalArgumentException`도 별도 처리해 잘못된 요청 값과 서버 내부 오류를 구분하도록 했습니다.

### 미처리 예외 기본 응답 추가

- `IllegalStateException`과 그 외 `Exception`에 대해 공통 `ProblemDetail` 응답을 반환하도록 처리했습니다.
- 클라이언트에는 일반화된 메시지를 반환하고, 서버 로그에는 요청 경로와 예외 정보를 남기도록 구성했습니다.

## 배경 및 의도

기존 reservation 모듈은 애플리케이션 예외와 요청 오류가 컨트롤러 단위에서 일관되게 표현되지 않아, 클라이언트가 오류 응답 형식을 예측하기 어려웠습니다.
이번 변경은 reservation 모듈의 예외 응답 표면을 `ProblemDetail` 기반으로 통일하고, 도메인/애플리케이션 에러 코드와 HTTP 상태 간 대응을 한 곳에서 관리하려는 목적입니다.

## 영향

- reservation API의 오류 응답 형식이 `ProblemDetail` 기반으로 일관되게 정리됩니다.
- 애플리케이션 에러 코드가 HTTP status 및 응답 `code` 필드에 대응되어 클라이언트 처리 기준이 더 명확해집니다.
- 검증/바인딩 실패와 예기치 않은 서버 오류가 공통 예외 처리 계층을 통해 반환됩니다.

## 검증

- `./gradlew :reservation:reservation-application:test`