### PR TITLE
SeatLocator와 TimeRange 팩토리 메서드명 정리

### DIFF
--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/infrastructure/web/controller/SeatAvailabilityController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/infrastructure/web/controller/SeatAvailabilityController.java
@@ -22,7 +22,7 @@ public class SeatAvailabilityController {
             @RequestParam(name = "start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant start,
             @RequestParam(name = "end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant end
     ) {
-        var range = SimpleTimeRange.from(start, end);
+        var range = SimpleTimeRange.of(start, end);
         var query = new FindAvailableSeatQuery(roomId, range);
         var result = reader.findAvailabilitySeats(query);
         return ResponseEntity.ok(result);

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/ReservationRangeOverlapCriteria.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/ReservationRangeOverlapCriteria.java
@@ -16,7 +16,7 @@ public record ReservationRangeOverlapCriteria(
 
     public static ReservationRangeOverlapCriteria of(TimeRange range) {
         return new ReservationRangeOverlapCriteria(
-                SimpleTimeRange.of(range),
+                SimpleTimeRange.from(range),
                 ReservationFilter.empty()
         );
     }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/ReservationRoomOverlapCriteria.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/ReservationRoomOverlapCriteria.java
@@ -19,7 +19,7 @@ public record ReservationRoomOverlapCriteria(
     public static ReservationRoomOverlapCriteria of(String roomId, TimeRange range) {
         return new ReservationRoomOverlapCriteria(
                 roomId,
-                SimpleTimeRange.of(range),
+                SimpleTimeRange.from(range),
                 ReservationFilter.empty()
         );
     }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/ReservationSeatLookupCriteria.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/ReservationSeatLookupCriteria.java
@@ -23,8 +23,8 @@ public record ReservationSeatLookupCriteria(
             TimeRange range
     ) {
         return new ReservationSeatLookupCriteria(
-                SimpleSeatLocator.of(locator),
-                SimpleTimeRange.of(range),
+                SimpleSeatLocator.from(locator),
+                SimpleTimeRange.from(range),
                 ReservationFilter.empty()
         );
     }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/ReservationSeatOverlapCriteria.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/ReservationSeatOverlapCriteria.java
@@ -20,8 +20,8 @@ public record ReservationSeatOverlapCriteria(
 
     public static ReservationSeatOverlapCriteria of(SeatLocator locator, TimeRange range) {
         return new ReservationSeatOverlapCriteria(
-                SimpleSeatLocator.of(locator),
-                SimpleTimeRange.of(range),
+                SimpleSeatLocator.from(locator),
+                SimpleTimeRange.from(range),
                 ReservationFilter.empty()
         );
     }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/service/ReservationCommandService.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/service/ReservationCommandService.java
@@ -46,8 +46,8 @@ public class ReservationCommandService implements
             throw new ReservationApplicationException(ReservationApplicationErrorCode.RESERVATION_ALREADY_EXISTS);
         });
 
-        var locator = SimpleSeatLocator.from(command.roomId(), command.seatId());
-        var range = SimpleTimeRange.from(command.startTime(), command.endTime());
+        var locator = SimpleSeatLocator.of(command.roomId(), command.seatId());
+        var range = SimpleTimeRange.of(command.startTime(), command.endTime());
 
         var criteria = ReservationSeatOverlapCriteria.of(locator, range)
                 .withFilter(ReservationFilter.empty().withStatuses(ReservationStatus.RESERVED));
@@ -82,8 +82,8 @@ public class ReservationCommandService implements
                 command.seatId()
         );
 
-        var currentLocator = SimpleSeatLocator.from(command.roomId(), command.seatId());
-        var currentRange = SimpleTimeRange.from(command.startTime(), command.endTime());
+        var currentLocator = SimpleSeatLocator.of(command.roomId(), command.seatId());
+        var currentRange = SimpleTimeRange.of(command.startTime(), command.endTime());
 
         var criteria = ReservationSeatOverlapCriteria.of(currentLocator, currentRange)
                 .withFilter(ReservationFilter.empty().withStatuses(ReservationStatus.RESERVED, ReservationStatus.USED));

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/service/ReservationQueryService.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/service/ReservationQueryService.java
@@ -34,8 +34,8 @@ public class ReservationQueryService implements
         var optReservation = switch (reservationLocator) {
             case IdBasedReservationLocator(Long reservationId) -> reader.findById(reservationId);
             case SeatBasedReservationLocator(String roomId, String seatId, Instant startTime, Instant endTime) -> {
-                var locator = SimpleSeatLocator.from(roomId, seatId);
-                var range = SimpleTimeRange.from(startTime, endTime);
+                var locator = SimpleSeatLocator.of(roomId, seatId);
+                var range = SimpleTimeRange.of(startTime, endTime);
                 var criteria = ReservationSeatLookupCriteria.of(locator, range)
                         .withFilter(ReservationFilter.empty().withStatuses(ReservationStatus.RESERVED));
                 yield reader.findOne(criteria);

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/ReservationQueryController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/ReservationQueryController.java
@@ -33,7 +33,7 @@ public class ReservationQueryController {
             @RequestParam(name = "status") ReservationStatus status
     ) {
         var userId = actorContextHolder.getActor().subject();
-        var range = SimpleTimeRange.from(startAt, endAt);
+        var range = SimpleTimeRange.of(startAt, endAt);
         var query = new FindMyReservationQuery(userId, range, status);
         var result = findMyReservationUseCase.find(query);
         return ResponseEntity.ok(result);

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/seat/application/service/SeatCommandService.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/seat/application/service/SeatCommandService.java
@@ -35,7 +35,7 @@ public class SeatCommandService implements
 
     @Override
     public boolean create(CreateSeatCommand command) {
-        var locator = SimpleSeatLocator.from(command.roomId(), command.seatId());
+        var locator = SimpleSeatLocator.of(command.roomId(), command.seatId());
 
         var conflict = query.existsByLocator(locator);
         if (conflict) return false;
@@ -53,8 +53,8 @@ public class SeatCommandService implements
 
     @Override
     public boolean update(UpdateSeatCommand command) {
-        var oldLocator = SimpleSeatLocator.from(command.oldRoomId(), command.oldSeatId());
-        var newLocator = SimpleSeatLocator.from(command.newRoomId(), command.newSeatId());
+        var oldLocator = SimpleSeatLocator.of(command.oldRoomId(), command.oldSeatId());
+        var newLocator = SimpleSeatLocator.of(command.newRoomId(), command.newSeatId());
         var oldSeat = query.findByLocator(oldLocator)
                 .orElseThrow(() -> new ReservationApplicationException(ReservationApplicationErrorCode.SEAT_NOT_FOUND));
 
@@ -69,7 +69,7 @@ public class SeatCommandService implements
 
     @Override
     public boolean delete(DeleteSeatCommand command) {
-        var locator = SimpleSeatLocator.from(command.roomId(), command.seatId());
+        var locator = SimpleSeatLocator.of(command.roomId(), command.seatId());
         store.deleteByLocator(locator);
 
         return true;

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/waitlist/application/port/in/result/WaitlistResult.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/waitlist/application/port/in/result/WaitlistResult.java
@@ -12,8 +12,8 @@ public record WaitlistResult(
     public static WaitlistResult from(Waitlist request) {
         return new WaitlistResult(
                 request.getUserId(),
-                SimpleSeatLocator.of(request.getLocator()),
-                SimpleTimeRange.of(request.getRange())
+                SimpleSeatLocator.from(request.getLocator()),
+                SimpleTimeRange.from(request.getRange())
         );
     }
 }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/waitlist/application/service/WaitlistService.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/waitlist/application/service/WaitlistService.java
@@ -33,8 +33,8 @@ public class WaitlistService implements
 
     @Override
     public Waitlist create(CreateWaitlistCommand command) {
-        var locator = SimpleSeatLocator.from(command.roomId(), command.seatId());
-        var range = SimpleTimeRange.from(command.startTime(), command.endTime());
+        var locator = SimpleSeatLocator.of(command.roomId(), command.seatId());
+        var range = SimpleTimeRange.of(command.startTime(), command.endTime());
 
         var criteria = ReservationSeatOverlapCriteria.of(locator, range)
                 .withFilter(ReservationFilter.empty().withStatuses(ReservationStatus.RESERVED));

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/WaitlistCreateCommandBuilder.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/WaitlistCreateCommandBuilder.java
@@ -58,7 +58,7 @@ public class WaitlistCreateCommandBuilder {
     }
 
     public WaitlistCreateCommandBuilder locator(String roomId, String seatId) {
-        this.locator = SimpleSeatLocator.from(roomId, seatId);
+        this.locator = SimpleSeatLocator.of(roomId, seatId);
         return this;
     }
 
@@ -68,7 +68,7 @@ public class WaitlistCreateCommandBuilder {
     }
 
     public WaitlistCreateCommandBuilder range(Instant startAt, Instant endAt) {
-        this.range = SimpleTimeRange.from(startAt, endAt);
+        this.range = SimpleTimeRange.of(startAt, endAt);
         return this;
     }
 

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/availability/application/model/AvailableSeatsTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/availability/application/model/AvailableSeatsTest.java
@@ -31,8 +31,8 @@ public class AvailableSeatsTest {
         var seatC = Seat.create("room-1", "C", now);
 
         var reservedLocators = List.<SeatLocator>of(
-                SimpleSeatLocator.from("room-1", "A"),
-                SimpleSeatLocator.from("room-1", "C")
+                SimpleSeatLocator.of("room-1", "A"),
+                SimpleSeatLocator.of("room-1", "C")
         );
 
         // when
@@ -67,8 +67,8 @@ public class AvailableSeatsTest {
         var seatB = Seat.create("room-1", "B", now);
 
         var reservedLocators = List.<SeatLocator>of(
-                SimpleSeatLocator.from("room-1", "A"),
-                SimpleSeatLocator.from("room-1", "B")
+                SimpleSeatLocator.of("room-1", "A"),
+                SimpleSeatLocator.of("room-1", "B")
         );
 
         // when
@@ -89,8 +89,8 @@ public class AvailableSeatsTest {
         var seatB = Seat.create("room-1", "B", now);
 
         var reservedLocators = List.<SeatLocator>of(
-                SimpleSeatLocator.from("room-1", "A"),
-                SimpleSeatLocator.from("room-1", "A")
+                SimpleSeatLocator.of("room-1", "A"),
+                SimpleSeatLocator.of("room-1", "A")
         );
 
         // when

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/availability/application/service/AvailableSeatServiceTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/availability/application/service/AvailableSeatServiceTest.java
@@ -50,13 +50,13 @@ public class AvailableSeatServiceTest {
     void return_available_seats() {
         var now = fixedClock.instant();
         var roomId = "room-1";
-        var range = SimpleTimeRange.from(
+        var range = SimpleTimeRange.of(
                 now,
                 now.plusSeconds(60)
         );
-        var seatALocator = SimpleSeatLocator.from(roomId, "A");
-        var seatBLocator = SimpleSeatLocator.from(roomId, "B");
-        var seatCLocator = SimpleSeatLocator.from(roomId, "C");
+        var seatALocator = SimpleSeatLocator.of(roomId, "A");
+        var seatBLocator = SimpleSeatLocator.of(roomId, "B");
+        var seatCLocator = SimpleSeatLocator.of(roomId, "C");
 
         var seatA = Seat.create(seatALocator, now);
         var seatB = Seat.create(seatBLocator, now);
@@ -95,7 +95,7 @@ public class AvailableSeatServiceTest {
 
         var now = fixedClock.instant();
         var roomId = "room-1";
-        var range = SimpleTimeRange.from(
+        var range = SimpleTimeRange.of(
                 now,
                 now.plusSeconds(60)
         );
@@ -119,8 +119,8 @@ public class AvailableSeatServiceTest {
     void ignore_canceled_reservation_when_calculating_available_seats() {
         var now = fixedClock.instant();
         var roomId = "room-1";
-        var range = SimpleTimeRange.from(now, now.plusSeconds(60));
-        var seatALocator = SimpleSeatLocator.from(roomId, "A");
+        var range = SimpleTimeRange.of(now, now.plusSeconds(60));
+        var seatALocator = SimpleSeatLocator.of(roomId, "A");
         var seatA = Seat.create(seatALocator, now);
 
         when(seatReader.findByRoomId(roomId))
@@ -144,8 +144,8 @@ public class AvailableSeatServiceTest {
     void ignore_expired_reservation_when_calculating_available_seats() {
         var now = fixedClock.instant();
         var roomId = "room-1";
-        var range = SimpleTimeRange.from(now, now.plusSeconds(60));
-        var seatALocator = SimpleSeatLocator.from(roomId, "A");
+        var range = SimpleTimeRange.of(now, now.plusSeconds(60));
+        var seatALocator = SimpleSeatLocator.of(roomId, "A");
         var seatA = Seat.create(seatALocator, now);
 
         when(seatReader.findByRoomId(roomId))
@@ -168,8 +168,8 @@ public class AvailableSeatServiceTest {
     void treat_used_reservation_as_occupied_seat() {
         var now = fixedClock.instant();
         var roomId = "room-1";
-        var range = SimpleTimeRange.from(now, now.plusSeconds(60));
-        var seatALocator = SimpleSeatLocator.from(roomId, "A");
+        var range = SimpleTimeRange.of(now, now.plusSeconds(60));
+        var seatALocator = SimpleSeatLocator.of(roomId, "A");
         var seatA = Seat.create(seatALocator, now);
 
         when(seatReader.findByRoomId(roomId))

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/book/application/FindMyReservationUseCaseTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/book/application/FindMyReservationUseCaseTest.java
@@ -55,7 +55,7 @@ public class FindMyReservationUseCaseTest {
 
         var actual = captor.getValue();
 
-        assertThat(actual.range()).isEqualTo(SimpleTimeRange.of(range));
+        assertThat(actual.range()).isEqualTo(SimpleTimeRange.from(range));
         assertThat(actual.filter().userIds()).containsExactlyInAnyOrder("user-1");
         assertThat(actual.filter().statuses()).containsExactly(ReservationStatus.RESERVED);
         assertThat(actual.filter().excludedIds()).isEmpty();

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/ReservationRangeOverlapCriteriaTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/ReservationRangeOverlapCriteriaTest.java
@@ -15,7 +15,7 @@ public class ReservationRangeOverlapCriteriaTest {
         var range = createRange();
         var criteria = ReservationRangeOverlapCriteria.of(range);
 
-        assertThat(criteria.range()).isEqualTo(SimpleTimeRange.of(range));
+        assertThat(criteria.range()).isEqualTo(SimpleTimeRange.from(range));
         assertThat(criteria.filter()).isEqualTo(ReservationFilter.empty());
     }
 

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/book/infrastructure/persistence/jpa/JpaReservationPersistenceAdapterTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/book/infrastructure/persistence/jpa/JpaReservationPersistenceAdapterTest.java
@@ -38,7 +38,7 @@ public class JpaReservationPersistenceAdapterTest {
     @DisplayName("기간이 겹치는 예약만 조회한다")
     void find_all_overlapping_by_user() {
         // given
-        var queryRange = SimpleTimeRange.from(
+        var queryRange = SimpleTimeRange.of(
                 Instant.parse("2026-04-20T10:00:00Z"),
                 Instant.parse("2026-04-20T12:00:00Z")
         );
@@ -95,7 +95,7 @@ public class JpaReservationPersistenceAdapterTest {
     @DisplayName("상태 조건이 있으면 해당 상태만 조회한다")
     void find_all_overlapping_with_status_filter() {
         // given
-        var queryRange = SimpleTimeRange.from(
+        var queryRange = SimpleTimeRange.of(
                 Instant.parse("2026-04-20T10:00:00Z"),
                 Instant.parse("2026-04-20T12:00:00Z")
         );
@@ -137,7 +137,7 @@ public class JpaReservationPersistenceAdapterTest {
     @DisplayName("excludedIds에 포함된 예약은 조회에서 제외한다")
     void exclude_ids() {
         // given
-        var queryRange = SimpleTimeRange.from(
+        var queryRange = SimpleTimeRange.of(
                 Instant.parse("2026-04-20T10:00:00Z"),
                 Instant.parse("2026-04-20T12:00:00Z")
         );

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/ReservationControllerTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/ReservationControllerTest.java
@@ -67,7 +67,7 @@ public class ReservationControllerTest {
         var actual = captor.getValue();
         assertThat(actual).isNotNull();
         assertThat(actual.userId()).isEqualTo("user-1");
-        assertThat(actual.range()).isEqualTo(SimpleTimeRange.from(startAt, endAt));
+        assertThat(actual.range()).isEqualTo(SimpleTimeRange.of(startAt, endAt));
         assertThat(actual.status()).isEqualTo(ReservationStatus.RESERVED);
     }
 

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/integration/ReservationCommandServiceTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/integration/ReservationCommandServiceTest.java
@@ -45,7 +45,7 @@ public class ReservationCommandServiceTest extends ReservationDatabaseCleanupSup
     void return_true_when_seat_is_created() {
         var givenRoomId = "room-1";
         var givenSeatId = "seat-1";
-        var locator = SimpleSeatLocator.from(givenRoomId, givenSeatId);
+        var locator = SimpleSeatLocator.of(givenRoomId, givenSeatId);
 
         var seatCreateCommand = new CreateSeatCommand(
                 givenRoomId,

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/waitlist/application/handler/SeatVacancyHandlerTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/waitlist/application/handler/SeatVacancyHandlerTest.java
@@ -8,7 +8,6 @@ import com.seatliberator.seatliberator.reservation.domain.event.ReservationExpir
 import com.seatliberator.seatliberator.reservation.domain.fixture.WaitlistFixtureBuilder;
 import com.seatliberator.seatliberator.reservation.domain.persistence.Waitlist;
 import com.seatliberator.seatliberator.reservation.shared.application.notifier.Notifier;
-import com.seatliberator.seatliberator.reservation.waitlist.application.handler.SeatVacancyHandler;
 import com.seatliberator.seatliberator.reservation.waitlist.application.internal.WaitlistPromotion;
 import com.seatliberator.seatliberator.reservation.waitlist.application.internal.WaitlistPromotionResult;
 import com.seatliberator.seatliberator.reservation.waitlist.application.port.out.WaitlistStore;
@@ -55,8 +54,8 @@ class SeatVacancyHandlerTest {
     @Test
     @DisplayName("예약 취소 이벤트를 받으면 활성 요청을 조회해 처리 결과를 저장하고 알린다")
     void handle_canceled_event() {
-        var locator = SimpleSeatLocator.from("room-1", "seat-1");
-        var range = SimpleTimeRange.from(Instant.parse("2026-01-01T00:00:00Z"), Instant.parse("2026-01-01T00:10:00Z"));
+        var locator = SimpleSeatLocator.of("room-1", "seat-1");
+        var range = SimpleTimeRange.of(Instant.parse("2026-01-01T00:00:00Z"), Instant.parse("2026-01-01T00:10:00Z"));
         var requestedAt = Instant.parse("2025-12-31T23:59:00Z");
         var now = Instant.parse("2026-01-01T00:01:00Z");
         var request = new WaitlistFixtureBuilder()
@@ -80,8 +79,8 @@ class SeatVacancyHandlerTest {
     @Test
     @DisplayName("예약 만료 이벤트를 받으면 AUTO_CLAIM 요청을 승격 결과에 따라 처리한다")
     void handle_expired_event() {
-        var locator = SimpleSeatLocator.from("room-1", "seat-1");
-        var range = SimpleTimeRange.from(Instant.parse("2026-01-01T00:00:00Z"), Instant.parse("2026-01-01T00:10:00Z"));
+        var locator = SimpleSeatLocator.of("room-1", "seat-1");
+        var range = SimpleTimeRange.of(Instant.parse("2026-01-01T00:00:00Z"), Instant.parse("2026-01-01T00:10:00Z"));
         var requestedAt = Instant.parse("2025-12-31T23:59:00Z");
         var now = Instant.parse("2026-01-01T00:01:00Z");
         var request = Waitlist.autoClaim("user-1", locator, range, requestedAt);

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/waitlist/application/service/WaitlistServiceTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/waitlist/application/service/WaitlistServiceTest.java
@@ -12,7 +12,6 @@ import com.seatliberator.seatliberator.reservation.shared.application.exception.
 import com.seatliberator.seatliberator.reservation.shared.application.exception.ReservationApplicationException;
 import com.seatliberator.seatliberator.reservation.waitlist.application.port.in.command.CreateWaitlistCommand;
 import com.seatliberator.seatliberator.reservation.waitlist.application.port.out.WaitlistStore;
-import com.seatliberator.seatliberator.reservation.waitlist.application.service.WaitlistService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -53,9 +52,9 @@ public class WaitlistServiceTest {
     @DisplayName("대기열 대상 좌석 및 시간에 예약이 존재하지 않으면 RESERVATION_NOT_FOUND 예외를 던진다")
     void throw_exception_when_reservation_not_found_in_locator_and_range() {
         var command = createWaitlistCreateCommand();
-        
-        var locator = SimpleSeatLocator.from(command.roomId(), command.seatId());
-        var range = SimpleTimeRange.from(command.startTime(), command.endTime());
+
+        var locator = SimpleSeatLocator.of(command.roomId(), command.seatId());
+        var range = SimpleTimeRange.of(command.startTime(), command.endTime());
 
         var criteria = ReservationSeatOverlapCriteria.of(locator, range)
                 .withFilter(ReservationFilter.empty().withStatuses(ReservationStatus.RESERVED));
@@ -71,8 +70,8 @@ public class WaitlistServiceTest {
     @DisplayName("이미 동일 시간 / 좌석에 대기열 요청이 존재하면 중복 요청 시 DUPLICATED_REQUEST 예외를 던진다.")
     void throw_exception_when_active_request_already_exists() {
         var command = createWaitlistCreateCommand();
-        var locator = SimpleSeatLocator.from(command.roomId(), command.seatId());
-        var range = SimpleTimeRange.from(command.startTime(), command.endTime());
+        var locator = SimpleSeatLocator.of(command.roomId(), command.seatId());
+        var range = SimpleTimeRange.of(command.startTime(), command.endTime());
 
         var criteria = ReservationSeatOverlapCriteria.of(locator, range)
                 .withFilter(ReservationFilter.empty().withStatuses(ReservationStatus.RESERVED));
@@ -90,8 +89,8 @@ public class WaitlistServiceTest {
     @DisplayName("활성 요청이 없으면 요청을 생성하고 저장한다")
     void save_request_when_no_active_request_exists() {
         var command = createWaitlistCreateCommand();
-        var locator = SimpleSeatLocator.from(command.roomId(), command.seatId());
-        var range = SimpleTimeRange.from(command.startTime(), command.endTime());
+        var locator = SimpleSeatLocator.of(command.roomId(), command.seatId());
+        var range = SimpleTimeRange.of(command.startTime(), command.endTime());
 
         var criteria = ReservationSeatOverlapCriteria.of(locator, range)
                 .withFilter(ReservationFilter.empty().withStatuses(ReservationStatus.RESERVED));
@@ -112,8 +111,8 @@ public class WaitlistServiceTest {
     @DisplayName("저장 시 무결성 예외가 발생하면 DUPLICATED_REQUEST 예외로 변환한다")
     void throw_duplicated_request_when_save_raises_data_integrity_violation() {
         var command = createWaitlistCreateCommand();
-        var locator = SimpleSeatLocator.from(command.roomId(), command.seatId());
-        var range = SimpleTimeRange.from(command.startTime(), command.endTime());
+        var locator = SimpleSeatLocator.of(command.roomId(), command.seatId());
+        var range = SimpleTimeRange.of(command.startTime(), command.endTime());
 
         var criteria = ReservationSeatOverlapCriteria.of(locator, range)
                 .withFilter(ReservationFilter.empty().withStatuses(ReservationStatus.RESERVED));
@@ -177,8 +176,8 @@ public class WaitlistServiceTest {
     }
 
     private void whenActiveWaitlistExists(CreateWaitlistCommand command, boolean value) {
-        var locator = SimpleSeatLocator.from(command.roomId(), command.seatId());
-        var range = SimpleTimeRange.from(command.startTime(), command.endTime());
+        var locator = SimpleSeatLocator.of(command.roomId(), command.seatId());
+        var range = SimpleTimeRange.of(command.startTime(), command.endTime());
         when(store.existsByUserIdAndLocatorAndRangeAndStatus(command.userId(), locator, range, WaitlistStatus.ACTIVE))
                 .thenReturn(value);
     }

--- a/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/EmbeddableSeatLocator.java
+++ b/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/EmbeddableSeatLocator.java
@@ -46,7 +46,7 @@ public class EmbeddableSeatLocator implements SeatLocator {
     }
 
     public void setLocate(String roomId, String seatId) {
-        var locator = SimpleSeatLocator.from(roomId, seatId);
+        var locator = SimpleSeatLocator.of(roomId, seatId);
         apply(locator);
     }
 

--- a/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/EmbeddableTimeRange.java
+++ b/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/EmbeddableTimeRange.java
@@ -51,7 +51,7 @@ public class EmbeddableTimeRange implements TimeRange {
     }
 
     public void setRange(Instant startAt, Instant endAt) {
-        var range = SimpleTimeRange.from(startAt, endAt);
+        var range = SimpleTimeRange.of(startAt, endAt);
         apply(range);
     }
 

--- a/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/SimpleSeatLocator.java
+++ b/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/SimpleSeatLocator.java
@@ -13,11 +13,11 @@ public record SimpleSeatLocator(
         }
     }
 
-    public static SimpleSeatLocator from(String roomId, String seatId) {
+    public static SimpleSeatLocator of(String roomId, String seatId) {
         return new SimpleSeatLocator(roomId, seatId);
     }
 
-    public static SimpleSeatLocator of(SeatLocator locator) {
+    public static SimpleSeatLocator from(SeatLocator locator) {
         return new SimpleSeatLocator(locator.roomId(), locator.seatId());
     }
 }

--- a/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/SimpleTimeRange.java
+++ b/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/SimpleTimeRange.java
@@ -12,11 +12,11 @@ public record SimpleTimeRange(
         }
     }
 
-    public static SimpleTimeRange from(Instant startAt, Instant endAt) {
+    public static SimpleTimeRange of(Instant startAt, Instant endAt) {
         return new SimpleTimeRange(startAt, endAt);
     }
 
-    public static SimpleTimeRange of(TimeRange range) {
+    public static SimpleTimeRange from(TimeRange range) {
         return new SimpleTimeRange(range.startAt(), range.endAt());
     }
 }

--- a/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/EmbeddableTimeRangeTest.java
+++ b/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/EmbeddableTimeRangeTest.java
@@ -64,7 +64,7 @@ public class EmbeddableTimeRangeTest {
         @Test
         @DisplayName("of 팩토리로 다른 TimeRange를 복사할 수 있다")
         void copy_range_with_of_factory() {
-            var source = SimpleTimeRange.from(startAt, endAt);
+            var source = SimpleTimeRange.of(startAt, endAt);
 
             var copied = EmbeddableTimeRange.of(source);
 

--- a/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/SeatLocatorContractTest.java
+++ b/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/SeatLocatorContractTest.java
@@ -48,7 +48,7 @@ public interface SeatLocatorContractTest<T extends SeatLocator> {
     default void create_locator_with_from_factory() {
         var roomId = getRoomId();
         var seatId = getSeatId();
-        var locator = SimpleSeatLocator.from(roomId, seatId);
+        var locator = SimpleSeatLocator.of(roomId, seatId);
 
         assertThat(locator.roomId()).isEqualTo(roomId);
         assertThat(locator.seatId()).isEqualTo(seatId);
@@ -59,9 +59,9 @@ public interface SeatLocatorContractTest<T extends SeatLocator> {
     default void copy_locator_with_of_factory() {
         var roomId = getRoomId();
         var seatId = getSeatId();
-        var source = SimpleSeatLocator.from(roomId, seatId);
+        var source = SimpleSeatLocator.of(roomId, seatId);
 
-        var copied = SimpleSeatLocator.of(source);
+        var copied = SimpleSeatLocator.from(source);
 
         assertThat(copied.roomId()).isEqualTo(roomId);
         assertThat(copied.seatId()).isEqualTo(seatId);
@@ -188,7 +188,7 @@ public interface SeatLocatorContractTest<T extends SeatLocator> {
     @Test
     @DisplayName("SeatLocator의 key()는 동일한 SeatLocatorKey를 반환한다")
     default void return_key_from_locator_default_method() {
-        SeatLocator locator = SimpleSeatLocator.from("room-1", "seat-1");
+        SeatLocator locator = SimpleSeatLocator.of("room-1", "seat-1");
 
         var key = locator.key();
 
@@ -198,7 +198,7 @@ public interface SeatLocatorContractTest<T extends SeatLocator> {
     @Test
     @DisplayName("서로 다른 SeatLocator 구현체라도 같은 값이면 같은 key를 만든다")
     default void create_same_key_across_different_implementations() {
-        SeatLocator simple = SimpleSeatLocator.from("room-1", "seat-1");
+        SeatLocator simple = SimpleSeatLocator.of("room-1", "seat-1");
         SeatLocator embeddable = EmbeddableSeatLocator.from("room-1", "seat-1");
 
         assertThat(simple.key()).isEqualTo(embeddable.key());
@@ -212,7 +212,7 @@ public interface SeatLocatorContractTest<T extends SeatLocator> {
         );
 
         assertThat(keys).contains(
-                SimpleSeatLocator.from("room-1", "seat-1").key()
+                SimpleSeatLocator.of("room-1", "seat-1").key()
         );
     }
 

--- a/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/SimpleSeatLocatorTest.java
+++ b/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/SimpleSeatLocatorTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 public class SimpleSeatLocatorTest implements SeatLocatorContractTest<SimpleSeatLocator> {
     @Override
     public SimpleSeatLocator create(String roomId, String seatId) {
-        return SimpleSeatLocator.from(roomId, seatId);
+        return SimpleSeatLocator.of(roomId, seatId);
     }
 
     @Override

--- a/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/SimpleTimeRangeTest.java
+++ b/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/SimpleTimeRangeTest.java
@@ -38,7 +38,7 @@ public class SimpleTimeRangeTest {
         @Test
         @DisplayName("from 팩토리로 생성할 수 있다")
         void create_range_with_from_factory() {
-            var range = SimpleTimeRange.from(startAt, endAt);
+            var range = SimpleTimeRange.of(startAt, endAt);
 
             assertThat(range.startAt()).isEqualTo(startAt);
             assertThat(range.endAt()).isEqualTo(endAt);
@@ -47,9 +47,9 @@ public class SimpleTimeRangeTest {
         @Test
         @DisplayName("다른 TimeRange로부터 동일한 구간을 복사할 수 있다")
         void copy_range_with_of_factory() {
-            var source = SimpleTimeRange.from(startAt, endAt);
+            var source = SimpleTimeRange.of(startAt, endAt);
 
-            var copied = SimpleTimeRange.of(source);
+            var copied = SimpleTimeRange.from(source);
 
             assertThat(copied.startAt()).isEqualTo(startAt);
             assertThat(copied.endAt()).isEqualTo(endAt);
@@ -62,7 +62,7 @@ public class SimpleTimeRangeTest {
         @Test
         @DisplayName("시작 시간 이상 종료 시간 미만이면 포함한다")
         void contains_time_within_range() {
-            var range = SimpleTimeRange.from(startAt, endAt);
+            var range = SimpleTimeRange.of(startAt, endAt);
 
             assertThat(range.contains(startAt)).isTrue();
             assertThat(range.contains(endAt.minusNanos(1))).isTrue();
@@ -71,7 +71,7 @@ public class SimpleTimeRangeTest {
         @Test
         @DisplayName("시작 시간 이전과 종료 시간 이후는 포함하지 않는다")
         void does_not_contain_time_outside_range() {
-            var range = SimpleTimeRange.from(startAt, endAt);
+            var range = SimpleTimeRange.of(startAt, endAt);
 
             assertThat(range.contains(startAt.minusNanos(1))).isFalse();
             assertThat(range.contains(endAt)).isFalse();
@@ -80,7 +80,7 @@ public class SimpleTimeRangeTest {
         @Test
         @DisplayName("종료 시간 이상이면 종료된 상태다")
         void return_true_when_time_is_on_or_after_end_at() {
-            var range = SimpleTimeRange.from(startAt, endAt);
+            var range = SimpleTimeRange.of(startAt, endAt);
 
             assertThat(range.isEnded(endAt.minusNanos(1))).isFalse();
             assertThat(range.isEnded(endAt)).isTrue();

--- a/reservation/reservation-domain/src/testFixtures/java/com/seatliberator/seatliberator/reservation/domain/fixture/SeatLocatorFixture.java
+++ b/reservation/reservation-domain/src/testFixtures/java/com/seatliberator/seatliberator/reservation/domain/fixture/SeatLocatorFixture.java
@@ -12,6 +12,6 @@ public class SeatLocatorFixture {
     }
 
     public static SeatLocator createLocator(String roomId, String seatId) {
-        return SimpleSeatLocator.from(roomId, seatId);
+        return SimpleSeatLocator.of(roomId, seatId);
     }
 }

--- a/reservation/reservation-domain/src/testFixtures/java/com/seatliberator/seatliberator/reservation/domain/fixture/TimeRangeFixture.java
+++ b/reservation/reservation-domain/src/testFixtures/java/com/seatliberator/seatliberator/reservation/domain/fixture/TimeRangeFixture.java
@@ -23,6 +23,6 @@ public class TimeRangeFixture {
     }
 
     public static TimeRange createRange(Instant startAt, Instant endAt) {
-        return SimpleTimeRange.from(startAt, endAt);
+        return SimpleTimeRange.of(startAt, endAt);
     }
 }


### PR DESCRIPTION
## 변경 사항

`SeatLocator`와 `TimeRange` 계열 값 객체의 팩토리 메서드 이름을 생성/복사 의미에 맞게 정리했습니다.

- 원시 값으로 새 값을 생성하는 경우 `of(...)`를 사용하도록 변경했습니다.
- 기존 인터페이스/값 객체를 복사하는 경우 `from(...)`을 사용하도록 변경했습니다.
- 변경된 네이밍에 맞춰 application/domain 코드와 테스트를 함께 갱신했습니다.

## 의도

이후 작업에서 좌석 상태 조회 모델을 추가하기 전에, 값 객체 팩토리 메서드의 의미를 먼저 일관되게 맞추기 위한 선행 정리입니다.

## 검증

- `./gradlew :reservation:reservation-application:test :reservation:reservation-domain:test`