### PR TITLE
상위 Role capability 상속 반영

### DIFF
--- a/identity/identity-client/README.md
+++ b/identity/identity-client/README.md
@@ -43,6 +43,7 @@ dependencies {
 `NamespaceRoleCapabilitiesRegistry` 를 생성합니다.
 
 즉, 소비자 서비스는 자기 namespace 에 대한 capability 매핑만 정의하면 됩니다.
+`Role` enum 순서(`GUEST -> USER -> MAINTAINER -> ADMIN`)를 기준으로 상위 role은 하위 role의 capability를 자동으로 포함합니다.
 
 예:
 

--- a/identity/identity-client/docs/NAMESPACE_ROLE_CAPABILITY_EXPANSION_GUIDE.md
+++ b/identity/identity-client/docs/NAMESPACE_ROLE_CAPABILITY_EXPANSION_GUIDE.md
@@ -97,7 +97,8 @@ public class BoardRoleCapabilityConfiguration {
 ```
 
 - 동일한 role을 중복 등록하면 `NamespaceRoleCapabilitiesRegistry` 생성 시 예외가 발생한다.
-- 관리자 role이 하위 role capability를 모두 포함해야 한다면 명시적으로 상위집합으로 등록해야 한다.
+- `Role` enum 순서(`GUEST -> USER -> MAINTAINER -> ADMIN`)를 기준으로 상위 role은 하위 role capability를 자동으로 포함한다.
+- 각 role에는 해당 role에서 새로 추가되는 capability만 등록하면 된다.
 
 ## 4. JWT 변환기 연결
 

--- a/identity/identity-client/src/main/java/com/seatliberator/seatliberator/identity/client/role/NamespaceRoleCapabilitiesRegistry.java
+++ b/identity/identity-client/src/main/java/com/seatliberator/seatliberator/identity/client/role/NamespaceRoleCapabilitiesRegistry.java
@@ -5,7 +5,9 @@ import com.seatliberator.seatliberator.identity.core.role.Role;
 import com.seatliberator.seatliberator.identity.core.role.SimpleNamespaceRole;
 import com.seatliberator.seatliberator.kernel.ApplicationNamespace;
 
+import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -15,15 +17,22 @@ public class NamespaceRoleCapabilitiesRegistry {
 
     public NamespaceRoleCapabilitiesRegistry(ApplicationNamespace namespace, List<RoleCapabilities> roleCapabilitiesList) {
         this.registry = new HashMap<>();
+        var directCapabilitiesByRole = new EnumMap<Role, Set<Capability>>(Role.class);
 
         for (var roleCapabilities : roleCapabilitiesList) {
             var role = roleCapabilities.role();
             var capabilities = roleCapabilities.capabilities();
-            var namespaceRole = SimpleNamespaceRole.from(namespace, role);
-            var previous = registry.putIfAbsent(namespaceRole, capabilities);
+            var previous = directCapabilitiesByRole.putIfAbsent(role, capabilities);
             if (previous != null) throw new IllegalStateException(String.format(
                     "Duplicated role capabilities. role=%s", role.name()
             ));
+        }
+
+        var inheritedCapabilities = new LinkedHashSet<Capability>();
+        for (var role : Role.values()) {
+            inheritedCapabilities.addAll(directCapabilitiesByRole.getOrDefault(role, Set.of()));
+            var namespaceRole = SimpleNamespaceRole.from(namespace, role);
+            registry.put(namespaceRole, Set.copyOf(inheritedCapabilities));
         }
     }
 

--- a/identity/identity-client/src/test/java/com/seatliberator/seatliberator/identity/client/role/NamespaceRoleCapabilitiesRegistryTest.java
+++ b/identity/identity-client/src/test/java/com/seatliberator/seatliberator/identity/client/role/NamespaceRoleCapabilitiesRegistryTest.java
@@ -1,0 +1,72 @@
+package com.seatliberator.seatliberator.identity.client.role;
+
+import com.seatliberator.seatliberator.identity.core.role.Role;
+import com.seatliberator.seatliberator.identity.core.role.SimpleNamespaceRole;
+import com.seatliberator.seatliberator.kernel.SimpleApplicationNamespace;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Namespace Role Capabilities Registry")
+class NamespaceRoleCapabilitiesRegistryTest {
+
+    @Test
+    @DisplayName("상위 Role은 하위 Role의 capability를 함께 가진다")
+    void higher_role_inherits_lower_role_capabilities() {
+        var namespace = SimpleApplicationNamespace.of("reservation");
+        var guestCapability = new SimpleCapability("room.list", "방 목록 조회");
+        var userCapability = new SimpleCapability("booking.create", "예약 생성");
+        var maintainerCapability = new SimpleCapability("room.manage", "방 관리");
+
+        var registry = new NamespaceRoleCapabilitiesRegistry(namespace, List.of(
+                new RoleCapabilities(Role.GUEST, Set.of(guestCapability)),
+                new RoleCapabilities(Role.USER, Set.of(userCapability)),
+                new RoleCapabilities(Role.MAINTAINER, Set.of(maintainerCapability)),
+                new RoleCapabilities(Role.ADMIN, Set.of())
+        ));
+
+        assertThat(registry.resolve(namespace, Role.GUEST))
+                .containsExactlyInAnyOrder(guestCapability);
+        assertThat(registry.resolve(namespace, Role.USER))
+                .containsExactlyInAnyOrder(guestCapability, userCapability);
+        assertThat(registry.resolve(namespace, Role.MAINTAINER))
+                .containsExactlyInAnyOrder(guestCapability, userCapability, maintainerCapability);
+        assertThat(registry.resolve(namespace, Role.ADMIN))
+                .containsExactlyInAnyOrder(guestCapability, userCapability, maintainerCapability);
+    }
+
+    @Test
+    @DisplayName("NamespaceRole로 resolve할 때도 누적 capability를 반환한다")
+    void resolve_by_namespace_role_returns_inherited_capabilities() {
+        var namespace = SimpleApplicationNamespace.of("reservation");
+        var guestCapability = new SimpleCapability("room.list", "방 목록 조회");
+        var userCapability = new SimpleCapability("room.read", "방 조회");
+        var userRole = SimpleNamespaceRole.from(namespace, Role.USER);
+
+        var registry = new NamespaceRoleCapabilitiesRegistry(namespace, List.of(
+                new RoleCapabilities(Role.GUEST, Set.of(guestCapability)),
+                new RoleCapabilities(Role.USER, Set.of(userCapability))
+        ));
+
+        assertThat(registry.resolve(userRole))
+                .containsExactlyInAnyOrder(guestCapability, userCapability);
+    }
+
+    @Test
+    @DisplayName("동일 Role capability가 중복 등록되면 예외")
+    void throw_exception_when_role_capabilities_is_duplicated() {
+        var namespace = SimpleApplicationNamespace.of("reservation");
+
+        assertThatThrownBy(() -> new NamespaceRoleCapabilitiesRegistry(namespace, List.of(
+                new RoleCapabilities(Role.USER, Set.of()),
+                new RoleCapabilities(Role.USER, Set.of())
+        )))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Duplicated role capabilities. role=USER");
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- 없음

## 변경 사항

identity-client 모듈에서 Canonical Role 계층에 맞춰 capability 확장 흐름을 정리했습니다.
이번 변경은 `GUEST -> USER -> MAINTAINER -> ADMIN` 순서로 상위 Role이 하위 Role capability를 자동으로 포함하도록 맞추고, 각 서비스가 Role별 추가 capability만 등록해도 최종 권한이 계층적으로 resolve되도록 하는 데 초점을 두었습니다.

### Role capability 누적 처리

- `NamespaceRoleCapabilitiesRegistry`가 Role별 직접 capability를 먼저 수집하도록 변경했습니다.
- `Role` enum 선언 순서대로 capability를 누적해 각 Role의 최종 capability set을 구성하도록 했습니다.
- `USER`는 `GUEST`, `MAINTAINER`는 `GUEST + USER`, `ADMIN`은 하위 Role capability를 모두 포함하도록 resolve 흐름을 정리했습니다.

### RoleCapabilities 등록 방식 문서화

- README에 상위 Role이 하위 Role capability를 자동으로 포함한다는 내용을 추가했습니다.
- namespace role capability 확장 가이드에서 기존의 상위집합 직접 등록 안내를 제거했습니다.
- 각 Role에는 해당 Role에서 새로 추가되는 capability만 등록하면 된다는 기준을 문서에 반영했습니다.

### 테스트 보강

- 상위 Role이 하위 Role capability를 함께 반환하는지 검증하는 단위 테스트를 추가했습니다.
- `NamespaceRole` 기반 resolve에서도 누적 capability가 반환되는지 확인했습니다.
- 동일 Role capability 중복 등록 시 예외가 유지되는지 검증했습니다.

## 배경 및 의도

기존 `NamespaceRoleCapabilitiesRegistry`는 각 Role에 직접 등록된 capability만 반환했습니다.
하지만 Canonical Role은 `GUEST -> USER -> MAINTAINER -> ADMIN` 순서로 더 넓은 권한을 갖는다는 전제를 두고 있어, 실제 capability 확장 결과와 Role 계층 정책이 어긋나는 문제가 있었습니다.

이로 인해 `USER`가 `GUEST` 권한을 자동으로 포함하지 못하거나, `ADMIN`이 별도 capability를 직접 등록하지 않으면 하위 Role 권한을 갖지 못하는 상황이 발생할 수 있었습니다.
이번 변경은 Role 계층 정책을 registry의 resolve 단계에 반영해, 각 서비스의 `RoleCapabilities` 설정이 중복된 상위집합을 직접 선언하지 않아도 되도록 하려는 목적입니다.

## 영향

- `namespace:USER`는 같은 namespace의 `GUEST` capability까지 함께 확장됩니다.
- `namespace:MAINTAINER`, `namespace:ADMIN`은 하위 Role capability를 모두 포함합니다.
- 기존 capability scope 기반 인가 규칙은 그대로 유지됩니다.
- `RoleCapabilities` 빈은 각 Role에서 새로 부여할 capability만 선언하면 됩니다.

## 검증

- `./gradlew :identity:identity-client:test`
- `./gradlew :bootstrap:resource-application-starter:test`
- `./gradlew :reservation:reservation-application:test`