### PR TITLE
OpenAPI 기반 API 문서 설명 추가

### DIFF
--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/infrastructure/web/controller/BoardController.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/infrastructure/web/controller/BoardController.java
@@ -6,28 +6,49 @@ import com.seatliberator.seatliberator.board.application.port.in.command.BoardDe
 import com.seatliberator.seatliberator.board.application.port.in.command.BoardUpdateCommand;
 import com.seatliberator.seatliberator.board.infrastructure.web.request.BoardCreateRequest;
 import com.seatliberator.seatliberator.board.infrastructure.web.request.BoardUpdateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
+@Tag(name = "Boards", description = "게시판 관리 API")
 @RequestMapping("/board")
 @RestController
 @RequiredArgsConstructor
 public class BoardController {
     private final BoardManager boardManager;
 
+    @Operation(summary = "게시판 목록 조회", description = "등록된 게시판 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping
     public ResponseEntity<?> getAll() {
         return ResponseEntity.ok(boardManager.getAll());
     }
 
+    @Operation(summary = "게시판 단건 조회", description = "게시판 ID로 게시판 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "게시판 없음")
+    })
     @GetMapping("/{boardId}")
-    public ResponseEntity<?> get(@PathVariable("boardId") UUID boardId) {
+    public ResponseEntity<?> get(
+            @Parameter(description = "게시판 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e3")
+            @PathVariable("boardId") UUID boardId
+    ) {
         return ResponseEntity.ok(boardManager.get(boardId));
     }
 
+    @Operation(summary = "게시판 생성", description = "새 게시판을 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
     @PostMapping
     public ResponseEntity<?> post(
             @RequestBody BoardCreateRequest body
@@ -42,8 +63,15 @@ public class BoardController {
         return ResponseEntity.ok(result);
     }
 
+    @Operation(summary = "게시판 정보 변경", description = "기존 게시판의 이름과 설명을 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "변경 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "게시판 없음")
+    })
     @PatchMapping("/{boardId}")
     public ResponseEntity<?> patch(
+            @Parameter(description = "게시판 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e3")
             @PathVariable("boardId") UUID boardId,
             @RequestBody BoardUpdateRequest body
     ) {
@@ -58,8 +86,14 @@ public class BoardController {
         return ResponseEntity.ok(result);
     }
 
+    @Operation(summary = "게시판 삭제", description = "기존 게시판을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "게시판 없음")
+    })
     @DeleteMapping("/{boardId}")
     public ResponseEntity<?> delete(
+            @Parameter(description = "게시판 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e3")
             @PathVariable("boardId") UUID boardId
     ) {
         var command = new BoardDeleteCommand(

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/infrastructure/web/controller/CategoryController.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/infrastructure/web/controller/CategoryController.java
@@ -6,6 +6,11 @@ import com.seatliberator.seatliberator.board.application.port.in.command.Categor
 import com.seatliberator.seatliberator.board.application.port.in.command.CategoryUpdateCommand;
 import com.seatliberator.seatliberator.board.infrastructure.web.request.CategoryCreateRequest;
 import com.seatliberator.seatliberator.board.infrastructure.web.request.CategoryUpdateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,27 +19,50 @@ import org.springframework.web.bind.annotation.*;
 import java.net.URI;
 import java.util.UUID;
 
+@Tag(name = "Categories", description = "게시판 카테고리 관리 API")
 @RequestMapping("/board/{boardId}/categories")
 @RestController
 @RequiredArgsConstructor
 public class CategoryController {
     private final CategoryManager categoryManager;
 
+    @Operation(summary = "카테고리 목록 조회", description = "특정 게시판에 속한 카테고리 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "게시판 없음")
+    })
     @GetMapping
-    public ResponseEntity<?> getAll(@PathVariable("boardId") UUID boardId) {
+    public ResponseEntity<?> getAll(
+            @Parameter(description = "게시판 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e3")
+            @PathVariable("boardId") UUID boardId
+    ) {
         return ResponseEntity.ok(categoryManager.getAll(boardId));
     }
 
+    @Operation(summary = "카테고리 단건 조회", description = "특정 게시판 안의 카테고리 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "카테고리 없음")
+    })
     @GetMapping("/{categoryId}")
     public ResponseEntity<?> get(
+            @Parameter(description = "게시판 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e3")
             @PathVariable("boardId") UUID boardId,
+            @Parameter(description = "카테고리 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e4")
             @PathVariable("categoryId") UUID categoryId
     ) {
         return ResponseEntity.ok(categoryManager.get(boardId, categoryId));
     }
 
+    @Operation(summary = "카테고리 생성", description = "특정 게시판에 새 카테고리를 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "게시판 없음")
+    })
     @PostMapping
     public ResponseEntity<?> post(
+            @Parameter(description = "게시판 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e3")
             @PathVariable("boardId") UUID boardId,
             @RequestBody @Valid CategoryCreateRequest body
     ) {
@@ -45,9 +73,17 @@ public class CategoryController {
                 .body(result);
     }
 
+    @Operation(summary = "카테고리 정보 변경", description = "특정 게시판 안의 카테고리 이름과 설명을 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "변경 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "카테고리 없음")
+    })
     @PatchMapping("/{categoryId}")
     public ResponseEntity<?> patch(
+            @Parameter(description = "게시판 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e3")
             @PathVariable("boardId") UUID boardId,
+            @Parameter(description = "카테고리 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e4")
             @PathVariable("categoryId") UUID categoryId,
             @RequestBody CategoryUpdateRequest body
     ) {
@@ -55,9 +91,16 @@ public class CategoryController {
         return ResponseEntity.ok(categoryManager.update(command));
     }
 
+    @Operation(summary = "카테고리 삭제", description = "특정 게시판 안의 카테고리를 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "카테고리 없음")
+    })
     @DeleteMapping("/{categoryId}")
     public ResponseEntity<?> delete(
+            @Parameter(description = "게시판 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e3")
             @PathVariable("boardId") UUID boardId,
+            @Parameter(description = "카테고리 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e4")
             @PathVariable("categoryId") UUID categoryId
     ) {
         categoryManager.delete(new CategoryDeleteCommand(boardId, categoryId));

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/infrastructure/web/controller/PostController.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/infrastructure/web/controller/PostController.java
@@ -6,6 +6,11 @@ import com.seatliberator.seatliberator.board.application.port.in.command.PostDel
 import com.seatliberator.seatliberator.board.application.port.in.command.PostUpdateCommand;
 import com.seatliberator.seatliberator.board.infrastructure.web.request.PostCreateRequest;
 import com.seatliberator.seatliberator.board.infrastructure.web.request.PostUpdateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 import java.net.URI;
 import java.util.UUID;
 
+@Tag(name = "Posts", description = "게시판 게시글 관리 API")
 @RequestMapping("/board/{boardId}/posts")
 @RestController
 @RequiredArgsConstructor
@@ -24,17 +30,32 @@ public class PostController {
 
     // GET /board/{boardId}/posts
     // 특정 게시판에 속한 게시글 목록을 조회
+    @Operation(summary = "게시글 목록 조회", description = "특정 게시판에 속한 게시글 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "게시판 없음")
+    })
     @GetMapping
-    public ResponseEntity<?> getAll(@PathVariable("boardId") UUID boardId) {
+    public ResponseEntity<?> getAll(
+            @Parameter(description = "게시판 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e3")
+            @PathVariable("boardId") UUID boardId
+    ) {
         return ResponseEntity.ok(postManager.getAll(boardId));
     }
 
     // GET /board/{boardId}/posts/{postId}
     // 특정 게시판 안의 특정 게시글 1건을 조회
     // boardId와 postId를 함께 받는 이유는 어떤 게시판의 게시글인지 명확히 알기 이ㅜ해
+    @Operation(summary = "게시글 단건 조회", description = "특정 게시판 안의 게시글 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "게시글 없음")
+    })
     @GetMapping("/{postId}")
     public ResponseEntity<?> get(
+            @Parameter(description = "게시판 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e3")
             @PathVariable("boardId") UUID boardId,
+            @Parameter(description = "게시글 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e5")
             @PathVariable("postId") UUID postId
     ) {
         return ResponseEntity.ok(postManager.get(boardId, postId));
@@ -43,8 +64,15 @@ public class PostController {
     // POST /board/{boardId}/posts
     // 요청 JSON을 서비스가 이해하는 커맨드로 변환해서 전달
     // 생성 성공하면 201 Created + Location 헤더를 반환
+    @Operation(summary = "게시글 생성", description = "특정 게시판에 새 게시글을 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "게시판 또는 카테고리 없음")
+    })
     @PostMapping
     public ResponseEntity<?> post(
+            @Parameter(description = "게시판 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e3")
             @PathVariable("boardId") UUID boardId,
             @RequestBody @Valid PostCreateRequest body
     ) {
@@ -58,9 +86,17 @@ public class PostController {
 
     // PATCH /board/{boardId}/posts/{postId}
     // 부분 수정 API인데 title/content 중 일부만 보내도 됨 null이면 기존값유지
+    @Operation(summary = "게시글 정보 변경", description = "특정 게시판 안의 게시글 제목, 내용, 카테고리를 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "변경 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "게시글 없음")
+    })
     @PatchMapping("/{postId}")
     public ResponseEntity<?> patch(
+            @Parameter(description = "게시판 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e3")
             @PathVariable("boardId") UUID boardId,
+            @Parameter(description = "게시글 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e5")
             @PathVariable("postId") UUID postId,
             @RequestBody PostUpdateRequest body
     ) {
@@ -71,9 +107,16 @@ public class PostController {
 
     // DELETE /board/{boardId}/posts/{postId}
     // 삭제 성공 시 응답 없이 204 No Content 반환함
+    @Operation(summary = "게시글 삭제", description = "특정 게시판 안의 게시글을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "게시글 없음")
+    })
     @DeleteMapping("/{postId}")
     public ResponseEntity<?> delete(
+            @Parameter(description = "게시판 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e3")
             @PathVariable("boardId") UUID boardId,
+            @Parameter(description = "게시글 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e5")
             @PathVariable("postId") UUID postId
     ) {
         postManager.delete(new PostDeleteCommand(boardId, postId));

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/infrastructure/web/request/BoardCreateRequest.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/infrastructure/web/request/BoardCreateRequest.java
@@ -1,7 +1,12 @@
 package com.seatliberator.seatliberator.board.infrastructure.web.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "게시판 생성 요청")
 public record BoardCreateRequest(
+        @Schema(description = "게시판 이름", example = "공지사항")
         String name,
+        @Schema(description = "게시판 설명", example = "서비스 공지와 운영 안내를 게시하는 공간입니다.")
         String description
 ) {
 }

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/infrastructure/web/request/BoardUpdateRequest.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/infrastructure/web/request/BoardUpdateRequest.java
@@ -1,12 +1,17 @@
 package com.seatliberator.seatliberator.board.infrastructure.web.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.jspecify.annotations.Nullable;
 
 import java.util.UUID;
 
+@Schema(description = "게시판 정보 변경 요청")
 public record BoardUpdateRequest(
+        @Schema(description = "게시판 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e3")
         UUID boardId,
+        @Schema(description = "변경할 게시판 이름", example = "자유게시판")
         @Nullable String name,
+        @Schema(description = "변경할 게시판 설명", example = "자유롭게 의견을 나누는 공간입니다.")
         @Nullable String description
 ) {
 }

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/infrastructure/web/request/CategoryCreateRequest.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/infrastructure/web/request/CategoryCreateRequest.java
@@ -1,10 +1,14 @@
 package com.seatliberator.seatliberator.board.infrastructure.web.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "카테고리 생성 요청")
 public record CategoryCreateRequest(
+        @Schema(description = "카테고리 이름", example = "스터디 모집")
         @NotBlank(message = "Category name is required.")
         String name,
+        @Schema(description = "카테고리 설명", example = "스터디 모집 글을 모아보는 카테고리입니다.")
         String description
 ) {
 }

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/infrastructure/web/request/CategoryUpdateRequest.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/infrastructure/web/request/CategoryUpdateRequest.java
@@ -1,9 +1,13 @@
 package com.seatliberator.seatliberator.board.infrastructure.web.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.jspecify.annotations.Nullable;
 
+@Schema(description = "카테고리 정보 변경 요청")
 public record CategoryUpdateRequest(
+        @Schema(description = "변경할 카테고리 이름", example = "Q&A")
         @Nullable String name,
+        @Schema(description = "변경할 카테고리 설명", example = "서비스 이용 질문을 남기는 카테고리입니다.")
         @Nullable String description
 ) {
 }

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/infrastructure/web/request/PostCreateRequest.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/infrastructure/web/request/PostCreateRequest.java
@@ -1,15 +1,20 @@
 package com.seatliberator.seatliberator.board.infrastructure.web.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.UUID;
 
+@Schema(description = "게시글 생성 요청")
 public record PostCreateRequest(
+        @Schema(description = "게시글이 속할 카테고리 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e4")
         @NotNull(message = "Category id is required.")
         UUID categoryId,
+        @Schema(description = "게시글 제목", example = "오늘 오후 스터디 같이 하실 분")
         @NotBlank(message = "Post title is required.")
         String title,
+        @Schema(description = "게시글 본문", example = "오후 2시부터 4시까지 알고리즘 스터디를 진행합니다.")
         @NotBlank(message = "Post content is required.")
         String content
 ) {

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/infrastructure/web/request/PostUpdateRequest.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/infrastructure/web/request/PostUpdateRequest.java
@@ -1,12 +1,17 @@
 package com.seatliberator.seatliberator.board.infrastructure.web.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.jspecify.annotations.Nullable;
 
 import java.util.UUID;
 
+@Schema(description = "게시글 정보 변경 요청")
 public record PostUpdateRequest(
+        @Schema(description = "변경할 카테고리 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e4")
         @Nullable UUID categoryId,
+        @Schema(description = "변경할 게시글 제목", example = "오늘 저녁 스터디 같이 하실 분")
         @Nullable String title,
+        @Schema(description = "변경할 게시글 본문", example = "오후 7시부터 9시까지 알고리즘 스터디를 진행합니다.")
         @Nullable String content
 ) {
 }

--- a/bootstrap/resource-application-starter/src/main/java/com/seatliberator/seatliberator/bootstrap/autoconfigure/ResourceServerAuthorizeProperties.java
+++ b/bootstrap/resource-application-starter/src/main/java/com/seatliberator/seatliberator/bootstrap/autoconfigure/ResourceServerAuthorizeProperties.java
@@ -18,7 +18,7 @@ public record ResourceServerAuthorizeProperties(
 
         URI jwkSetUri,
 
-        @DefaultValue({"/error", "/actuator/prometheus", "/actuator/health", "/actuator/health/**"})
+        @DefaultValue({"/error", "/actuator/prometheus", "/actuator/health", "/actuator/health/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html"})
         @NotEmpty
         List<@NotBlank String> permits,
 

--- a/bootstrap/web-application-starter/build.gradle.kts
+++ b/bootstrap/web-application-starter/build.gradle.kts
@@ -26,4 +26,7 @@ dependencies {
     // Observability
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
+
+    // Documentation
+    api("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2")
 }

--- a/identity/identity-application/src/main/java/com/seatliberator/seatliberator/identity/infrastructure/security/authentication/method/credential/CredentialAuthenticationOpenApiConfiguration.java
+++ b/identity/identity-application/src/main/java/com/seatliberator/seatliberator/identity/infrastructure/security/authentication/method/credential/CredentialAuthenticationOpenApiConfiguration.java
@@ -1,0 +1,144 @@
+package com.seatliberator.seatliberator.identity.infrastructure.security.authentication.method.credential;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+@SuppressWarnings("unchecked")
+public class CredentialAuthenticationOpenApiConfiguration {
+    private static final String SIGN_IN_SCHEMA = "CredentialSignInRequest";
+    private static final String SIGN_UP_SCHEMA = "CredentialSignUpRequest";
+    private static final String ISSUED_TOKEN_SCHEMA = "IssuedTokenEntry";
+
+    @Bean
+    OpenApiCustomizer credentialAuthenticationOpenApiCustomizer(
+            CredentialAuthenticationConfigurationProperties properties
+    ) {
+        return openApi -> {
+            applySchemas(openApi);
+            applyCredentialPath(
+                    openApi,
+                    properties.signIn(),
+                    "이메일 로그인",
+                    "이메일과 비밀번호로 로그인하고 토큰을 발급합니다.",
+                    SIGN_IN_SCHEMA
+            );
+            applyCredentialPath(
+                    openApi,
+                    properties.signUp(),
+                    "이메일 회원가입",
+                    "닉네임, 이메일, 비밀번호로 계정을 생성하고 토큰을 발급합니다.",
+                    SIGN_UP_SCHEMA
+            );
+        };
+    }
+
+    private void applyCredentialPath(
+            OpenAPI openApi,
+            Endpoint endpoint,
+            String summary,
+            String description,
+            String requestSchemaName
+    ) {
+        var operation = new Operation()
+                .addTagsItem("Authentication")
+                .summary(summary)
+                .description(description)
+                .requestBody(jsonRequestBody(requestSchemaName))
+                .responses(new ApiResponses()
+                        .addApiResponse("200", jsonResponse("인증 성공", ISSUED_TOKEN_SCHEMA))
+                        .addApiResponse("400", new ApiResponse().description("잘못된 요청"))
+                        .addApiResponse("401", new ApiResponse().description("인증 실패")));
+
+        var item = new PathItem();
+        if ("POST".equalsIgnoreCase(endpoint.method())) {
+            item.post(operation);
+        }
+
+        paths(openApi).addPathItem(endpoint.uri(), item);
+    }
+
+    private RequestBody jsonRequestBody(String schemaName) {
+        return new RequestBody()
+                .required(true)
+                .content(new Content().addMediaType(
+                        org.springframework.http.MediaType.APPLICATION_JSON_VALUE,
+                        new MediaType().schema(ref(schemaName))
+                ));
+    }
+
+    private ApiResponse jsonResponse(String description, String schemaName) {
+        return new ApiResponse()
+                .description(description)
+                .content(new Content().addMediaType(
+                        org.springframework.http.MediaType.APPLICATION_JSON_VALUE,
+                        new MediaType().schema(ref(schemaName))
+                ));
+    }
+
+    private void applySchemas(OpenAPI openApi) {
+        components(openApi)
+                .addSchemas(SIGN_IN_SCHEMA, signInSchema())
+                .addSchemas(SIGN_UP_SCHEMA, signUpSchema())
+                .addSchemas(ISSUED_TOKEN_SCHEMA, issuedTokenSchema());
+    }
+
+    private Schema<?> signInSchema() {
+        return new ObjectSchema()
+                .description("이메일 인증 로그인 요청")
+                .addProperty("email", new StringSchema().description("로그인 이메일").example("user@example.com"))
+                .addProperty("password", new StringSchema().description("로그인 비밀번호").example("password1234!"))
+                .required(List.of("email", "password"));
+    }
+
+    private Schema<?> signUpSchema() {
+        return new ObjectSchema()
+                .description("이메일 인증 회원가입 요청")
+                .addProperty("nickname", new StringSchema().description("사용자 닉네임").example("lilamaris"))
+                .addProperty("email", new StringSchema().description("로그인에 사용할 이메일").example("user@example.com"))
+                .addProperty("password", new StringSchema().description("로그인에 사용할 비밀번호").example("password1234!"))
+                .required(List.of("nickname", "email", "password"));
+    }
+
+    private Schema<?> issuedTokenSchema() {
+        return new ObjectSchema()
+                .description("인증 성공 후 발급된 토큰")
+                .addProperty("accessToken", new StringSchema().description("API 인증에 사용할 액세스 토큰"))
+                .addProperty("refreshToken", new StringSchema().description("액세스 토큰 재발급에 사용할 리프레시 토큰"))
+                .required(List.of("accessToken", "refreshToken"));
+    }
+
+    private Schema<?> ref(String schemaName) {
+        return new Schema<>().$ref("#/components/schemas/" + schemaName);
+    }
+
+    private Components components(OpenAPI openApi) {
+        if (openApi.getComponents() == null) {
+            openApi.setComponents(new Components());
+        }
+        return openApi.getComponents();
+    }
+
+    private Paths paths(OpenAPI openApi) {
+        if (openApi.getPaths() == null) {
+            openApi.setPaths(new Paths());
+        }
+        return openApi.getPaths();
+    }
+}

--- a/identity/identity-application/src/main/java/com/seatliberator/seatliberator/identity/infrastructure/security/authentication/method/credential/request/CredentialSignInRequest.java
+++ b/identity/identity-application/src/main/java/com/seatliberator/seatliberator/identity/infrastructure/security/authentication/method/credential/request/CredentialSignInRequest.java
@@ -1,7 +1,12 @@
 package com.seatliberator.seatliberator.identity.infrastructure.security.authentication.method.credential.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "이메일 인증 로그인 요청")
 public record CredentialSignInRequest(
+        @Schema(description = "로그인 이메일", example = "user@example.com")
         String email,
+        @Schema(description = "로그인 비밀번호", example = "password1234!")
         String password
 ) {
 }

--- a/identity/identity-application/src/main/java/com/seatliberator/seatliberator/identity/infrastructure/security/authentication/method/credential/request/CredentialSignUpRequest.java
+++ b/identity/identity-application/src/main/java/com/seatliberator/seatliberator/identity/infrastructure/security/authentication/method/credential/request/CredentialSignUpRequest.java
@@ -1,8 +1,14 @@
 package com.seatliberator.seatliberator.identity.infrastructure.security.authentication.method.credential.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "이메일 인증 회원가입 요청")
 public record CredentialSignUpRequest(
+        @Schema(description = "사용자 닉네임", example = "lilamaris")
         String nickname,
+        @Schema(description = "로그인에 사용할 이메일", example = "user@example.com")
         String email,
+        @Schema(description = "로그인에 사용할 비밀번호", example = "password1234!")
         String password
 ) {
 }

--- a/identity/identity-application/src/main/java/com/seatliberator/seatliberator/identity/infrastructure/security/authentication/method/token/IssuedTokenEntry.java
+++ b/identity/identity-application/src/main/java/com/seatliberator/seatliberator/identity/infrastructure/security/authentication/method/token/IssuedTokenEntry.java
@@ -1,7 +1,12 @@
 package com.seatliberator.seatliberator.identity.infrastructure.security.authentication.method.token;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "인증 성공 후 발급된 토큰")
 public record IssuedTokenEntry(
+        @Schema(description = "API 인증에 사용할 액세스 토큰")
         String accessToken,
+        @Schema(description = "액세스 토큰 재발급에 사용할 리프레시 토큰")
         String refreshToken
 ) {
 }

--- a/identity/identity-application/src/main/java/com/seatliberator/seatliberator/jwks/infrastructure/web/controller/JwksController.java
+++ b/identity/identity-application/src/main/java/com/seatliberator/seatliberator/jwks/infrastructure/web/controller/JwksController.java
@@ -4,17 +4,23 @@ import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.seatliberator.seatliberator.jwks.application.port.in.KeyProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
 
+@Tag(name = "JWKS", description = "JWT 검증용 공개키 조회 API")
 @RestController
 @RequiredArgsConstructor
 public class JwksController {
     private final KeyProvider keyProvider;
 
+    @Operation(summary = "JWKS 조회", description = "리소스 서버가 JWT 서명을 검증할 때 사용하는 공개키 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping("/.well-known/jwks.json")
     public Map<String, Object> keys() {
         var result = keyProvider.getVerificationKeys();

--- a/notification/notification-application/src/main/java/com/seatliberator/seatliberator/notification/infrastructure/web/controller/NotificationController.java
+++ b/notification/notification-application/src/main/java/com/seatliberator/seatliberator/notification/infrastructure/web/controller/NotificationController.java
@@ -2,17 +2,27 @@ package com.seatliberator.seatliberator.notification.infrastructure.web.controll
 
 import com.seatliberator.seatliberator.identity.client.actor.ActorContextHolder;
 import com.seatliberator.seatliberator.notification.application.port.in.NotificationReader;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Notifications", description = "사용자 알림 조회 API")
 @RestController
 @RequiredArgsConstructor
 public class NotificationController {
     private final NotificationReader notificationReader;
     private final ActorContextHolder actorContextHolder;
 
+    @Operation(summary = "내 알림 조회", description = "로그인한 사용자에게 전달된 알림 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "권한 없음")
+    })
     @GetMapping("/notification")
     public ResponseEntity<?> getNotification() {
         var userId = actorContextHolder.getActor().subject();

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/infrastructure/web/controller/SeatAvailabilityController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/infrastructure/web/controller/SeatAvailabilityController.java
@@ -8,6 +8,11 @@ import com.seatliberator.seatliberator.reservation.availability.application.port
 import com.seatliberator.seatliberator.reservation.availability.application.port.in.query.FindSeatStatusesQuery;
 import com.seatliberator.seatliberator.reservation.domain.SimpleSeatLocator;
 import com.seatliberator.seatliberator.reservation.domain.SimpleTimeRange;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.Instant;
 
+@Tag(name = "Seat Availability", description = "스터디룸 좌석 가용 상태 조회 API")
 @RestController
 @RequestMapping("/rooms")
 @RequiredArgsConstructor
@@ -23,10 +29,18 @@ public class SeatAvailabilityController {
     private final FindSeatStatusesUseCase findSeatStatusesUseCase;
     private final FindSeatOccupancyRangesUseCase findSeatOccupancyRangesUseCase;
 
+    @Operation(summary = "예약 가능한 좌석 조회", description = "특정 방에서 요청한 시간대에 예약 가능한 좌석 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
     @GetMapping("/{roomId}/available-seats")
     public ResponseEntity<?> getAvailableSeats(
+            @Parameter(description = "방 ID", example = "room-1")
             @PathVariable("roomId") String roomId,
+            @Parameter(description = "조회 시작 시각", example = "2026-04-20T13:00:00Z")
             @RequestParam(name = "start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant startAt,
+            @Parameter(description = "조회 종료 시각", example = "2026-04-20T14:30:00Z")
             @RequestParam(name = "end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant endAt
     ) {
         var range = SimpleTimeRange.of(startAt, endAt);
@@ -35,10 +49,18 @@ public class SeatAvailabilityController {
         return ResponseEntity.ok(result);
     }
 
+    @Operation(summary = "좌석별 점유 상태 조회", description = "특정 방의 좌석별 예약 점유 상태를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
     @GetMapping("/{roomId}/seat-statuses")
     public ResponseEntity<?> getSeatStatuses(
+            @Parameter(description = "방 ID", example = "room-1")
             @PathVariable("roomId") String roomId,
+            @Parameter(description = "조회 시작 시각", example = "2026-04-20T13:00:00Z")
             @RequestParam(name = "start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant startAt,
+            @Parameter(description = "조회 종료 시각", example = "2026-04-20T14:30:00Z")
             @RequestParam(name = "end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant endAt
     ) {
         var range = SimpleTimeRange.of(startAt, endAt);
@@ -47,11 +69,21 @@ public class SeatAvailabilityController {
         return ResponseEntity.ok(result);
     }
 
+    @Operation(summary = "좌석 점유 구간 조회", description = "특정 좌석이 요청한 기간 안에서 실제로 점유된 시간 구간을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "좌석 없음")
+    })
     @GetMapping("/{roomId}/seats/{seatId}/occupy")
     public ResponseEntity<?> getSeatOccupiedRange(
+            @Parameter(description = "방 ID", example = "room-1")
             @PathVariable("roomId") String roomId,
+            @Parameter(description = "좌석 ID", example = "A-1")
             @PathVariable("seatId") String seatId,
+            @Parameter(description = "조회 시작 시각", example = "2026-04-20T13:00:00Z")
             @RequestParam(name = "start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant startAt,
+            @Parameter(description = "조회 종료 시각", example = "2026-04-20T14:30:00Z")
             @RequestParam(name = "end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant endAt
     ) {
         var locator = SimpleSeatLocator.of(roomId, seatId);

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/CreateReservationController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/CreateReservationController.java
@@ -4,11 +4,17 @@ import com.seatliberator.seatliberator.identity.client.actor.ActorContextHolder;
 import com.seatliberator.seatliberator.reservation.book.application.port.in.CreateReservationUseCase;
 import com.seatliberator.seatliberator.reservation.book.application.port.in.command.CreateReservationCommand;
 import com.seatliberator.seatliberator.reservation.book.infrastructure.web.request.ReservationCreateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Reservations", description = "스터디룸 좌석 예약 관련 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -17,9 +23,17 @@ public class CreateReservationController {
     private final CreateReservationUseCase createReservationUseCase;
     private final ActorContextHolder actorContextHolder;
 
+    @Operation(summary = "예약 생성", description = "특정 방의 특정 좌석에 대해서 예약을 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "예약 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "권한 없음")
+    })
     @PostMapping("/{roomId}/seats/{seatId}/reservations")
     public ResponseEntity<?> create(
+            @Parameter(description = "방 ID", example = "room-1")
             @PathVariable("roomId") String roomId,
+            @Parameter(description = "좌석 ID", example = "A-1")
             @PathVariable("seatId") String seatId,
             @RequestBody ReservationCreateRequest request
     ) {

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/ReservationController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/ReservationController.java
@@ -6,15 +6,16 @@ import com.seatliberator.seatliberator.reservation.book.application.port.in.Upda
 import com.seatliberator.seatliberator.reservation.book.application.port.in.command.CancelReservationCommand;
 import com.seatliberator.seatliberator.reservation.book.application.port.in.command.UpdateReservationCommand;
 import com.seatliberator.seatliberator.reservation.book.infrastructure.web.request.ReservationUpdateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Reservations", description = "스터디룸 좌석 예약 관련 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -25,6 +26,12 @@ public class ReservationController {
 
     private final ActorContextHolder actorContextHolder;
 
+    @Operation(summary = "예약 변경", description = "이미 생성된 기존 예약의 정보를 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "변경 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "권한 없음")
+    })
     @PutMapping
     public ResponseEntity<?> update(
             @RequestBody ReservationUpdateRequest request
@@ -43,6 +50,12 @@ public class ReservationController {
         return ResponseEntity.ok(result);
     }
 
+    @Operation(summary = "예약 취소", description = "이미 생성된 기존 예약을 취소합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "취소 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "권한 없음")
+    })
     @DeleteMapping
     public ResponseEntity<?> delete() {
         var userId = actorContextHolder.getActor().subject();

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/ReservationQueryController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/ReservationQueryController.java
@@ -5,6 +5,11 @@ import com.seatliberator.seatliberator.reservation.book.application.port.in.Find
 import com.seatliberator.seatliberator.reservation.book.application.port.in.query.FindMyReservationQuery;
 import com.seatliberator.seatliberator.reservation.domain.ReservationStatus;
 import com.seatliberator.seatliberator.reservation.domain.SimpleTimeRange;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -16,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.time.Instant;
 
+@Tag(name = "Reservations", description = "스터디룸 좌석 예약 관련 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -26,10 +32,19 @@ public class ReservationQueryController {
 
     private final ActorContextHolder actorContextHolder;
 
+    @Operation(summary = "내 예약 조회", description = "로그인한 사용자의 예약 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "권한 없음")
+    })
     @GetMapping("/me")
     public ResponseEntity<?> me(
+            @Parameter(description = "조회 시작 시각", example = "2026-04-20T14:00:00Z")
             @RequestParam(name = "start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant startAt,
+            @Parameter(description = "조회 종료 시각", example = "2026-04-20T14:00:00Z")
             @RequestParam(name = "end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant endAt,
+            @Parameter(description = "조회 대상 예약 상태")
             @RequestParam(name = "status") ReservationStatus status
     ) {
         var userId = actorContextHolder.getActor().subject();

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/request/ReservationCreateRequest.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/request/ReservationCreateRequest.java
@@ -1,9 +1,14 @@
 package com.seatliberator.seatliberator.reservation.book.infrastructure.web.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.Instant;
 
+@Schema(description = "예약 생성 요청")
 public record ReservationCreateRequest(
+        @Schema(description = "예약 시작 시간", example = "2026-01-01T13:00Z")
         Instant startAt,
+        @Schema(description = "예약 종료 시간", example = "2026-01-01T14:30Z")
         Instant endAt
 ) {
 }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/request/ReservationUpdateRequest.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/request/ReservationUpdateRequest.java
@@ -1,11 +1,18 @@
 package com.seatliberator.seatliberator.reservation.book.infrastructure.web.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.Instant;
 
+@Schema(description = "예약 변경 요청")
 public record ReservationUpdateRequest(
+        @Schema(description = "예약한 좌석의 방 ID", example = "room-1")
         String roomId,
+        @Schema(description = "예약한 좌석 ID", example = "A-1")
         String seatId,
+        @Schema(description = "예약 시작 시간", example = "2026-01-01T13:00Z")
         Instant startAt,
+        @Schema(description = "예약 종료 시간", example = "2026-01-01T14:30Z")
         Instant endAt
 ) {
 }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/seat/infrastructure/web/controller/SeatController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/seat/infrastructure/web/controller/SeatController.java
@@ -1,6 +1,5 @@
 package com.seatliberator.seatliberator.reservation.seat.infrastructure.web.controller;
 
-
 import com.seatliberator.seatliberator.reservation.seat.application.port.in.CreateSeatUseCase;
 import com.seatliberator.seatliberator.reservation.seat.application.port.in.DeleteSeatUseCase;
 import com.seatliberator.seatliberator.reservation.seat.application.port.in.UpdateSeatUseCase;
@@ -9,12 +8,18 @@ import com.seatliberator.seatliberator.reservation.seat.application.port.in.comm
 import com.seatliberator.seatliberator.reservation.seat.application.port.in.command.UpdateSeatCommand;
 import com.seatliberator.seatliberator.reservation.seat.infrastructure.web.request.SeatCreateRequest;
 import com.seatliberator.seatliberator.reservation.seat.infrastructure.web.request.SeatUpdateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
+@Tag(name = "Seats", description = "스터디룸 좌석 관련 관리 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -25,8 +30,15 @@ public class SeatController {
     private final UpdateSeatUseCase updateSeatUseCase;
     private final DeleteSeatUseCase deleteSeatUseCase;
 
+    @Operation(summary = "좌석 생성", description = "특정 방에 좌석을 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "권한 없음")
+    })
     @PostMapping("/{roomId}/seats")
     public Map<String, Boolean> create(
+            @Parameter(description = "방 ID", example = "room-1")
             @PathVariable("roomId") String roomId,
             @RequestBody SeatCreateRequest request
     ) {
@@ -36,9 +48,17 @@ public class SeatController {
         return Map.of("success", result);
     }
 
+    @Operation(summary = "좌석 위치 변경", description = "기존 좌석의 위치를 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "변경 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "권한 없음")
+    })
     @PutMapping("/{roomId}/seats/{seatId}")
     public Map<String, Boolean> update(
+            @Parameter(description = "방 ID", example = "room-1")
             @PathVariable("roomId") String roomId,
+            @Parameter(description = "좌석 ID", example = "A-1")
             @PathVariable("seatId") String seatId,
             @RequestBody SeatUpdateRequest request
     ) {
@@ -48,9 +68,17 @@ public class SeatController {
         return Map.of("success", result);
     }
 
+    @Operation(summary = "좌석 삭제", description = "좌석을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "권한 없음")
+    })
     @DeleteMapping("/{roomId}/seats/{seatId}")
     public Map<String, Boolean> delete(
+            @Parameter(description = "방 ID", example = "room-1")
             @PathVariable("roomId") String roomId,
+            @Parameter(description = "좌석 ID", example = "A-1")
             @PathVariable("seatId") String seatId
     ) {
         var command = new DeleteSeatCommand(roomId, seatId);

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/seat/infrastructure/web/request/SeatCreateRequest.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/seat/infrastructure/web/request/SeatCreateRequest.java
@@ -1,6 +1,10 @@
 package com.seatliberator.seatliberator.reservation.seat.infrastructure.web.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "좌석 생성 요청")
 public record SeatCreateRequest(
+        @Schema(description = "좌석 ID", example = "A-1")
         String seatId
 ) {
 }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/seat/infrastructure/web/request/SeatUpdateRequest.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/seat/infrastructure/web/request/SeatUpdateRequest.java
@@ -1,7 +1,12 @@
 package com.seatliberator.seatliberator.reservation.seat.infrastructure.web.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "좌석 정보 변경 요청")
 public record SeatUpdateRequest(
+        @Schema(description = "좌석이 속할 새로운 방 ID", example = "room-2")
         String newRoomId,
+        @Schema(description = "좌석의 새로운 ID", example = "B-1")
         String newSeatId
 ) {
 }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/waitlist/infrastructure/web/controller/WaitlistController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/waitlist/infrastructure/web/controller/WaitlistController.java
@@ -6,12 +6,18 @@ import com.seatliberator.seatliberator.reservation.waitlist.application.port.in.
 import com.seatliberator.seatliberator.reservation.waitlist.application.port.in.command.CancelWaitlistCommand;
 import com.seatliberator.seatliberator.reservation.waitlist.application.port.in.command.CreateWaitlistCommand;
 import com.seatliberator.seatliberator.reservation.waitlist.infrastructure.web.request.CreateWaitlistRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
+@Tag(name = "Waitlist", description = "좌석 대기열 요청 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/waitlist")
@@ -22,7 +28,12 @@ public class WaitlistController {
 
     private final ActorContextHolder actorContextHolder;
 
-    // 대기열 등록
+    @Operation(summary = "대기열 등록", description = "예약이 불가능한 좌석에 대해 대기열 요청을 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "등록 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "권한 없음")
+    })
     @PostMapping
     public ResponseEntity<Void> create(
             @RequestBody CreateWaitlistRequest request
@@ -43,9 +54,16 @@ public class WaitlistController {
         return ResponseEntity.ok().build();
     }
 
-    // 대기열 취소
+    @Operation(summary = "대기열 취소", description = "로그인한 사용자의 기존 대기열 요청을 취소합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "취소 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "대기열 요청 없음")
+    })
     @DeleteMapping("/{waitlistId}")
     public ResponseEntity<Void> cancel(
+            @Parameter(description = "대기열 요청 ID", example = "018f2d5d-6a8d-7b42-9c1a-0c7a08b1d2e3")
             @PathVariable UUID waitlistId
     ) {
         var userId = actorContextHolder.getActor().subject();

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/waitlist/infrastructure/web/request/CreateWaitlistRequest.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/waitlist/infrastructure/web/request/CreateWaitlistRequest.java
@@ -1,14 +1,21 @@
 package com.seatliberator.seatliberator.reservation.waitlist.infrastructure.web.request;
 
 import com.seatliberator.seatliberator.reservation.domain.WaitlistBehavior;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.Instant;
 
+@Schema(description = "대기열 등록 요청")
 public record CreateWaitlistRequest(
+        @Schema(description = "대기열을 등록할 방 ID", example = "room-1")
         String roomId,
+        @Schema(description = "대기열을 등록할 좌석 ID", example = "A-1")
         String seatId,
+        @Schema(description = "희망 예약 시작 시간", example = "2026-01-01T13:00Z")
         Instant startAt,
+        @Schema(description = "희망 예약 종료 시간", example = "2026-01-01T14:30Z")
         Instant endAt,
+        @Schema(description = "좌석이 비었을 때 처리 방식", example = "AUTO_CLAIM")
         WaitlistBehavior behavior
 ) {
 }


### PR DESCRIPTION
## 관련 이슈

- 없음

## 변경 사항

각 애플리케이션의 API를 Swagger UI에서 확인할 수 있도록 springdoc 의존성을 추가하고, 주요 컨트롤러와 요청/응답 스키마에 OpenAPI 설명을 보강했습니다.
이번 변경은 단순히 의존성을 추가하는 것에서 끝내지 않고, 외부에 노출되는 API 경로와 request DTO가 문서에서 같은 톤으로 읽히도록 `@Tag`, `@Operation`, `@ApiResponse`, `@Parameter`, `@Schema` 설명을 맞추는 데 초점을 두었습니다.

### springdoc 기반 문서 진입점 추가

- `web-application-starter`에 `springdoc-openapi-starter-webmvc-ui` 의존성을 추가했습니다.
- resource server 기본 permit 경로에 `/v3/api-docs/**`, `/swagger-ui/**`, `/swagger-ui.html`을 추가해 문서 진입점이 인증 필터에 막히지 않도록 했습니다.

### reservation API 문서화

- seat 생성/수정/삭제 API와 reservation 생성/수정/취소/내 예약 조회 API에 OpenAPI 설명을 추가했습니다.
- availability 조회 API와 waitlist 등록/취소 API에도 같은 톤의 summary, description, 응답 설명, path/query parameter 설명을 추가했습니다.
- reservation, seat, waitlist request DTO에 schema 설명과 예시를 추가했습니다.

### board / notification API 문서화

- board, category, post 컨트롤러의 조회/생성/수정/삭제 endpoint에 태그와 operation 설명을 추가했습니다.
- board/category/post request DTO에 schema 설명과 예시를 추가했습니다.
- notification 조회 API에 태그와 응답 설명을 추가했습니다.

### identity API 문서화

- JWKS 공개키 조회 API에 OpenAPI 설명을 추가했습니다.
- security filter 기반으로 처리되는 `/auth/sign-in`, `/auth/sign-up` endpoint가 OpenAPI 문서에 드러나도록 customizer를 추가했습니다.
- credential 로그인/회원가입 request와 토큰 발급 response 스키마에 설명을 추가했습니다.

## 배경 및 의도

API 경로가 gateway와 리소스 중심 URI 기준으로 정리되면서, 클라이언트가 실제 호출 가능한 endpoint와 요청 스키마를 한곳에서 확인할 수 있는 문서 진입점이 필요해졌습니다.
이번 변경은 각 모듈의 웹 계층에 흩어진 API 설명을 springdoc 기반 OpenAPI 문서로 모으고, 필터 기반 인증 endpoint처럼 컨트롤러 스캔만으로 드러나지 않는 경로도 명시적으로 문서화하려는 목적입니다.

## 영향

- 각 애플리케이션에서 Swagger UI와 OpenAPI JSON을 통해 API 목록과 요청 스키마를 확인할 수 있습니다.
- reservation, board, identity, notification API의 path/query parameter와 request schema 설명이 문서에 노출됩니다.
- 인증 필터가 Swagger UI와 API docs 경로를 차단하지 않습니다.

## 검증

- `./gradlew :reservation:reservation-application:test :board:board-application:test :notification:notification-application:test :identity:identity-application:test`
- `./gradlew :identity:identity-application:compileJava`