### PR TITLE
Room Seat 기본 조회 API 추가

### DIFF
--- a/identity/identity-client/README.md
+++ b/identity/identity-client/README.md
@@ -43,6 +43,7 @@ dependencies {
 `NamespaceRoleCapabilitiesRegistry` 를 생성합니다.
 
 즉, 소비자 서비스는 자기 namespace 에 대한 capability 매핑만 정의하면 됩니다.
+`Role` enum 순서(`GUEST -> USER -> MAINTAINER -> ADMIN`)를 기준으로 상위 role은 하위 role의 capability를 자동으로 포함합니다.
 
 예:
 

--- a/identity/identity-client/docs/NAMESPACE_ROLE_CAPABILITY_EXPANSION_GUIDE.md
+++ b/identity/identity-client/docs/NAMESPACE_ROLE_CAPABILITY_EXPANSION_GUIDE.md
@@ -97,7 +97,8 @@ public class BoardRoleCapabilityConfiguration {
 ```
 
 - 동일한 role을 중복 등록하면 `NamespaceRoleCapabilitiesRegistry` 생성 시 예외가 발생한다.
-- 관리자 role이 하위 role capability를 모두 포함해야 한다면 명시적으로 상위집합으로 등록해야 한다.
+- `Role` enum 순서(`GUEST -> USER -> MAINTAINER -> ADMIN`)를 기준으로 상위 role은 하위 role capability를 자동으로 포함한다.
+- 각 role에는 해당 role에서 새로 추가되는 capability만 등록하면 된다.
 
 ## 4. JWT 변환기 연결
 

--- a/identity/identity-client/src/main/java/com/seatliberator/seatliberator/identity/client/role/NamespaceRoleCapabilitiesRegistry.java
+++ b/identity/identity-client/src/main/java/com/seatliberator/seatliberator/identity/client/role/NamespaceRoleCapabilitiesRegistry.java
@@ -5,7 +5,9 @@ import com.seatliberator.seatliberator.identity.core.role.Role;
 import com.seatliberator.seatliberator.identity.core.role.SimpleNamespaceRole;
 import com.seatliberator.seatliberator.kernel.ApplicationNamespace;
 
+import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -15,15 +17,22 @@ public class NamespaceRoleCapabilitiesRegistry {
 
     public NamespaceRoleCapabilitiesRegistry(ApplicationNamespace namespace, List<RoleCapabilities> roleCapabilitiesList) {
         this.registry = new HashMap<>();
+        var directCapabilitiesByRole = new EnumMap<Role, Set<Capability>>(Role.class);
 
         for (var roleCapabilities : roleCapabilitiesList) {
             var role = roleCapabilities.role();
             var capabilities = roleCapabilities.capabilities();
-            var namespaceRole = SimpleNamespaceRole.from(namespace, role);
-            var previous = registry.putIfAbsent(namespaceRole, capabilities);
+            var previous = directCapabilitiesByRole.putIfAbsent(role, capabilities);
             if (previous != null) throw new IllegalStateException(String.format(
                     "Duplicated role capabilities. role=%s", role.name()
             ));
+        }
+
+        var inheritedCapabilities = new LinkedHashSet<Capability>();
+        for (var role : Role.values()) {
+            inheritedCapabilities.addAll(directCapabilitiesByRole.getOrDefault(role, Set.of()));
+            var namespaceRole = SimpleNamespaceRole.from(namespace, role);
+            registry.put(namespaceRole, Set.copyOf(inheritedCapabilities));
         }
     }
 

--- a/identity/identity-client/src/test/java/com/seatliberator/seatliberator/identity/client/role/NamespaceRoleCapabilitiesRegistryTest.java
+++ b/identity/identity-client/src/test/java/com/seatliberator/seatliberator/identity/client/role/NamespaceRoleCapabilitiesRegistryTest.java
@@ -1,0 +1,72 @@
+package com.seatliberator.seatliberator.identity.client.role;
+
+import com.seatliberator.seatliberator.identity.core.role.Role;
+import com.seatliberator.seatliberator.identity.core.role.SimpleNamespaceRole;
+import com.seatliberator.seatliberator.kernel.SimpleApplicationNamespace;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Namespace Role Capabilities Registry")
+class NamespaceRoleCapabilitiesRegistryTest {
+
+    @Test
+    @DisplayName("상위 Role은 하위 Role의 capability를 함께 가진다")
+    void higher_role_inherits_lower_role_capabilities() {
+        var namespace = SimpleApplicationNamespace.of("reservation");
+        var guestCapability = new SimpleCapability("room.list", "방 목록 조회");
+        var userCapability = new SimpleCapability("booking.create", "예약 생성");
+        var maintainerCapability = new SimpleCapability("room.manage", "방 관리");
+
+        var registry = new NamespaceRoleCapabilitiesRegistry(namespace, List.of(
+                new RoleCapabilities(Role.GUEST, Set.of(guestCapability)),
+                new RoleCapabilities(Role.USER, Set.of(userCapability)),
+                new RoleCapabilities(Role.MAINTAINER, Set.of(maintainerCapability)),
+                new RoleCapabilities(Role.ADMIN, Set.of())
+        ));
+
+        assertThat(registry.resolve(namespace, Role.GUEST))
+                .containsExactlyInAnyOrder(guestCapability);
+        assertThat(registry.resolve(namespace, Role.USER))
+                .containsExactlyInAnyOrder(guestCapability, userCapability);
+        assertThat(registry.resolve(namespace, Role.MAINTAINER))
+                .containsExactlyInAnyOrder(guestCapability, userCapability, maintainerCapability);
+        assertThat(registry.resolve(namespace, Role.ADMIN))
+                .containsExactlyInAnyOrder(guestCapability, userCapability, maintainerCapability);
+    }
+
+    @Test
+    @DisplayName("NamespaceRole로 resolve할 때도 누적 capability를 반환한다")
+    void resolve_by_namespace_role_returns_inherited_capabilities() {
+        var namespace = SimpleApplicationNamespace.of("reservation");
+        var guestCapability = new SimpleCapability("room.list", "방 목록 조회");
+        var userCapability = new SimpleCapability("room.read", "방 조회");
+        var userRole = SimpleNamespaceRole.from(namespace, Role.USER);
+
+        var registry = new NamespaceRoleCapabilitiesRegistry(namespace, List.of(
+                new RoleCapabilities(Role.GUEST, Set.of(guestCapability)),
+                new RoleCapabilities(Role.USER, Set.of(userCapability))
+        ));
+
+        assertThat(registry.resolve(userRole))
+                .containsExactlyInAnyOrder(guestCapability, userCapability);
+    }
+
+    @Test
+    @DisplayName("동일 Role capability가 중복 등록되면 예외")
+    void throw_exception_when_role_capabilities_is_duplicated() {
+        var namespace = SimpleApplicationNamespace.of("reservation");
+
+        assertThatThrownBy(() -> new NamespaceRoleCapabilitiesRegistry(namespace, List.of(
+                new RoleCapabilities(Role.USER, Set.of()),
+                new RoleCapabilities(Role.USER, Set.of())
+        )))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Duplicated role capabilities. role=USER");
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/application/port/in/FindRoomUseCase.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/application/port/in/FindRoomUseCase.java
@@ -1,0 +1,8 @@
+package com.seatliberator.seatliberator.reservation.room.application.port.in;
+
+import com.seatliberator.seatliberator.reservation.room.application.port.in.query.FindRoomQuery;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.result.RoomResult;
+
+public interface FindRoomUseCase {
+    RoomResult find(FindRoomQuery query);
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/application/port/in/FindSeatUseCase.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/application/port/in/FindSeatUseCase.java
@@ -1,12 +1,8 @@
 package com.seatliberator.seatliberator.reservation.room.application.port.in;
 
-import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.query.FindSeatQuery;
 import com.seatliberator.seatliberator.reservation.room.application.port.in.result.SeatResult;
 
-import java.util.List;
-
 public interface FindSeatUseCase {
-    SeatResult read(SeatLocator locator);
-
-    List<SeatResult> findAllByRoomId(String roomId);
+    SeatResult find(FindSeatQuery query);
 }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/application/port/in/ListRoomUseCase.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/application/port/in/ListRoomUseCase.java
@@ -1,0 +1,9 @@
+package com.seatliberator.seatliberator.reservation.room.application.port.in;
+
+import com.seatliberator.seatliberator.reservation.room.application.port.in.result.RoomResult;
+
+import java.util.List;
+
+public interface ListRoomUseCase {
+    List<RoomResult> list();
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/application/port/in/ListSeatUseCase.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/application/port/in/ListSeatUseCase.java
@@ -1,0 +1,10 @@
+package com.seatliberator.seatliberator.reservation.room.application.port.in;
+
+import com.seatliberator.seatliberator.reservation.room.application.port.in.query.ListSeatQuery;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.result.SeatResult;
+
+import java.util.List;
+
+public interface ListSeatUseCase {
+    List<SeatResult> list(ListSeatQuery query);
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/application/port/in/query/FindRoomQuery.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/application/port/in/query/FindRoomQuery.java
@@ -1,0 +1,6 @@
+package com.seatliberator.seatliberator.reservation.room.application.port.in.query;
+
+public record FindRoomQuery(
+        String roomId
+) {
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/application/port/in/query/FindSeatQuery.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/application/port/in/query/FindSeatQuery.java
@@ -1,0 +1,7 @@
+package com.seatliberator.seatliberator.reservation.room.application.port.in.query;
+
+public record FindSeatQuery(
+        String roomId,
+        String seatId
+) {
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/application/port/in/query/ListSeatQuery.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/application/port/in/query/ListSeatQuery.java
@@ -1,0 +1,6 @@
+package com.seatliberator.seatliberator.reservation.room.application.port.in.query;
+
+public record ListSeatQuery(
+        String roomId
+) {
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/application/port/out/RoomReader.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/application/port/out/RoomReader.java
@@ -2,10 +2,13 @@ package com.seatliberator.seatliberator.reservation.room.application.port.out;
 
 import com.seatliberator.seatliberator.reservation.domain.persistence.Room;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RoomReader {
     boolean existsByRoomId(String roomId);
 
     Optional<Room> findByRoomId(String roomId);
+
+    List<Room> findAll();
 }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/application/service/RoomQueryService.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/application/service/RoomQueryService.java
@@ -1,0 +1,37 @@
+package com.seatliberator.seatliberator.reservation.room.application.service;
+
+import com.seatliberator.seatliberator.reservation.room.application.port.in.FindRoomUseCase;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.ListRoomUseCase;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.query.FindRoomQuery;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.result.RoomResult;
+import com.seatliberator.seatliberator.reservation.room.application.port.out.RoomReader;
+import com.seatliberator.seatliberator.reservation.shared.application.exception.ReservationApplicationErrorCode;
+import com.seatliberator.seatliberator.reservation.shared.application.exception.ReservationApplicationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RoomQueryService implements
+        ListRoomUseCase,
+        FindRoomUseCase {
+    private final RoomReader reader;
+
+    @Override
+    public RoomResult find(FindRoomQuery query) {
+        return reader.findByRoomId(query.roomId())
+                .map(RoomResult::from)
+                .orElseThrow(() -> new ReservationApplicationException(ReservationApplicationErrorCode.ROOM_NOT_FOUND));
+    }
+
+    @Override
+    public List<RoomResult> list() {
+        return reader.findAll().stream()
+                .map(RoomResult::from)
+                .toList();
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/application/service/SeatQueryService.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/application/service/SeatQueryService.java
@@ -1,8 +1,12 @@
 package com.seatliberator.seatliberator.reservation.room.application.service;
 
-import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
+import com.seatliberator.seatliberator.reservation.domain.SimpleSeatLocator;
 import com.seatliberator.seatliberator.reservation.room.application.port.in.FindSeatUseCase;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.ListSeatUseCase;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.query.FindSeatQuery;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.query.ListSeatQuery;
 import com.seatliberator.seatliberator.reservation.room.application.port.in.result.SeatResult;
+import com.seatliberator.seatliberator.reservation.room.application.port.out.RoomReader;
 import com.seatliberator.seatliberator.reservation.room.application.port.out.SeatReader;
 import com.seatliberator.seatliberator.reservation.shared.application.exception.ReservationApplicationErrorCode;
 import com.seatliberator.seatliberator.reservation.shared.application.exception.ReservationApplicationException;
@@ -15,20 +19,31 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class SeatQueryService implements FindSeatUseCase {
-    private final SeatReader query;
+public class SeatQueryService implements
+        ListSeatUseCase,
+        FindSeatUseCase {
+    private final RoomReader roomReader;
+    private final SeatReader seatReader;
 
     @Override
-    public SeatResult read(SeatLocator locator) {
-        return query.findByLocator(locator)
+    public List<SeatResult> list(ListSeatQuery query) {
+        ensureRoomExists(query.roomId());
+        return seatReader.findByRoomId(query.roomId()).stream()
+                .map(SeatResult::from)
+                .toList();
+    }
+
+    @Override
+    public SeatResult find(FindSeatQuery query) {
+        ensureRoomExists(query.roomId());
+        var locator = SimpleSeatLocator.of(query.roomId(), query.seatId());
+        return seatReader.findByLocator(locator)
                 .map(SeatResult::from)
                 .orElseThrow(() -> new ReservationApplicationException(ReservationApplicationErrorCode.SEAT_NOT_FOUND));
     }
 
-    @Override
-    public List<SeatResult> findAllByRoomId(String roomId) {
-        return query.findByRoomId(roomId).stream()
-                .map(SeatResult::from)
-                .toList();
+    private void ensureRoomExists(String roomId) {
+        var exists = roomReader.existsByRoomId(roomId);
+        if (!exists) throw new ReservationApplicationException(ReservationApplicationErrorCode.ROOM_NOT_FOUND);
     }
 }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/persistence/jpa/JpaRoomPersistenceAdapter.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/persistence/jpa/JpaRoomPersistenceAdapter.java
@@ -7,6 +7,7 @@ import com.seatliberator.seatliberator.reservation.room.infrastructure.persisten
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -22,6 +23,11 @@ public class JpaRoomPersistenceAdapter implements RoomStore, RoomReader {
     @Override
     public Optional<Room> findByRoomId(String roomId) {
         return repository.findByRoomId(roomId);
+    }
+
+    @Override
+    public List<Room> findAll() {
+        return repository.findAll();
     }
 
     @Override

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/controller/RoomQueryController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/controller/RoomQueryController.java
@@ -1,0 +1,56 @@
+package com.seatliberator.seatliberator.reservation.room.infrastructure.web.controller;
+
+import com.seatliberator.seatliberator.reservation.room.application.port.in.FindRoomUseCase;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.ListRoomUseCase;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.query.FindRoomQuery;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Rooms", description = "스터디룸 방 조회 관리 API")
+@Slf4j
+@RestController
+@RequestMapping("/rooms")
+@RequiredArgsConstructor
+public class RoomQueryController {
+    private final ListRoomUseCase listRoomUseCase;
+    private final FindRoomUseCase findRoomUseCase;
+
+    @Operation(summary = "방 목록 조회", description = "방 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "권한 없음")
+    })
+    @GetMapping
+    @PreAuthorize("hasAuthority('room.list')")
+    public ResponseEntity<?> findRooms() {
+        var result = listRoomUseCase.list();
+        return ResponseEntity.ok(result);
+    }
+
+    @Operation(summary = "특정 방 조회", description = "특정 Id 방의 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "권한 없음")
+    })
+    @GetMapping("/{roomId}")
+    @PreAuthorize("hasAuthority('room.read')")
+    public ResponseEntity<?> findRoom(
+            @Parameter(description = "조회할 방 ID", example = "study-room-1")
+            @PathVariable("roomId") String roomId
+    ) {
+        var query = new FindRoomQuery(roomId);
+        var result = findRoomUseCase.find(query);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/controller/SeatQueryController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/controller/SeatQueryController.java
@@ -1,0 +1,63 @@
+package com.seatliberator.seatliberator.reservation.room.infrastructure.web.controller;
+
+import com.seatliberator.seatliberator.reservation.room.application.port.in.FindSeatUseCase;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.ListSeatUseCase;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.query.FindSeatQuery;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.query.ListSeatQuery;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Seats", description = "스터디룸 좌석 조회 관리 API")
+@Slf4j
+@RestController
+@RequestMapping("/rooms")
+@RequiredArgsConstructor
+public class SeatQueryController {
+    private final ListSeatUseCase listSeatUseCase;
+    private final FindSeatUseCase findSeatUseCase;
+
+    @Operation(summary = "좌석 목록 조회", description = "특정 방의 좌석 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "권한 없음")
+    })
+    @GetMapping("/{roomId}/seats")
+    @PreAuthorize("hasAuthority('seat.list')")
+    public ResponseEntity<?> listSeatsInRoom(
+            @Parameter(description = "조회할 방 ID", example = "study-room-1")
+            @PathVariable("roomId") String roomId
+    ) {
+        var query = new ListSeatQuery(roomId);
+        var result = listSeatUseCase.list(query);
+        return ResponseEntity.ok(result);
+    }
+
+    @Operation(summary = "좌석 조회", description = "특정 Id 좌석의 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "권한 없음")
+    })
+    @GetMapping("/{roomId}/seats/{seatId}")
+    @PreAuthorize("hasAuthority('seat.read')")
+    public ResponseEntity<?> findSeatInRoom(
+            @Parameter(description = "조회할 방 ID", example = "study-room-1")
+            @PathVariable("roomId") String roomId,
+            @Parameter(description = "조회할 좌석 ID", example = "seat-A")
+            @PathVariable("seatId") String seatId
+    ) {
+        var query = new FindSeatQuery(roomId, seatId);
+        var result = findSeatUseCase.find(query);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/shared/infrastructure/security/ReservationCapability.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/shared/infrastructure/security/ReservationCapability.java
@@ -9,9 +9,9 @@ public enum ReservationCapability implements Capability {
     ROOM_READ("room.read", "방 조회"),
     ROOM_MANAGE("room.manage", "방 관리"),
 
-    SEAT_LIST("seat.list", "자리 목록 조회"),
-    SEAT_READ("seat.read", "자리 조회"),
-    SEAT_MANAGE("seat.manage", "자리 관리"),
+    SEAT_LIST("seat.list", "좌석 목록 조회"),
+    SEAT_READ("seat.read", "좌석 조회"),
+    SEAT_MANAGE("seat.manage", "좌석 관리"),
 
     BOOKING_CREATE("booking.create", "예약 생성"),
     OWNED_BOOKING_CANCEL("owned.booking.cancel", "예약 취소"),

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/shared/infrastructure/web/advice/ReservationGlobalControllerAdvice.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/shared/infrastructure/web/advice/ReservationGlobalControllerAdvice.java
@@ -130,7 +130,7 @@ public class ReservationGlobalControllerAdvice {
 
     private HttpStatus resolveStatus(Enum<?> errorCode) {
         return switch (errorCode.name()) {
-            case "RESERVATION_NOT_FOUND", "SEAT_NOT_FOUND" -> HttpStatus.NOT_FOUND;
+            case "RESERVATION_NOT_FOUND", "SEAT_NOT_FOUND", "ROOM_NOT_FOUND" -> HttpStatus.NOT_FOUND;
             case "RESERVATION_ALREADY_EXISTS", "RESERVATION_TIME_CONFLICT" -> HttpStatus.CONFLICT;
             case "RESERVATION_READ_FORBIDDEN", "RESERVATION_VERIFY_FORBIDDEN" -> HttpStatus.FORBIDDEN;
             default -> HttpStatus.BAD_REQUEST;

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/room/application/RoomQueryServiceTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/room/application/RoomQueryServiceTest.java
@@ -1,0 +1,98 @@
+package com.seatliberator.seatliberator.reservation.room.application;
+
+import com.seatliberator.seatliberator.reservation.room.application.port.in.FindRoomUseCase;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.ListRoomUseCase;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.query.FindRoomQuery;
+import com.seatliberator.seatliberator.reservation.room.application.port.out.RoomReader;
+import com.seatliberator.seatliberator.reservation.room.application.service.RoomQueryService;
+import com.seatliberator.seatliberator.reservation.shared.application.exception.ReservationApplicationErrorCode;
+import com.seatliberator.seatliberator.reservation.shared.application.exception.ReservationApplicationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.seatliberator.seatliberator.reservation.domain.fixture.RoomFixture.createRoom;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Room Query UseCase")
+public class RoomQueryServiceTest {
+    @Mock
+    RoomReader reader;
+
+    @Nested
+    @DisplayName("List Room UseCase")
+    class ListRoomUseCaseTest {
+        ListRoomUseCase useCase;
+
+        @BeforeEach
+        void run() {
+            useCase = new RoomQueryService(reader);
+        }
+
+        @Test
+        @DisplayName("전체 방 목록을 조회한다")
+        void list_rooms() {
+            var room = createRoom();
+            when(reader.findAll()).thenReturn(List.of(room));
+
+            var result = useCase.list();
+
+            assertThat(result)
+                    .hasSize(1)
+                    .first()
+                    .extracting("roomId")
+                    .isEqualTo(room.getRoomId());
+
+            verify(reader).findAll();
+        }
+    }
+
+    @Nested
+    @DisplayName("Find Room UseCase")
+    class FindRoomUseCaseTest {
+        FindRoomUseCase useCase;
+
+        @BeforeEach
+        void run() {
+            useCase = new RoomQueryService(reader);
+        }
+
+        @Test
+        @DisplayName("roomId에 해당하는 방을 조회한다")
+        void find_room() {
+            var room = createRoom();
+            var query = new FindRoomQuery(room.getRoomId());
+            when(reader.findByRoomId(room.getRoomId())).thenReturn(Optional.of(room));
+
+            var result = useCase.find(query);
+
+            assertThat(result.roomId()).isEqualTo(room.getRoomId());
+            verify(reader).findByRoomId(room.getRoomId());
+        }
+
+        @Test
+        @DisplayName("roomId에 해당하는 방이 없으면 ROOM_NOT_FOUND 예외")
+        void throw_exception_when_room_not_found() {
+            var query = new FindRoomQuery("missing-room");
+            when(reader.findByRoomId(query.roomId())).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> useCase.find(query))
+                    .isInstanceOf(ReservationApplicationException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ReservationApplicationErrorCode.ROOM_NOT_FOUND);
+
+            verify(reader).findByRoomId(query.roomId());
+        }
+    }
+}

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/room/application/SeatQueryServiceTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/room/application/SeatQueryServiceTest.java
@@ -1,0 +1,160 @@
+package com.seatliberator.seatliberator.reservation.room.application;
+
+import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.FindSeatUseCase;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.ListSeatUseCase;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.query.FindSeatQuery;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.query.ListSeatQuery;
+import com.seatliberator.seatliberator.reservation.room.application.port.out.RoomReader;
+import com.seatliberator.seatliberator.reservation.room.application.port.out.SeatReader;
+import com.seatliberator.seatliberator.reservation.room.application.service.SeatQueryService;
+import com.seatliberator.seatliberator.reservation.shared.application.exception.ReservationApplicationErrorCode;
+import com.seatliberator.seatliberator.reservation.shared.application.exception.ReservationApplicationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.seatliberator.seatliberator.reservation.domain.fixture.RoomFixture.createRoom;
+import static com.seatliberator.seatliberator.reservation.domain.fixture.SeatFixture.create;
+import static com.seatliberator.seatliberator.reservation.domain.fixture.TestSupport.fixedClock;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Seat Query UseCase")
+public class SeatQueryServiceTest {
+    @Mock
+    RoomReader roomReader;
+
+    @Mock
+    SeatReader seatReader;
+
+    @Nested
+    @DisplayName("List Seat UseCase")
+    class ListSeatUseCaseTest {
+        ListSeatUseCase useCase;
+
+        @BeforeEach
+        void run() {
+            useCase = new SeatQueryService(roomReader, seatReader);
+        }
+
+        @Test
+        @DisplayName("roomId에 해당하는 좌석 목록을 조회한다")
+        void list_seats() {
+            var room = createRoom();
+            var seat = create(room, "seat-a", fixedClock.instant());
+            var query = new ListSeatQuery(room.getRoomId());
+
+            when(roomReader.existsByRoomId(room.getRoomId())).thenReturn(true);
+            when(seatReader.findByRoomId(room.getRoomId())).thenReturn(List.of(seat));
+
+            var result = useCase.list(query);
+
+            assertThat(result)
+                    .hasSize(1)
+                    .first()
+                    .extracting("seatId")
+                    .isEqualTo(seat.getSeatId());
+
+            verify(roomReader).existsByRoomId(room.getRoomId());
+            verify(seatReader).findByRoomId(room.getRoomId());
+        }
+
+        @Test
+        @DisplayName("roomId에 해당하는 방이 없으면 ROOM_NOT_FOUND 예외")
+        void throw_exception_when_room_not_found() {
+            var query = new ListSeatQuery("missing-room");
+
+            when(roomReader.existsByRoomId(query.roomId())).thenReturn(false);
+
+            assertThatThrownBy(() -> useCase.list(query))
+                    .isInstanceOf(ReservationApplicationException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ReservationApplicationErrorCode.ROOM_NOT_FOUND);
+
+            verify(roomReader).existsByRoomId(query.roomId());
+            verify(seatReader, never()).findByRoomId(query.roomId());
+        }
+    }
+
+    @Nested
+    @DisplayName("Find Seat UseCase")
+    class FindSeatUseCaseTest {
+        FindSeatUseCase useCase;
+
+        @BeforeEach
+        void run() {
+            useCase = new SeatQueryService(roomReader, seatReader);
+        }
+
+        @Test
+        @DisplayName("roomId와 seatId에 해당하는 좌석을 조회한다")
+        void find_seat() {
+            var room = createRoom();
+            var seat = create(room, "seat-a", fixedClock.instant());
+            var query = new FindSeatQuery(room.getRoomId(), seat.getSeatId());
+
+            when(roomReader.existsByRoomId(room.getRoomId())).thenReturn(true);
+            when(seatReader.findByLocator(any())).thenReturn(Optional.of(seat));
+
+            var result = useCase.find(query);
+
+            assertThat(result.seatId()).isEqualTo(seat.getSeatId());
+
+            var locatorCaptor = ArgumentCaptor.forClass(SeatLocator.class);
+            verify(roomReader).existsByRoomId(room.getRoomId());
+            verify(seatReader).findByLocator(locatorCaptor.capture());
+
+            var locator = locatorCaptor.getValue();
+            assertThat(locator.roomId()).isEqualTo(room.getRoomId());
+            assertThat(locator.seatId()).isEqualTo(seat.getSeatId());
+        }
+
+        @Test
+        @DisplayName("roomId에 해당하는 방이 없으면 ROOM_NOT_FOUND 예외")
+        void throw_exception_when_room_not_found() {
+            var query = new FindSeatQuery("missing-room", "seat-a");
+
+            when(roomReader.existsByRoomId(query.roomId())).thenReturn(false);
+
+            assertThatThrownBy(() -> useCase.find(query))
+                    .isInstanceOf(ReservationApplicationException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ReservationApplicationErrorCode.ROOM_NOT_FOUND);
+
+            verify(roomReader).existsByRoomId(query.roomId());
+            verify(seatReader, never()).findByLocator(any());
+        }
+
+        @Test
+        @DisplayName("seatId에 해당하는 좌석이 없으면 SEAT_NOT_FOUND 예외")
+        void throw_exception_when_seat_not_found() {
+            var room = createRoom();
+            var query = new FindSeatQuery(room.getRoomId(), "missing-seat");
+
+            when(roomReader.existsByRoomId(room.getRoomId())).thenReturn(true);
+            when(seatReader.findByLocator(any())).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> useCase.find(query))
+                    .isInstanceOf(ReservationApplicationException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ReservationApplicationErrorCode.SEAT_NOT_FOUND);
+
+            verify(roomReader).existsByRoomId(room.getRoomId());
+            verify(seatReader).findByLocator(any());
+        }
+    }
+}

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/room/infrastructure/RoomQueryControllerMvcTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/room/infrastructure/RoomQueryControllerMvcTest.java
@@ -1,0 +1,158 @@
+package com.seatliberator.seatliberator.reservation.room.infrastructure;
+
+import com.seatliberator.seatliberator.reservation.room.application.port.in.FindRoomUseCase;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.ListRoomUseCase;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.query.FindRoomQuery;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.result.RoomResult;
+import com.seatliberator.seatliberator.reservation.room.infrastructure.web.controller.RoomQueryController;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+
+import static com.seatliberator.seatliberator.reservation.domain.fixture.TestSupport.fixedClock;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RoomQueryController.class)
+@Import({RoomQueryControllerMvcTest.TestSecurityConfig.class})
+@DisplayName("Room Query Controller MVC")
+public class RoomQueryControllerMvcTest {
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    WebApplicationContext context;
+
+    @MockitoBean
+    ListRoomUseCase listRoomUseCase;
+
+    @MockitoBean
+    FindRoomUseCase findRoomUseCase;
+
+    Clock clock = fixedClock;
+
+    Instant now = clock.instant();
+
+    @BeforeEach
+    void run() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
+
+    @TestConfiguration
+    @EnableWebSecurity
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            return http
+                    .csrf(AbstractHttpConfigurer::disable)
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+                    .httpBasic(Customizer.withDefaults())
+                    .build();
+        }
+    }
+
+    @Nested
+    @DisplayName("방 목록 조회")
+    class ListRoom {
+        @Test
+        @DisplayName("인증되지 않으면 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(get("/rooms"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @WithMockUser(authorities = "other.permission")
+        @DisplayName("room.list 권한이 없으면 403")
+        void forbidden() throws Exception {
+            mockMvc.perform(get("/rooms"))
+                    .andExpect(status().isForbidden());
+
+            verify(listRoomUseCase, never()).list();
+        }
+
+        @Test
+        @WithMockUser(authorities = "room.list")
+        @DisplayName("room.list 권한이 있으면 방 목록을 조회한다")
+        void list_rooms() throws Exception {
+            var result = List.of(new RoomResult("study-room-1", now));
+            when(listRoomUseCase.list()).thenReturn(result);
+
+            mockMvc.perform(get("/rooms"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$[0].roomId").value("study-room-1"));
+
+            verify(listRoomUseCase).list();
+        }
+    }
+
+    @Nested
+    @DisplayName("방 단건 조회")
+    class FindRoom {
+        @Test
+        @DisplayName("인증되지 않으면 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(get("/rooms/{roomId}", "study-room-1"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @WithMockUser(authorities = "other.permission")
+        @DisplayName("room.read 권한이 없으면 403")
+        void forbidden() throws Exception {
+            mockMvc.perform(get("/rooms/{roomId}", "study-room-1"))
+                    .andExpect(status().isForbidden());
+
+            verify(findRoomUseCase, never()).find(any());
+        }
+
+        @Test
+        @WithMockUser(authorities = "room.read")
+        @DisplayName("room.read 권한이 있으면 path variable로 query를 만들어 유스케이스를 호출한다")
+        void find_room() throws Exception {
+            when(findRoomUseCase.find(any(FindRoomQuery.class)))
+                    .thenReturn(new RoomResult("study-room-1", now));
+
+            mockMvc.perform(get("/rooms/{roomId}", "study-room-1"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.roomId").value("study-room-1"));
+
+            var captor = ArgumentCaptor.forClass(FindRoomQuery.class);
+            verify(findRoomUseCase).find(captor.capture());
+            assertThat(captor.getValue().roomId()).isEqualTo("study-room-1");
+        }
+    }
+}

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/room/infrastructure/SeatQueryControllerMvcTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/room/infrastructure/SeatQueryControllerMvcTest.java
@@ -1,0 +1,165 @@
+package com.seatliberator.seatliberator.reservation.room.infrastructure;
+
+import com.seatliberator.seatliberator.reservation.domain.SeatStatus;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.FindSeatUseCase;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.ListSeatUseCase;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.query.FindSeatQuery;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.query.ListSeatQuery;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.result.SeatResult;
+import com.seatliberator.seatliberator.reservation.room.infrastructure.web.controller.SeatQueryController;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+
+import static com.seatliberator.seatliberator.reservation.domain.fixture.TestSupport.fixedClock;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SeatQueryController.class)
+@Import({SeatQueryControllerMvcTest.TestSecurityConfig.class})
+@DisplayName("Seat Query Controller MVC")
+public class SeatQueryControllerMvcTest {
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    WebApplicationContext context;
+
+    @MockitoBean
+    ListSeatUseCase listSeatUseCase;
+
+    @MockitoBean
+    FindSeatUseCase findSeatUseCase;
+
+    Clock clock = fixedClock;
+
+    Instant now = clock.instant();
+
+    @BeforeEach
+    void run() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
+
+    @TestConfiguration
+    @EnableWebSecurity
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            return http
+                    .csrf(AbstractHttpConfigurer::disable)
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+                    .httpBasic(Customizer.withDefaults())
+                    .build();
+        }
+    }
+
+    @Nested
+    @DisplayName("좌석 목록 조회")
+    class ListSeat {
+        @Test
+        @DisplayName("인증되지 않으면 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(get("/rooms/{roomId}/seats", "study-room-1"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @WithMockUser(authorities = "other.permission")
+        @DisplayName("seat.list 권한이 없으면 403")
+        void forbidden() throws Exception {
+            mockMvc.perform(get("/rooms/{roomId}/seats", "study-room-1"))
+                    .andExpect(status().isForbidden());
+
+            verify(listSeatUseCase, never()).list(any());
+        }
+
+        @Test
+        @WithMockUser(authorities = "seat.list")
+        @DisplayName("seat.list 권한이 있으면 path variable로 query를 만들어 유스케이스를 호출한다")
+        void list_seats() throws Exception {
+            var result = List.of(new SeatResult("seat-a", now, SeatStatus.ACTIVE, null, null));
+            when(listSeatUseCase.list(any(ListSeatQuery.class))).thenReturn(result);
+
+            mockMvc.perform(get("/rooms/{roomId}/seats", "study-room-1"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$[0].seatId").value("seat-a"));
+
+            var captor = ArgumentCaptor.forClass(ListSeatQuery.class);
+            verify(listSeatUseCase).list(captor.capture());
+            assertThat(captor.getValue().roomId()).isEqualTo("study-room-1");
+        }
+    }
+
+    @Nested
+    @DisplayName("좌석 단건 조회")
+    class FindSeat {
+        @Test
+        @DisplayName("인증되지 않으면 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(get("/rooms/{roomId}/seats/{seatId}", "study-room-1", "seat-a"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @WithMockUser(authorities = "other.permission")
+        @DisplayName("seat.read 권한이 없으면 403")
+        void forbidden() throws Exception {
+            mockMvc.perform(get("/rooms/{roomId}/seats/{seatId}", "study-room-1", "seat-a"))
+                    .andExpect(status().isForbidden());
+
+            verify(findSeatUseCase, never()).find(any());
+        }
+
+        @Test
+        @WithMockUser(authorities = "seat.read")
+        @DisplayName("seat.read 권한이 있으면 path variable로 query를 만들어 유스케이스를 호출한다")
+        void find_seat() throws Exception {
+            when(findSeatUseCase.find(any(FindSeatQuery.class)))
+                    .thenReturn(new SeatResult("seat-a", now, SeatStatus.ACTIVE, null, null));
+
+            mockMvc.perform(get("/rooms/{roomId}/seats/{seatId}", "study-room-1", "seat-a"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.seatId").value("seat-a"));
+
+            var captor = ArgumentCaptor.forClass(FindSeatQuery.class);
+            verify(findSeatUseCase).find(captor.capture());
+
+            var query = captor.getValue();
+            assertThat(query.roomId()).isEqualTo("study-room-1");
+            assertThat(query.seatId()).isEqualTo("seat-a");
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- 없음

## 변경 사항

Follow-up of #112
Base branch was changed to main after #112 was merged.

reservation 모듈에서 Room과 Seat의 기본 조회 API를 추가했습니다.
이번 변경은 Room/Seat 명령 흐름과 Room 하위 좌석 리소스 구조에 맞춰, 방 목록/단건 조회와 특정 방의 좌석 목록/단건 조회를 application port와 web controller로 분리해 제공하는 데 초점을 두었습니다.

### Room 조회 흐름 추가

- `FindRoomUseCase`, `ListRoomUseCase`와 `FindRoomQuery`를 추가했습니다.
- `RoomQueryService`를 추가해 Room 단건 조회와 전체 목록 조회를 처리하도록 했습니다.
- `RoomReader`와 JPA adapter에 전체 Room 조회 기능을 추가했습니다.
- `ROOM_NOT_FOUND`가 조회 API에서 404로 응답되도록 전역 예외 매핑을 보강했습니다.

### Seat 조회 흐름 추가

- `FindSeatUseCase`를 `FindSeatQuery` 기반 단건 조회 포트로 정리했습니다.
- `ListSeatUseCase`, `ListSeatQuery`, `FindSeatQuery`를 추가했습니다.
- `SeatQueryService`에서 Room 존재 여부를 먼저 확인한 뒤 좌석 목록과 단건을 조회하도록 했습니다.
- 없는 Room은 `ROOM_NOT_FOUND`, 없는 Seat는 `SEAT_NOT_FOUND`로 구분해 반환하도록 정리했습니다.

### Room / Seat 조회 API 연결

- `RoomQueryController`를 추가해 방 목록과 단건 조회 API를 제공했습니다.
- `SeatQueryController`를 추가해 `/rooms/{roomId}/seats` 하위 좌석 목록과 단건 조회 API를 제공했습니다.
- 조회 API별 `room.list`, `room.read`, `seat.list`, `seat.read` capability 인가를 연결했습니다.
- 좌석 capability 설명을 `자리`에서 `좌석` 표현으로 정리했습니다.

### 테스트 보강

- Room query service 테스트를 추가해 방 목록, 단건 조회와 `ROOM_NOT_FOUND` 예외를 검증했습니다.
- Seat query service 테스트를 추가해 Room 존재 확인, 좌석 목록/단건 조회, `ROOM_NOT_FOUND`와 `SEAT_NOT_FOUND` 분기를 검증했습니다.
- Room query controller MVC 테스트를 추가해 권한과 path variable 기반 query 변환을 검증했습니다.
- Seat query controller MVC 테스트를 추가해 권한과 Room 하위 좌석 조회 query 변환을 검증했습니다.

## 배경 및 의도

기존 Room/Seat 흐름은 생성, 수정, 삭제 중심으로 정리되어 있었고, 클라이언트가 방 목록이나 특정 방의 좌석 목록을 기본 리소스 형태로 조회할 수 있는 API 경계는 별도로 드러나지 않았습니다.
Room 기반 좌석 관리 흐름이 `/rooms/{roomId}/seats` 하위 리소스 구조로 정리되면서, 조회 API도 같은 경로와 application port 구조에 맞춰 분리할 필요가 생겼습니다.

이번 변경은 Room과 Seat의 조회 책임을 command 흐름과 분리하고, 조회 요청에서 없는 Room과 없는 Seat를 명확하게 구분해 클라이언트가 리소스 상태를 일관되게 해석할 수 있도록 하려는 목적입니다.

## 영향

- `GET /rooms`로 방 목록을 조회할 수 있습니다.
- `GET /rooms/{roomId}`로 특정 방을 조회할 수 있습니다.
- `GET /rooms/{roomId}/seats`로 특정 방의 좌석 목록을 조회할 수 있습니다.
- `GET /rooms/{roomId}/seats/{seatId}`로 특정 방의 좌석을 조회할 수 있습니다.
- 존재하지 않는 Room 조회는 `ROOM_NOT_FOUND` 404 응답으로 처리됩니다.
- 존재하는 Room 안에서 대상 Seat가 없으면 `SEAT_NOT_FOUND` 404 응답으로 처리됩니다.

## 검증

- `./gradlew :reservation:reservation-application:test`