### PR TITLE
feat(reservation-domain): Seat 상태 전이 모델을 추가함

### DIFF
--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/model/CreateReservationPolicyModel.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/model/CreateReservationPolicyModel.java
@@ -1,4 +1,0 @@
-package com.seatliberator.seatliberator.reservation.book.application.model;
-
-public class CreateReservationPolicyModel {
-}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/service/SeatCommandService.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/service/SeatCommandService.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.util.List;
 
 @Service
@@ -30,6 +31,8 @@ public class SeatCommandService implements
     private final SeatStore store;
     private final SeatReader query;
 
+    private final Clock clock;
+
     @Override
     public boolean create(CreateSeatCommand command) {
         var locator = SimpleSeatLocator.from(command.roomId(), command.seatId());
@@ -39,7 +42,8 @@ public class SeatCommandService implements
 
         Seat seat = Seat.create(
                 command.roomId(),
-                command.seatId()
+                command.seatId(),
+                clock.instant()
         );
 
         store.save(seat);

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/shared/application/seed/DevFixture.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/shared/application/seed/DevFixture.java
@@ -2,6 +2,7 @@ package com.seatliberator.seatliberator.reservation.shared.application.seed;
 
 import com.seatliberator.seatliberator.reservation.domain.persistence.Seat;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,7 +19,7 @@ public class DevFixture {
         List<Seat> result = new ArrayList<>();
         for (var room : rooms) {
             for (var seat : seats) {
-                result.add(Seat.create(room, seat));
+                result.add(Seat.create(room, seat, Instant.now()));
             }
         }
         return result;

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/availability/application/model/AvailableSeatsTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/availability/application/model/AvailableSeatsTest.java
@@ -3,22 +3,32 @@ package com.seatliberator.seatliberator.reservation.availability.application.mod
 import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
 import com.seatliberator.seatliberator.reservation.domain.SimpleSeatLocator;
 import com.seatliberator.seatliberator.reservation.domain.persistence.Seat;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.List;
 
+import static com.seatliberator.seatliberator.reservation.domain.fixture.TestSupport.fixedClock;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("Application.model: AvailableSeats")
 public class AvailableSeatsTest {
+    Instant now;
+
+    @BeforeEach
+    void run() {
+        now = fixedClock.instant();
+    }
+
     @Test
     @DisplayName("예약된 좌석 locator를 제외한 좌석만 남긴다")
     void exclude_reserved_seats() {
         // given
-        var seatA = Seat.create("room-1", "A");
-        var seatB = Seat.create("room-1", "B");
-        var seatC = Seat.create("room-1", "C");
+        var seatA = Seat.create("room-1", "A", now);
+        var seatB = Seat.create("room-1", "B", now);
+        var seatC = Seat.create("room-1", "C", now);
 
         var reservedLocators = List.<SeatLocator>of(
                 SimpleSeatLocator.from("room-1", "A"),
@@ -36,8 +46,8 @@ public class AvailableSeatsTest {
     @Test
     @DisplayName("예약된 좌석이 없으면 모든 좌석을 가용 좌석으로 본다")
     void keep_all_seats_when_reserved_locator_is_empty() {
-        var seatA = Seat.create("room-1", "A");
-        var seatB = Seat.create("room-1", "B");
+        var seatA = Seat.create("room-1", "A", now);
+        var seatB = Seat.create("room-1", "B", now);
 
         var result = AvailableSeats.from(
                 List.of(seatA, seatB),
@@ -53,8 +63,8 @@ public class AvailableSeatsTest {
     @DisplayName("모든 좌석이 예약됐으면 빈 가용 좌석 컬렉션을 반환한다")
     void return_empty_when_all_seats_are_reserved() {
         // given
-        var seatA = Seat.create("room-1", "A");
-        var seatB = Seat.create("room-1", "B");
+        var seatA = Seat.create("room-1", "A", now);
+        var seatB = Seat.create("room-1", "B", now);
 
         var reservedLocators = List.<SeatLocator>of(
                 SimpleSeatLocator.from("room-1", "A"),
@@ -75,8 +85,8 @@ public class AvailableSeatsTest {
     @DisplayName("예약 locator가 중복되어 있어도 결과는 한 번만 제외된 것처럼 동작한다")
     void handle_duplicate_reserved_locators() {
         // given
-        var seatA = Seat.create("room-1", "A");
-        var seatB = Seat.create("room-1", "B");
+        var seatA = Seat.create("room-1", "A", now);
+        var seatB = Seat.create("room-1", "B", now);
 
         var reservedLocators = List.<SeatLocator>of(
                 SimpleSeatLocator.from("room-1", "A"),

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/availability/application/service/AvailableSeatServiceTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/availability/application/service/AvailableSeatServiceTest.java
@@ -11,6 +11,7 @@ import com.seatliberator.seatliberator.reservation.domain.SimpleSeatLocator;
 import com.seatliberator.seatliberator.reservation.domain.SimpleTimeRange;
 import com.seatliberator.seatliberator.reservation.domain.persistence.Reservation;
 import com.seatliberator.seatliberator.reservation.domain.persistence.Seat;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +19,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Instant;
 import java.util.List;
 
 import static com.seatliberator.seatliberator.reservation.domain.fixture.TestSupport.fixedClock;
@@ -36,6 +38,13 @@ public class AvailableSeatServiceTest {
     @InjectMocks
     AvailableSeatService reader;
 
+    Instant now;
+
+    @BeforeEach
+    void run() {
+        now = fixedClock.instant();
+    }
+
     @Test
     @DisplayName("특정 시간 및 방에서 예약할 수 있는 좌석을 반환한다")
     void return_available_seats() {
@@ -49,9 +58,9 @@ public class AvailableSeatServiceTest {
         var seatBLocator = SimpleSeatLocator.from(roomId, "B");
         var seatCLocator = SimpleSeatLocator.from(roomId, "C");
 
-        var seatA = Seat.create(seatALocator);
-        var seatB = Seat.create(seatBLocator);
-        var seatC = Seat.create(seatCLocator);
+        var seatA = Seat.create(seatALocator, now);
+        var seatB = Seat.create(seatBLocator, now);
+        var seatC = Seat.create(seatCLocator, now);
 
         when(seatReader.findByRoomId(roomId))
                 .thenReturn(List.of(seatA, seatB, seatC));
@@ -112,7 +121,7 @@ public class AvailableSeatServiceTest {
         var roomId = "room-1";
         var range = SimpleTimeRange.from(now, now.plusSeconds(60));
         var seatALocator = SimpleSeatLocator.from(roomId, "A");
-        var seatA = Seat.create(seatALocator);
+        var seatA = Seat.create(seatALocator, now);
 
         when(seatReader.findByRoomId(roomId))
                 .thenReturn(List.of(seatA));
@@ -137,7 +146,7 @@ public class AvailableSeatServiceTest {
         var roomId = "room-1";
         var range = SimpleTimeRange.from(now, now.plusSeconds(60));
         var seatALocator = SimpleSeatLocator.from(roomId, "A");
-        var seatA = Seat.create(seatALocator);
+        var seatA = Seat.create(seatALocator, now);
 
         when(seatReader.findByRoomId(roomId))
                 .thenReturn(List.of(seatA));
@@ -161,7 +170,7 @@ public class AvailableSeatServiceTest {
         var roomId = "room-1";
         var range = SimpleTimeRange.from(now, now.plusSeconds(60));
         var seatALocator = SimpleSeatLocator.from(roomId, "A");
-        var seatA = Seat.create(seatALocator);
+        var seatA = Seat.create(seatALocator, now);
 
         when(seatReader.findByRoomId(roomId))
                 .thenReturn(List.of(seatA));

--- a/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/SeatStatus.java
+++ b/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/SeatStatus.java
@@ -1,0 +1,6 @@
+package com.seatliberator.seatliberator.reservation.domain;
+
+public enum SeatStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/Seat.java
+++ b/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/Seat.java
@@ -2,10 +2,13 @@ package com.seatliberator.seatliberator.reservation.domain.persistence;
 
 import com.seatliberator.seatliberator.reservation.domain.EmbeddableSeatLocator;
 import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
+import com.seatliberator.seatliberator.reservation.domain.SeatStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.Instant;
 
 @Entity
 @Getter
@@ -24,19 +27,99 @@ public class Seat {
     @Embedded
     private EmbeddableSeatLocator locator;
 
-    private Seat(EmbeddableSeatLocator locator) {
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private SeatStatus status;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "last_activated_at", nullable = false)
+    private Instant lastActivatedAt;
+
+    @Column(name = "last_inactivated_at")
+    private Instant lastInactivatedAt;
+
+    private Seat(
+            EmbeddableSeatLocator locator,
+            SeatStatus status,
+            Instant createdAt
+    ) {
+        if (locator == null) throw new IllegalArgumentException("locator must not be null.");
+        if (status == null) throw new IllegalArgumentException("status must not be null.");
+        if (createdAt == null) throw new IllegalArgumentException("createdAt must not be null.");
         this.locator = locator;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.lastActivatedAt = createdAt;
     }
 
-    public static Seat create(String roomId, String seatId) {
-        return new Seat(EmbeddableSeatLocator.from(roomId, seatId));
+    public static Seat create(String roomId, String seatId, Instant createdAt) {
+        return create(EmbeddableSeatLocator.from(roomId, seatId), createdAt);
     }
 
-    public static Seat create(SeatLocator locator) {
-        return new Seat(EmbeddableSeatLocator.of(locator));
+    public static Seat create(SeatLocator locator, Instant createdAt) {
+        if (locator == null) throw new IllegalArgumentException("locator must not be null.");
+        return create(EmbeddableSeatLocator.of(locator), createdAt);
+    }
+
+    private static Seat create(EmbeddableSeatLocator locator, Instant createdAt) {
+         return new Seat(locator, SeatStatus.ACTIVE, createdAt);
+    }
+
+    public void update(SeatLocator locator) {
+        if (locator == null) throw new IllegalArgumentException("locator must not be null.");
+        this.locator.setLocate(locator.roomId(), locator.seatId());
     }
 
     public void update(String roomId, String seatId) {
         this.locator.setLocate(roomId, seatId);
+    }
+
+    public void active(Instant activatedAt) {
+        if (activatedAt == null) throw new IllegalArgumentException("activatedAt must not be null.");
+
+        ensureDifferentStatus(SeatStatus.ACTIVE);
+        ensureNotBefore(activatedAt, "activatedAt", createdAt, "createdAt");
+        ensureNotBefore(activatedAt, "activatedAt", lastInactivatedAt, "lastInactivatedAt");
+
+        this.lastActivatedAt = activatedAt;
+        this.status = SeatStatus.ACTIVE;
+    }
+
+    public void inactive(Instant inactivatedAt) {
+        if (inactivatedAt == null) throw new IllegalArgumentException("inactivatedAt must not be null.");
+
+        ensureDifferentStatus(SeatStatus.INACTIVE);
+        ensureNotBefore(inactivatedAt, "inactivatedAt", createdAt, "createdAt");
+        ensureNotBefore(inactivatedAt, "inactivatedAt", lastActivatedAt, "lastActivatedAt");
+
+        this.lastInactivatedAt = inactivatedAt;
+        this.status = SeatStatus.INACTIVE;
+    }
+
+    private void ensureNotBefore(Instant at, String fieldName, Instant ref, String refFieldName) {
+        if (at.isBefore(ref)) throw new IllegalArgumentException(String.format(
+                "%s can not be earlier than %s.",
+                fieldName,
+                refFieldName
+        ));
+    }
+
+    private void ensureNotBeforeCreatedAt(Instant at, String fieldName) {
+        if (at.isBefore(createdAt)) throw new IllegalArgumentException(String.format(
+                "%s can not be earlier than createdAt.",
+                fieldName
+        ));
+    }
+
+    private void ensureDifferentStatus(SeatStatus status) {
+        if (this.status == status) {
+            throw new IllegalStateException(String.format(
+                    "Can not transition to %s from %s",
+                    status.name().toLowerCase(),
+                    this.status.name().toLowerCase()
+            ));
+        }
     }
 }

--- a/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/persistence/SeatTest.java
+++ b/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/persistence/SeatTest.java
@@ -1,0 +1,328 @@
+package com.seatliberator.seatliberator.reservation.domain.persistence;
+
+import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
+import com.seatliberator.seatliberator.reservation.domain.SeatStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static com.seatliberator.seatliberator.reservation.domain.fixture.SeatLocatorFixture.createLocator;
+import static com.seatliberator.seatliberator.reservation.domain.fixture.TestSupport.fixedClock;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Seat")
+public class SeatTest {
+
+    @Nested
+    @DisplayName("Creation")
+    class Creation {
+        @Test
+        @DisplayName("roomId와 seatId를 넘겨서 Seat 생성 가능")
+        void create_with_roomId_and_seatId() {
+            var roomId = "room-1";
+            var seatId = "A";
+            var createdAt = fixedClock.instant();
+            var seat = Seat.create(roomId, seatId, createdAt);
+
+            assertThat(seat.getLocator().roomId()).isEqualTo(roomId);
+            assertThat(seat.getLocator().seatId()).isEqualTo(seatId);
+        }
+
+        @Test
+        @DisplayName("SeatLocator를 넘겨서 Seat 생성 가능")
+        void create_with_locator() {
+            var locator = createLocator();
+            var createdAt = fixedClock.instant();
+            var seat = Seat.create(locator, createdAt);
+
+            assertThat(seat.getLocator().key()).isEqualTo(locator.key());
+        }
+
+        @Test
+        @DisplayName("SeatLocator가 null이면 예외")
+        void throw_exception_when_locator_is_null() {
+            SeatLocator locator = null;
+            var createdAt = fixedClock.instant();
+
+            assertThatThrownBy(() -> Seat.create(locator, createdAt))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("locator must not be null.");
+        }
+    }
+
+    @Nested
+    @DisplayName("Update")
+    class Update {
+        @Test
+        @DisplayName("새로운 roomId, seatId를 넘겨서 Locator 값 변경 가능")
+        void update_with_roomId_and_seat_id() {
+            var locator = createLocator("room-1", "A");
+            var createdAt = fixedClock.instant();
+            var seat = Seat.create(locator, createdAt);
+
+            var newLocator = createLocator("room-2", "B");
+            seat.update(newLocator.roomId(), newLocator.seatId());
+
+            assertThat(seat.getLocator().roomId()).isEqualTo(newLocator.roomId());
+            assertThat(seat.getLocator().seatId()).isEqualTo(newLocator.seatId());
+            assertThat(seat.getLocator().key()).isEqualTo(newLocator.key());
+        }
+
+        @Test
+        @DisplayName("null roomId를 넘기면 예외")
+        void throw_exception_when_update_with_null_roomId() {
+            var locator = createLocator("room-1", "A");
+            var createdAt = fixedClock.instant();
+            var seat = Seat.create(locator, createdAt);
+
+            assertThatThrownBy(() -> seat.update(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("locator must not be null.");
+        }
+
+        @Test
+        @DisplayName("새로운 locator를 넘겨서 값 변경 가능")
+        void update_with_new_locator() {
+            var locator = createLocator("room-1", "A");
+            var createdAt = fixedClock.instant();
+            var seat = Seat.create(locator, createdAt);
+
+            var newLocator = createLocator("room-2", "B");
+            seat.update(newLocator);
+
+            assertThat(seat.getLocator().roomId()).isEqualTo(newLocator.roomId());
+            assertThat(seat.getLocator().seatId()).isEqualTo(newLocator.seatId());
+            assertThat(seat.getLocator().key()).isEqualTo(newLocator.key());
+        }
+
+        @Test
+        @DisplayName("null locator를 넘기면 예외")
+        void throw_exception_when_update_with_null_locator() {
+            var locator = createLocator("room-1", "A");
+            var createdAt = fixedClock.instant();
+            var seat = Seat.create(locator, createdAt);
+
+            assertThatThrownBy(() -> seat.update(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("locator must not be null.");
+        }
+    }
+
+    @Nested
+    @DisplayName("Transition")
+    class Transition {
+        @Test
+        @DisplayName("생성 시 사용 가능 상태로 초기화된다")
+        void active_when_created() {
+            var locator = createLocator();
+            var createdAt = fixedClock.instant();
+            var seat = Seat.create(locator, createdAt);
+
+            assertThat(seat.getStatus()).isEqualTo(SeatStatus.ACTIVE);
+        }
+
+        @Test
+        @DisplayName("좌석을 비활성화 상태로 변경할 수 있다")
+        void can_transition_inactive() {
+            var locator = createLocator();
+            var createdAt = fixedClock.instant();
+            var seat = Seat.create(locator, createdAt);
+
+            var inactivatedAt = createdAt.plusSeconds(5);
+            seat.inactive(inactivatedAt);
+
+            assertThat(seat.getStatus()).isEqualTo(SeatStatus.INACTIVE);
+        }
+
+        @Test
+        @DisplayName("비활성화된 좌석을 또 비활성화할 수 없다")
+        void can_not_transition_to_inactive_from_inactive() {
+            var locator = createLocator();
+            var createdAt = fixedClock.instant();
+            var seat = Seat.create(locator, createdAt);
+
+            var inactivatedAt = createdAt.plusSeconds(5);
+            seat.inactive(inactivatedAt);
+
+            assertThatThrownBy(() -> seat.inactive(inactivatedAt))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Can not transition to inactive from inactive");
+        }
+
+        @Test
+        @DisplayName("비활성화된 좌석은 다시 활성화할 수 있다")
+        void can_transition_to_active_from_inactive() {
+            var locator = createLocator();
+            var createdAt = fixedClock.instant();
+            var seat = Seat.create(locator, createdAt);
+
+            var inactivatedAt = createdAt.plusSeconds(5);
+            seat.inactive(inactivatedAt);
+
+            assertThat(seat.getStatus()).isEqualTo(SeatStatus.INACTIVE);
+
+            var activatedAt = inactivatedAt.plusSeconds(5);
+            seat.active(activatedAt);
+            assertThat(seat.getStatus()).isEqualTo(SeatStatus.ACTIVE);
+        }
+
+        @Test
+        @DisplayName("활성화된 좌석은 다시 활성화할 수 없다")
+        void can_not_transition_to_active_from_active() {
+            var locator = createLocator();
+            var createdAt = fixedClock.instant();
+            var seat = Seat.create(locator, createdAt);
+
+            assertThatThrownBy(() -> seat.active(createdAt.plusSeconds(5)))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Can not transition to active from active");
+        }
+    }
+
+    @Nested
+    @DisplayName("Time")
+    class Time {
+        @Test
+        @DisplayName("생성된 좌석은 createdAt을 갖는다")
+        void store_createdAt_when_initialized() {
+            var locator = createLocator();
+            var activatedAt = fixedClock.instant();
+            var seat = Seat.create(locator, activatedAt);
+
+            assertThat(seat.getCreatedAt()).isEqualTo(activatedAt);
+        }
+
+        @Test
+        @DisplayName("생성 시각은 null이면 예외")
+        void throw_exception_when_createdAt_is_null() {
+            var locator = createLocator();
+
+            assertThatThrownBy(() -> Seat.create(locator, null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("createdAt must not be null.");
+        }
+
+        @Test
+        @DisplayName("ACTIVE 상태로 생성된 좌석의 activatedAt은 createdAt과 같다")
+        void activated_at_is_same_as_created_at_when_initialize_to_active_state() {
+            var locator = createLocator();
+            var createdAt = fixedClock.instant();
+            var seat = Seat.create(locator, createdAt);
+
+            assertThat(seat.getLastActivatedAt()).isEqualTo(createdAt);
+        }
+
+        @Test
+        @DisplayName("비활성화된 좌석은 inactivatedAt을 갖는다")
+        void store_inactivatedAt_when_inactive_seat() {
+            var locator = createLocator();
+            var createdAt = fixedClock.instant();
+            var seat = Seat.create(locator, createdAt);
+
+            var inactivatedAt = createdAt.plusSeconds(5);
+            seat.inactive(inactivatedAt);
+
+            assertThat(seat.getLastInactivatedAt()).isEqualTo(inactivatedAt);
+        }
+
+        @Test
+        @DisplayName("좌석 비활성화 시, 비활성화 시각이 null이면 예외")
+        void throw_exception_when_inactive_with_null_inactivated_at() {
+            var locator = createLocator();
+            var createdAt = fixedClock.instant();
+            var seat = Seat.create(locator, createdAt);
+
+            assertThatThrownBy(() -> seat.inactive(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("inactivatedAt must not be null.");
+        }
+
+        @Test
+        @DisplayName("좌석 비활성화 시, 비활성화 시각이 생성 시각보다 과거면 예외")
+        void throw_exception_when_inactivated_at_is_before_than_created_at() {
+            var locator = createLocator();
+            var createdAt = fixedClock.instant();
+            var seat = Seat.create(locator, createdAt);
+
+            var inactivatedAt = createdAt.minusSeconds(5);
+            assertThatThrownBy(() -> seat.inactive(inactivatedAt))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("inactivatedAt can not be earlier than createdAt.");
+        }
+
+        @Test
+        @DisplayName("비활성화 시각이 생성 시각과 같으면 허용된다")
+        void can_inactive_with_inactivatedAt_same_as_createdAt() {
+            var locator = createLocator();
+            var createdAt = fixedClock.instant();
+            var seat = Seat.create(locator, createdAt);
+
+            seat.inactive(createdAt);
+
+            assertThat(seat.getLastInactivatedAt()).isEqualTo(createdAt);
+        }
+
+        @Test
+        @DisplayName("활성화된 좌석은 activatedAt을 갖는다")
+        void store_activated_at_when_active_seat() {
+            var locator = createLocator();
+            var createdAt = fixedClock.instant();
+            var seat = Seat.create(locator, createdAt);
+
+            var inactivatedAt = createdAt.plusSeconds(5);
+            seat.inactive(inactivatedAt);
+
+            assertThat(seat.getStatus()).isEqualTo(SeatStatus.INACTIVE);
+
+            var activatedAt = inactivatedAt.plusSeconds(5);
+            seat.active(activatedAt);
+
+            assertThat(seat.getLastActivatedAt()).isEqualTo(activatedAt);
+        }
+
+        @Test
+        @DisplayName("좌석 활성화 시, activatedAt이 null이면 예외")
+        void throw_exception_when_active_with_null_activated_at() {
+            var locator = createLocator();
+            var createdAt = fixedClock.instant();
+            var seat = Seat.create(locator, createdAt);
+
+            var inactivatedAt = createdAt.plusSeconds(5);
+            seat.inactive(inactivatedAt);
+
+            assertThatThrownBy(() -> seat.active(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("activatedAt must not be null.");
+        }
+
+        @Test
+        @DisplayName("좌석 활성화 시, activatedAt이 createdAt보다 과거면 예외")
+        void throw_exception_when_activated_at_is_before_than_created_at() {
+            var locator = createLocator();
+            var createdAt = fixedClock.instant();
+            var seat = Seat.create(locator, createdAt);
+
+            var inactivatedAt = createdAt.plusSeconds(5);
+            seat.inactive(inactivatedAt);
+
+            var activatedAt = createdAt.minusSeconds(5);
+            assertThatThrownBy(() -> seat.active(activatedAt))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("activatedAt can not be earlier than createdAt.");
+        }
+
+        @Test
+        @DisplayName("활성화 시각이 생성 시각과 같으면 허용된다")
+        void can_active_with_activatedAt_same_as_createdAt() {
+            var locator = createLocator();
+            var createdAt = fixedClock.instant();
+            var seat = Seat.create(locator, createdAt);
+
+            seat.inactive(createdAt);
+            seat.active(createdAt);
+
+            assertThat(seat.getLastActivatedAt()).isEqualTo(createdAt);
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- 없음

## 변경 사항

`Seat` 도메인에 활성/비활성 상태 전이와 상태 변경 시각을 표현하는 모델을 추가했습니다.
이번 변경은 좌석 위치만 들고 있던 엔티티에 상태와 시각 정보를 명시적으로 넣고, 생성 시점과 활성화/비활성화 전이 규칙을 도메인 메서드로 고정하는 데 초점을 두었습니다. 또한 이 모델 변경에 맞춰 좌석 생성 경로와 가용 좌석 테스트 픽스처도 함께 정리했습니다.

### Seat 상태 전이 모델 추가

- `SeatStatus` enum을 도입하고, `Seat`에 `status`, `createdAt`, `lastActivatedAt`, `lastInactivatedAt` 필드를 추가했습니다.
- `Seat.create(...)`가 생성 시각을 받아 초기 `ACTIVE` 상태와 최초 활성 시각을 함께 기록하도록 변경했습니다.
- `Seat.active(...)`, `Seat.inactive(...)` 메서드를 추가해 중복 전이와 시각 역전이 발생하지 않도록 상태 전이 규칙을 엔티티 내부에 두었습니다.

### 좌석 생성 경로 및 픽스처 정리

- `SeatCommandService`에 `Clock`을 주입하고 신규 좌석 생성 시 `clock.instant()`를 사용하도록 변경했습니다.
- `DevFixture`와 가용 좌석 관련 테스트에서 좌석 생성 시각을 함께 넘기도록 맞췄습니다.
- 더 이상 사용되지 않던 `CreateReservationPolicyModel` 빈 타입은 제거했습니다.

### Seat 도메인 테스트 보강

- `SeatTest`를 추가해 생성, locator 변경, 활성/비활성 전이, 시간 제약 검증을 도메인 단위 테스트로 보강했습니다.
- 기존 `AvailableSeatsTest`, `AvailableSeatServiceTest`도 새 생성 시그니처에 맞춰 정리했습니다.

## 배경 및 의도

기존 `Seat` 엔티티는 좌석 위치만 표현하고 있어, 좌석 비활성화 같은 상태 전이나 상태 변경 시각을 도메인 안에서 직접 다룰 수 없었습니다.
이번 변경은 이후 좌석 숨김/비활성화 정책이나 상태 기반 조회가 필요해질 때를 대비해, 상태 전이 규칙과 시간 제약을 `Seat` 엔티티 내부에서 일관되게 유지할 수 있는 기반을 마련하려는 목적입니다.

## 영향

- `Seat`가 활성/비활성 상태와 생성/전이 시각을 함께 보존합니다.
- 좌석 생성 경로는 생성 시각을 명시적으로 주입하는 방식으로 정리됩니다.
- 이후 좌석 상태 기반 정책이나 조회 조건을 확장할 때 재사용 가능한 도메인 모델이 생깁니다.

## 검증

- `./gradlew :reservation:reservation-domain:test :reservation:reservation-application:test`