### PR TITLE
Reservation API 엔드포인트 경로 정렬

### DIFF
--- a/.run/app-local-full.run.xml
+++ b/.run/app-local-full.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="app-local-full" type="CompoundRunConfigurationType">
+    <toRun name="BoardApplication" type="Application" />
+    <toRun name="GatewayApplication" type="Application" />
+    <toRun name="IdentityApplication" type="Application" />
+    <toRun name="NotificationApplication" type="Application" />
+    <toRun name="ReservationApplication" type="Application" />
+    <toRun name="Kafka" type="docker-deploy" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
             - id: reservation-service-route
               uri: http://localhost:8082
               predicates:
-                - Path=/api/v1/reservation/**,/api/v1/seat/**,/api/v1/rooms/**,/api/v1/waitlist/**
+                - Path=/api/v1/reservation/**,/api/v1/rooms/**,/api/v1/waitlist/**
               filters:
                 - RewritePath=/api/v1/?(?<segment>.*), /$\{segment}
 

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -12,10 +12,17 @@ spring:
       server:
         webflux:
           routes:
-            - id: identity-service-route
+            - id: identity-credential
               uri: http://localhost:8081
               predicates:
-                - Path=/auth/**,/oauth2/**,/login/**,/.well-known/jwks.json
+                - Path=/api/v1/auth/**
+              filters:
+                - RewritePath=/api/v1/?(?<segment>.*), /$\{segment}
+
+            - id: identity-oauth-jwks
+              uri: http://localhost:8081
+              predicates:
+                - Path=/oauth2/**,/login/**,/.well-known/jwks.json
 
             - id: reservation-service-route
               uri: http://localhost:8082

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -27,7 +27,7 @@ spring:
             - id: reservation-service-route
               uri: http://localhost:8082
               predicates:
-                - Path=/api/v1/reservation/**,/api/v1/rooms/**,/api/v1/waitlist/**
+                - Path=/api/v1/reservations/**,/api/v1/rooms/**,/api/v1/waitlist/**
               filters:
                 - RewritePath=/api/v1/?(?<segment>.*), /$\{segment}
 

--- a/reservation/reservation-application/Dockerfile
+++ b/reservation/reservation-application/Dockerfile
@@ -1,0 +1,13 @@
+FROM gradle:8.14.4-jdk21 AS builder
+WORKDIR /app
+
+COPY . .
+
+RUN gradle :reservation:reservation-application:bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+COPY --from=builder /app/reservation/reservation-application/build/libs/*.jar app.jar
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/CreateReservationController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/CreateReservationController.java
@@ -1,0 +1,39 @@
+package com.seatliberator.seatliberator.reservation.book.infrastructure.web.controller;
+
+import com.seatliberator.seatliberator.identity.client.actor.ActorContextHolder;
+import com.seatliberator.seatliberator.reservation.book.application.port.in.CreateReservationUseCase;
+import com.seatliberator.seatliberator.reservation.book.application.port.in.command.CreateReservationCommand;
+import com.seatliberator.seatliberator.reservation.book.infrastructure.web.request.ReservationCreateRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/rooms")
+public class CreateReservationController {
+    private final CreateReservationUseCase createReservationUseCase;
+    private final ActorContextHolder actorContextHolder;
+
+    @PostMapping("/{roomId}/seats/{seatId}/reservations")
+    public ResponseEntity<?> create(
+            @PathVariable("roomId") String roomId,
+            @PathVariable("seatId") String seatId,
+            @RequestBody ReservationCreateRequest request
+    ) {
+        var userId = actorContextHolder.getActor().subject();
+
+        var command = new CreateReservationCommand(
+                userId,
+                roomId,
+                seatId,
+                request.startAt(),
+                request.endAt()
+        );
+        var result = createReservationUseCase.create(command);
+
+        return ResponseEntity.ok(result);
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/ReservationController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/ReservationController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,6 +25,7 @@ public class ReservationController {
 
     private final ActorContextHolder actorContextHolder;
 
+    @PutMapping
     public ResponseEntity<?> update(
             @RequestBody ReservationUpdateRequest request
     ) {

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/ReservationController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/ReservationController.java
@@ -2,49 +2,28 @@ package com.seatliberator.seatliberator.reservation.book.infrastructure.web.cont
 
 import com.seatliberator.seatliberator.identity.client.actor.ActorContextHolder;
 import com.seatliberator.seatliberator.reservation.book.application.port.in.CancelReservationUseCase;
-import com.seatliberator.seatliberator.reservation.book.application.port.in.CreateReservationUseCase;
 import com.seatliberator.seatliberator.reservation.book.application.port.in.UpdateReservationUseCase;
 import com.seatliberator.seatliberator.reservation.book.application.port.in.command.CancelReservationCommand;
-import com.seatliberator.seatliberator.reservation.book.application.port.in.command.CreateReservationCommand;
 import com.seatliberator.seatliberator.reservation.book.application.port.in.command.UpdateReservationCommand;
-import com.seatliberator.seatliberator.reservation.book.infrastructure.web.request.ReservationCreateRequest;
 import com.seatliberator.seatliberator.reservation.book.infrastructure.web.request.ReservationUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/reservation")
+@RequestMapping("/reservations")
 public class ReservationController {
-
-    private final CreateReservationUseCase createReservationUseCase;
     private final UpdateReservationUseCase updateReservationUseCase;
     private final CancelReservationUseCase cancelReservationUseCase;
 
     private final ActorContextHolder actorContextHolder;
 
-    @PostMapping
-    public ResponseEntity<?> create(
-            @RequestBody ReservationCreateRequest request
-    ) {
-        var userId = actorContextHolder.getActor().subject();
-
-        var command = new CreateReservationCommand(
-                userId,
-                request.roomId(),
-                request.seatId(),
-                request.startAt(),
-                request.endAt()
-        );
-        var result = createReservationUseCase.create(command);
-
-        return ResponseEntity.ok(result);
-    }
-
-    @PutMapping
     public ResponseEntity<?> update(
             @RequestBody ReservationUpdateRequest request
     ) {

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/request/ReservationCreateRequest.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/request/ReservationCreateRequest.java
@@ -3,8 +3,6 @@ package com.seatliberator.seatliberator.reservation.book.infrastructure.web.requ
 import java.time.Instant;
 
 public record ReservationCreateRequest(
-        String roomId,
-        String seatId,
         Instant startAt,
         Instant endAt
 ) {

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/seat/infrastructure/web/controller/SeatController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/seat/infrastructure/web/controller/SeatController.java
@@ -18,47 +18,40 @@ import java.util.Map;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/seat")
+@RequestMapping("/rooms")
 public class SeatController {
 
     private final CreateSeatUseCase createSeatUseCase;
     private final UpdateSeatUseCase updateSeatUseCase;
     private final DeleteSeatUseCase deleteSeatUseCase;
 
-    @PostMapping
+    @PostMapping("/{roomId}/seats")
     public Map<String, Boolean> create(
+            @PathVariable("roomId") String roomId,
             @RequestBody SeatCreateRequest request
     ) {
-        boolean result = createSeatUseCase.create(
-                new CreateSeatCommand(
-                        request.roomId(),
-                        request.seatId()
-                )
-        );
+        var command = new CreateSeatCommand(roomId, request.seatId());
+        boolean result = createSeatUseCase.create(command);
 
         return Map.of("success", result);
     }
 
-    @PutMapping
+    @PutMapping("/{roomId}/seats/{seatId}")
     public Map<String, Boolean> update(
+            @PathVariable("roomId") String roomId,
+            @PathVariable("seatId") String seatId,
             @RequestBody SeatUpdateRequest request
     ) {
-        boolean result = updateSeatUseCase.update(
-                new UpdateSeatCommand(
-                        request.oldRoomId(),
-                        request.oldSeatId(),
-                        request.newRoomId(),
-                        request.newSeatId()
-                )
-        );
+        var command = new UpdateSeatCommand(roomId, seatId, request.newRoomId(), request.newSeatId());
+        boolean result = updateSeatUseCase.update(command);
 
         return Map.of("success", result);
     }
 
-    @DeleteMapping("/{roomId}/{seatId}")
+    @DeleteMapping("/{roomId}/seats/{seatId}")
     public Map<String, Boolean> delete(
-            @PathVariable String roomId,
-            @PathVariable String seatId
+            @PathVariable("roomId") String roomId,
+            @PathVariable("seatId") String seatId
     ) {
         var command = new DeleteSeatCommand(roomId, seatId);
         boolean result = deleteSeatUseCase.delete(command);

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/seat/infrastructure/web/request/SeatCreateRequest.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/seat/infrastructure/web/request/SeatCreateRequest.java
@@ -1,7 +1,6 @@
 package com.seatliberator.seatliberator.reservation.seat.infrastructure.web.request;
 
 public record SeatCreateRequest(
-        String roomId,
         String seatId
 ) {
 }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/seat/infrastructure/web/request/SeatUpdateRequest.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/seat/infrastructure/web/request/SeatUpdateRequest.java
@@ -1,8 +1,6 @@
 package com.seatliberator.seatliberator.reservation.seat.infrastructure.web.request;
 
 public record SeatUpdateRequest(
-        String oldRoomId,
-        String oldSeatId,
         String newRoomId,
         String newSeatId
 ) {


### PR DESCRIPTION
## 관련 이슈

- 없음

## 변경 사항

gateway 라우트와 reservation 애플리케이션의 외부 API 경로를 리소스 중심 URI 기준으로 정리했습니다.
이번 변경은 `/reservation`, `/seat`처럼 단일 기능 이름에 묶여 있던 경로를 `/reservations`, `/rooms/{roomId}/seats...` 형태로 맞추고, gateway의 `/api/v1` 라우트도 실제 컨트롤러 진입점과 일관되게 조정하는 데 초점을 두었습니다.

### reservation / seat 엔드포인트 정렬

- 좌석 생성, 수정, 삭제 API를 `/rooms/{roomId}/seats` 및 `/rooms/{roomId}/seats/{seatId}` 경로로 정리했습니다.
- 예약 생성 API를 `CreateReservationController`로 분리하고 `/rooms/{roomId}/seats/{seatId}/reservations` 경로에서 처리하도록 변경했습니다.
- 예약 수정/취소 API의 기본 경로를 `/reservations`로 맞추고, 수정 API에 `PUT` 매핑이 명시되도록 보정했습니다.
- 경로에서 전달되는 `roomId`, `seatId`는 request body가 아니라 path variable을 기준으로 command를 구성하도록 요청 DTO를 정리했습니다.

### gateway 라우트 정리

- identity credential 라우트를 `/api/v1/auth/**` 기준으로 분리하고, OAuth/JWKS 라우트는 기존 공개 경로를 유지하도록 나눴습니다.
- reservation 라우트를 `/api/v1/reservations/**`, `/api/v1/rooms/**`, `/api/v1/waitlist/**` 기준으로 맞췄습니다.
- gateway에서 rewrite되는 외부 경로와 downstream 컨트롤러 경로가 같은 리소스 구조를 바라보도록 정리했습니다.

### 로컬 실행 및 배포 보강

- 전체 로컬 애플리케이션과 Kafka를 함께 실행하는 IntelliJ compound run 설정을 추가했습니다.
- reservation application을 컨테이너로 빌드할 수 있도록 Dockerfile을 추가했습니다.

## 배경 및 의도

최근 reservation 모듈에서 좌석 조회와 예약 상태 조회 API가 `/rooms` 하위 리소스 기준으로 추가되면서, 기존 seat / reservation 명령 API와 gateway 라우트 사이의 경로 체계가 서로 다르게 보이기 시작했습니다.
이번 변경은 좌석과 예약의 소유 관계가 URI에 드러나도록 컨트롤러 경로를 정렬하고, 외부 진입점인 gateway 설정도 같은 기준으로 맞추려는 목적입니다.

## 영향

- seat 명령 API는 방 하위 좌석 리소스 경로를 사용합니다.
- 예약 생성 API는 특정 좌석 하위 예약 생성 경로로 이동합니다.
- 예약 수정/취소 API는 `/reservations` 복수형 경로를 사용합니다.
- gateway의 `/api/v1` 라우트가 변경된 reservation 컨트롤러 경로와 맞춰집니다.
- 로컬 전체 실행과 reservation application 컨테이너 빌드 진입점이 추가됩니다.

## 검증

- `./gradlew :gateway:test :reservation:reservation-application:test :reservation:reservation-application:bootJar`