### PR TITLE
특정 기간 내 좌석 점유 구간 조회 API 추가

### DIFF
--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/application/port/in/FindSeatOccupancyRangesUseCase.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/application/port/in/FindSeatOccupancyRangesUseCase.java
@@ -1,0 +1,10 @@
+package com.seatliberator.seatliberator.reservation.availability.application.port.in;
+
+import com.seatliberator.seatliberator.reservation.availability.application.port.in.query.FindOccupancyRangesQuery;
+import com.seatliberator.seatliberator.reservation.availability.application.port.in.result.SeatOccupancyRangeResult;
+
+import java.util.List;
+
+public interface FindSeatOccupancyRangesUseCase {
+    List<SeatOccupancyRangeResult> find(FindOccupancyRangesQuery query);
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/application/port/in/query/FindOccupancyRangesQuery.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/application/port/in/query/FindOccupancyRangesQuery.java
@@ -1,0 +1,10 @@
+package com.seatliberator.seatliberator.reservation.availability.application.port.in.query;
+
+import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
+import com.seatliberator.seatliberator.reservation.domain.TimeRange;
+
+public record FindOccupancyRangesQuery(
+        SeatLocator locator,
+        TimeRange range
+) {
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/application/port/in/result/SeatOccupancyRangeResult.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/application/port/in/result/SeatOccupancyRangeResult.java
@@ -1,0 +1,14 @@
+package com.seatliberator.seatliberator.reservation.availability.application.port.in.result;
+
+import com.seatliberator.seatliberator.reservation.domain.TimeRange;
+
+import java.time.Instant;
+
+public record SeatOccupancyRangeResult(
+        Instant startAt,
+        Instant endAt
+) {
+    public static SeatOccupancyRangeResult of(TimeRange range) {
+        return new SeatOccupancyRangeResult(range.startAt(), range.endAt());
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/application/service/SeatAvailabilityService.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/application/service/SeatAvailabilityService.java
@@ -3,14 +3,20 @@ package com.seatliberator.seatliberator.reservation.availability.application.ser
 import com.seatliberator.seatliberator.reservation.availability.application.model.AvailableSeats;
 import com.seatliberator.seatliberator.reservation.availability.application.model.SeatReservationStatusClassifier;
 import com.seatliberator.seatliberator.reservation.availability.application.port.in.FindAvailableSeatsUseCase;
+import com.seatliberator.seatliberator.reservation.availability.application.port.in.FindSeatOccupancyRangesUseCase;
 import com.seatliberator.seatliberator.reservation.availability.application.port.in.FindSeatStatusesUseCase;
 import com.seatliberator.seatliberator.reservation.availability.application.port.in.query.FindAvailableSeatQuery;
+import com.seatliberator.seatliberator.reservation.availability.application.port.in.query.FindOccupancyRangesQuery;
 import com.seatliberator.seatliberator.reservation.availability.application.port.in.query.FindSeatStatusesQuery;
 import com.seatliberator.seatliberator.reservation.availability.application.port.in.result.AvailableSeatResult;
+import com.seatliberator.seatliberator.reservation.availability.application.port.in.result.SeatOccupancyRangeResult;
 import com.seatliberator.seatliberator.reservation.availability.application.port.in.result.SeatStatusesResult;
 import com.seatliberator.seatliberator.reservation.book.application.contract.OccupancySeatLocatorFinder;
+import com.seatliberator.seatliberator.reservation.book.application.contract.OccupancySeatRangeFinder;
 import com.seatliberator.seatliberator.reservation.domain.persistence.Seat;
 import com.seatliberator.seatliberator.reservation.seat.application.port.out.SeatReader;
+import com.seatliberator.seatliberator.reservation.shared.application.exception.ReservationApplicationErrorCode;
+import com.seatliberator.seatliberator.reservation.shared.application.exception.ReservationApplicationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,9 +26,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SeatAvailabilityService implements
         FindAvailableSeatsUseCase,
-        FindSeatStatusesUseCase {
+        FindSeatStatusesUseCase,
+        FindSeatOccupancyRangesUseCase {
     private final SeatReader seatReader;
     private final OccupancySeatLocatorFinder occupancySeatLocatorFinder;
+    private final OccupancySeatRangeFinder occupancySeatRangeFinder;
 
     @Override
     public List<AvailableSeatResult> find(FindAvailableSeatQuery query) {
@@ -49,14 +57,29 @@ public class SeatAvailabilityService implements
 
         if (seatLocators.isEmpty()) return List.of();
 
-        var occupancyReservations = occupancySeatLocatorFinder.find(roomId, range);
+        var occupiedLocators = occupancySeatLocatorFinder.find(roomId, range);
 
-        var statuses = SeatReservationStatusClassifier.from(seatLocators, occupancyReservations).toMap();
+        var statuses = SeatReservationStatusClassifier.from(seatLocators, occupiedLocators).toMap();
 
         return seatLocators.stream()
                 .map(locator ->
                         SeatStatusesResult.of(locator, statuses.get(locator.key()))
                 )
+                .toList();
+    }
+
+    @Override
+    public List<SeatOccupancyRangeResult> find(FindOccupancyRangesQuery query) {
+        var targetLocator = query.locator();
+        var targetRange = query.range();
+
+        var exists = seatReader.existsByLocator(targetLocator);
+        if (!exists) throw new ReservationApplicationException(ReservationApplicationErrorCode.SEAT_NOT_FOUND);
+
+        var occupiedRanges = occupancySeatRangeFinder.find(targetLocator, targetRange);
+
+        return occupiedRanges.stream()
+                .map(SeatOccupancyRangeResult::of)
                 .toList();
     }
 }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/infrastructure/web/controller/SeatAvailabilityController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/infrastructure/web/controller/SeatAvailabilityController.java
@@ -1,9 +1,12 @@
 package com.seatliberator.seatliberator.reservation.availability.infrastructure.web.controller;
 
 import com.seatliberator.seatliberator.reservation.availability.application.port.in.FindAvailableSeatsUseCase;
+import com.seatliberator.seatliberator.reservation.availability.application.port.in.FindSeatOccupancyRangesUseCase;
 import com.seatliberator.seatliberator.reservation.availability.application.port.in.FindSeatStatusesUseCase;
 import com.seatliberator.seatliberator.reservation.availability.application.port.in.query.FindAvailableSeatQuery;
+import com.seatliberator.seatliberator.reservation.availability.application.port.in.query.FindOccupancyRangesQuery;
 import com.seatliberator.seatliberator.reservation.availability.application.port.in.query.FindSeatStatusesQuery;
+import com.seatliberator.seatliberator.reservation.domain.SimpleSeatLocator;
 import com.seatliberator.seatliberator.reservation.domain.SimpleTimeRange;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -18,6 +21,7 @@ import java.time.Instant;
 public class SeatAvailabilityController {
     private final FindAvailableSeatsUseCase findAvailableSeatsUseCase;
     private final FindSeatStatusesUseCase findSeatStatusesUseCase;
+    private final FindSeatOccupancyRangesUseCase findSeatOccupancyRangesUseCase;
 
     @GetMapping("/{roomId}/available-seats")
     public ResponseEntity<?> getAvailableSeats(
@@ -40,6 +44,20 @@ public class SeatAvailabilityController {
         var range = SimpleTimeRange.of(startAt, endAt);
         var query = new FindSeatStatusesQuery(roomId, range);
         var result = findSeatStatusesUseCase.find(query);
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{roomId}/seats/{seatId}/occupy")
+    public ResponseEntity<?> getSeatOccupiedRange(
+            @PathVariable("roomId") String roomId,
+            @PathVariable("seatId") String seatId,
+            @RequestParam(name = "start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant startAt,
+            @RequestParam(name = "end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant endAt
+    ) {
+        var locator = SimpleSeatLocator.of(roomId, seatId);
+        var range = SimpleTimeRange.of(startAt, endAt);
+        var query = new FindOccupancyRangesQuery(locator, range);
+        var result = findSeatOccupancyRangesUseCase.find(query);
         return ResponseEntity.ok(result);
     }
 }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/contract/OccupancySeatRangeFinder.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/contract/OccupancySeatRangeFinder.java
@@ -1,0 +1,10 @@
+package com.seatliberator.seatliberator.reservation.book.application.contract;
+
+import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
+import com.seatliberator.seatliberator.reservation.domain.TimeRange;
+
+import java.util.List;
+
+public interface OccupancySeatRangeFinder {
+    List<TimeRange> find(SeatLocator locator, TimeRange range);
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/contract/service/DefaultOccupancySeatRangeFinder.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/contract/service/DefaultOccupancySeatRangeFinder.java
@@ -1,0 +1,31 @@
+package com.seatliberator.seatliberator.reservation.book.application.contract.service;
+
+import com.seatliberator.seatliberator.reservation.book.application.contract.OccupancySeatRangeFinder;
+import com.seatliberator.seatliberator.reservation.book.application.model.ReservationOccupancyPolicy;
+import com.seatliberator.seatliberator.reservation.book.application.port.out.ReservationReader;
+import com.seatliberator.seatliberator.reservation.book.application.port.out.criteria.ReservationFilter;
+import com.seatliberator.seatliberator.reservation.book.application.port.out.criteria.ReservationSeatOverlapCriteria;
+import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
+import com.seatliberator.seatliberator.reservation.domain.TimeRange;
+import com.seatliberator.seatliberator.reservation.domain.persistence.Reservation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DefaultOccupancySeatRangeFinder implements OccupancySeatRangeFinder {
+    private final ReservationReader reader;
+    private final ReservationOccupancyPolicy policy = new ReservationOccupancyPolicy();
+
+    @Override
+    public List<TimeRange> find(SeatLocator locator, TimeRange range) {
+        var criteria = ReservationSeatOverlapCriteria.of(locator, range)
+                .withFilter(ReservationFilter.empty().withStatuses(policy.occupyingStatuses()));
+
+        return reader.findAllOverlapping(criteria).stream()
+                .<TimeRange>map(Reservation::getRange)
+                .toList();
+    }
+}

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/availability/application/service/FindAvailableSeatsUseCaseTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/availability/application/service/FindAvailableSeatsUseCaseTest.java
@@ -4,6 +4,7 @@ import com.seatliberator.seatliberator.reservation.availability.application.port
 import com.seatliberator.seatliberator.reservation.availability.application.port.in.query.FindAvailableSeatQuery;
 import com.seatliberator.seatliberator.reservation.availability.application.port.in.result.AvailableSeatResult;
 import com.seatliberator.seatliberator.reservation.book.application.contract.OccupancySeatLocatorFinder;
+import com.seatliberator.seatliberator.reservation.book.application.contract.OccupancySeatRangeFinder;
 import com.seatliberator.seatliberator.reservation.domain.fixture.SeatFixture;
 import com.seatliberator.seatliberator.reservation.seat.application.port.out.SeatReader;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,14 +32,16 @@ public class FindAvailableSeatsUseCaseTest {
     @Mock
     OccupancySeatLocatorFinder occupancySeatLocatorFinder;
 
+    @Mock
+    OccupancySeatRangeFinder occupancySeatRangeFinder;
+
     FindAvailableSeatsUseCase useCase;
 
     Instant now = fixedClock.instant();
-    ;
 
     @BeforeEach
     void run() {
-        useCase = new SeatAvailabilityService(seatReader, occupancySeatLocatorFinder);
+        useCase = new SeatAvailabilityService(seatReader, occupancySeatLocatorFinder, occupancySeatRangeFinder);
     }
 
     @Test

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/availability/application/service/FindSeatStatusesUseCaseTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/availability/application/service/FindSeatStatusesUseCaseTest.java
@@ -5,6 +5,7 @@ import com.seatliberator.seatliberator.reservation.availability.application.port
 import com.seatliberator.seatliberator.reservation.availability.application.port.in.query.FindSeatStatusesQuery;
 import com.seatliberator.seatliberator.reservation.availability.application.port.in.result.SeatStatusesResult;
 import com.seatliberator.seatliberator.reservation.book.application.contract.OccupancySeatLocatorFinder;
+import com.seatliberator.seatliberator.reservation.book.application.contract.OccupancySeatRangeFinder;
 import com.seatliberator.seatliberator.reservation.domain.fixture.SeatFixture;
 import com.seatliberator.seatliberator.reservation.seat.application.port.out.SeatReader;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,13 +33,16 @@ public class FindSeatStatusesUseCaseTest {
     @Mock
     OccupancySeatLocatorFinder occupancySeatLocatorFinder;
 
+    @Mock
+    OccupancySeatRangeFinder occupancySeatRangeFinder;
+
     FindSeatStatusesUseCase useCase;
 
     Instant now = fixedClock.instant();
 
     @BeforeEach
     void run() {
-        useCase = new SeatAvailabilityService(seatReader, occupancySeatLocatorFinder);
+        useCase = new SeatAvailabilityService(seatReader, occupancySeatLocatorFinder, occupancySeatRangeFinder);
     }
 
     @Test

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/book/application/contract/service/DefaultOccupancySeatLocatorFinderTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/book/application/contract/service/DefaultOccupancySeatLocatorFinderTest.java
@@ -1,6 +1,8 @@
 package com.seatliberator.seatliberator.reservation.book.application.contract.service;
 
+import com.seatliberator.seatliberator.reservation.book.application.model.ReservationOccupancyPolicy;
 import com.seatliberator.seatliberator.reservation.book.application.port.out.ReservationReader;
+import com.seatliberator.seatliberator.reservation.book.application.port.out.criteria.ReservationFilter;
 import com.seatliberator.seatliberator.reservation.book.application.port.out.criteria.ReservationRoomOverlapCriteria;
 import com.seatliberator.seatliberator.reservation.domain.ReservationStatus;
 import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
@@ -25,6 +27,8 @@ class DefaultOccupancySeatLocatorFinderTest {
     @Mock
     ReservationReader reader;
 
+    ReservationOccupancyPolicy policy = new ReservationOccupancyPolicy();
+
     @InjectMocks
     DefaultOccupancySeatLocatorFinder finder;
 
@@ -33,7 +37,8 @@ class DefaultOccupancySeatLocatorFinderTest {
     void find_overlapping_reservations_by_room_and_range() {
         var roomId = "room-1";
         var range = createRange();
-        var criteria = ReservationRoomOverlapCriteria.of(roomId, range);
+        var criteria = ReservationRoomOverlapCriteria.of(roomId, range)
+                .withFilter(ReservationFilter.empty().withStatuses(policy.occupyingStatuses()));
 
         when(reader.findAllOverlapping(criteria)).thenReturn(List.of());
 
@@ -66,15 +71,11 @@ class DefaultOccupancySeatLocatorFinderTest {
                 .status(ReservationStatus.RESERVED)
                 .build();
 
-        var canceled = builder.copy()
-                .locator(canceledLocator)
-                .status(ReservationStatus.CANCELED)
-                .build();
-
-        var criteria = ReservationRoomOverlapCriteria.of(roomId, range);
+        var criteria = ReservationRoomOverlapCriteria.of(roomId, range)
+                .withFilter(ReservationFilter.empty().withStatuses(policy.occupyingStatuses()));
 
         when(reader.findAllOverlapping(criteria))
-                .thenReturn(List.of(used, reserved, canceled));
+                .thenReturn(List.of(used, reserved));
 
         var result = finder.find(roomId, range);
 

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/book/application/contract/service/OccupancySeatRangeFinderTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/book/application/contract/service/OccupancySeatRangeFinderTest.java
@@ -1,0 +1,90 @@
+package com.seatliberator.seatliberator.reservation.book.application.contract.service;
+
+import com.seatliberator.seatliberator.reservation.book.application.contract.OccupancySeatRangeFinder;
+import com.seatliberator.seatliberator.reservation.book.application.model.ReservationOccupancyPolicy;
+import com.seatliberator.seatliberator.reservation.book.application.port.out.ReservationReader;
+import com.seatliberator.seatliberator.reservation.book.application.port.out.criteria.ReservationFilter;
+import com.seatliberator.seatliberator.reservation.book.application.port.out.criteria.ReservationSeatOverlapCriteria;
+import com.seatliberator.seatliberator.reservation.domain.ReservationStatus;
+import com.seatliberator.seatliberator.reservation.domain.fixture.ReservationFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static com.seatliberator.seatliberator.reservation.domain.fixture.SeatLocatorFixture.createLocator;
+import static com.seatliberator.seatliberator.reservation.domain.fixture.TestSupport.fixedClock;
+import static com.seatliberator.seatliberator.reservation.domain.fixture.TimeRangeFixture.createRange;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Occupancy Seat Range Finder")
+public class OccupancySeatRangeFinderTest {
+    @Mock
+    ReservationReader reader;
+
+    OccupancySeatRangeFinder finder;
+
+    ReservationOccupancyPolicy policy = new ReservationOccupancyPolicy();
+
+    @BeforeEach
+    void run() {
+        finder = new DefaultOccupancySeatRangeFinder(reader);
+    }
+
+    @Test
+    @DisplayName("targetLocator에 해당하는 좌석이 targetRange 구간 내 점유된 구간을 조회한다")
+    void find_occupied_range_by_target_locator_and_range() {
+        var locator = createLocator();
+        var range = createRange();
+
+        var criteria = ReservationSeatOverlapCriteria.of(locator, range)
+                .withFilter(ReservationFilter.empty().withStatuses(policy.occupyingStatuses()));
+        when(reader.findAllOverlapping(criteria)).thenReturn(List.of());
+
+        var result = finder.find(locator, range);
+
+        assertThat(result).isEmpty();
+        verify(reader).findAllOverlapping(criteria);
+        verifyNoMoreInteractions(reader);
+    }
+
+    @Test
+    @DisplayName("점유 구간의 range만 반환한다")
+    void return_only_occupied_range() {
+        var locator = createLocator();
+        var builder = new ReservationFixture.Builder()
+                .locator(locator);
+
+        var usedAt = fixedClock.instant();
+        var used = builder.copy()
+                .range(createRange(usedAt))
+                .status(ReservationStatus.USED)
+                .build();
+
+        var reservedAt = usedAt.plusSeconds(3600);
+        var reserved = builder.copy()
+                .range(createRange(reservedAt))
+                .status(ReservationStatus.RESERVED)
+                .build();
+
+        var targetRange = createRange(usedAt, reservedAt);
+        var criteria = ReservationSeatOverlapCriteria.of(locator, targetRange)
+                .withFilter(ReservationFilter.empty().withStatuses(policy.occupyingStatuses()));
+        when(reader.findAllOverlapping(criteria))
+                .thenReturn(List.of(used, reserved));
+
+        var result = finder.find(locator, targetRange);
+
+        assertThat(result)
+                .hasSize(2)
+                .containsExactlyInAnyOrder(used.getRange(), reserved.getRange());
+        verify(reader).findAllOverlapping(criteria);
+        verifyNoMoreInteractions(reader);
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- 없음

## 변경 사항

특정 기간과 좌석을 기준으로 실제 예약이 점유하고 있는 시간 구간을 조회하는 API를 추가했습니다.
이번 변경은 방 단위 좌석 가용 여부 조회와 별개로, 단일 좌석의 점유 구간을 명시적으로 확인할 수 있도록 availability application 계층과 book 패키지의 내부 협력 계약을 확장하는 데 초점을 두었습니다.

### 좌석 점유 구간 조회 API 추가

- `SeatAvailabilityController`에 `/rooms/{roomId}/seats/{seatId}/occupy` 경로를 추가했습니다.
- `FindSeatOccupancyRangesUseCase`, `FindOccupancyRangesQuery`, `SeatOccupancyRangeResult`를 추가해 좌석별 점유 구간 조회 유스케이스를 분리했습니다.
- 존재하지 않는 좌석을 조회하는 경우 `SEAT_NOT_FOUND` 애플리케이션 예외를 반환하도록 처리했습니다.

### 예약 점유 구간 조회 협력 계약 추가

- `OccupancySeatRangeFinder` 계약을 추가해 availability 계층이 예약 저장소 세부 조건을 직접 알지 않도록 분리했습니다.
- `DefaultOccupancySeatRangeFinder`에서 좌석과 기간이 겹치는 예약 중 실제 점유 상태인 예약만 조회하도록 구성했습니다.
- 조회된 예약의 `TimeRange`를 그대로 반환해 클라이언트가 요청 기간 내 점유된 시간대를 확인할 수 있도록 했습니다.

### 테스트 보강

- `OccupancySeatRangeFinderTest`를 추가해 점유 상태 예약만 반환하고 비점유 상태 예약은 제외하는 흐름을 검증했습니다.
- 기존 available seats / seat statuses 테스트에서 새 협력 객체 주입에 맞춰 fixture를 정리했습니다.
- 좌석 점유 locator 조회 테스트도 occupancy status 필터링 기준에 맞춰 함께 정리했습니다.

## 배경 및 의도

기존 좌석 조회 API는 요청 기간 동안 예약 가능한 좌석 목록이나 좌석별 점유 여부만 반환했습니다.
하지만 단일 좌석의 예약 점유 구간을 직접 확인하려면, 예약 조회 조건과 점유 상태 판단 정책을 호출부에서 다시 조합해야 했습니다.
이번 변경은 점유 구간 조회를 별도 유스케이스로 드러내고, 실제 예약이 좌석을 점유하는지 판단하는 책임은 기존 occupancy 정책과 book 패키지 내부 계약에 남겨두려는 목적입니다.

## 영향

- 클라이언트는 특정 좌석의 점유된 시간 구간을 별도 API로 조회할 수 있습니다.
- availability 계층은 예약 점유 구간을 내부 협력 계약을 통해 조회하므로 예약 조회 세부 조건과 분리됩니다.
- 예약 상태별 점유 판단 기준이 locator 조회와 range 조회에서 같은 정책을 사용하도록 맞춰집니다.

## 검증

- `./gradlew :reservation:reservation-application:test`