### PR TITLE
identity 테스트 사용자 seed 추가 및 gateway 인증 진입점 수정

### DIFF
--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -12,17 +12,17 @@ spring:
       server:
         webflux:
           routes:
-            - id: identity-credential
+            - id: identity-authentication
               uri: http://localhost:8081
               predicates:
-                - Path=/api/v1/auth/**
+                - Path=/api/v1/auth/**,/api/v1/oauth2/**,/api/v1/login/**
               filters:
                 - RewritePath=/api/v1/?(?<segment>.*), /$\{segment}
 
-            - id: identity-oauth-jwks
+            - id: identity-jwks
               uri: http://localhost:8081
               predicates:
-                - Path=/oauth2/**,/login/**,/.well-known/jwks.json
+                - Path=/.well-known/jwks.json
 
             - id: reservation-service-route
               uri: http://localhost:8082

--- a/identity/identity-application/src/main/java/com/seatliberator/seatliberator/identity/application/seed/ApplicationSeedRunner.java
+++ b/identity/identity-application/src/main/java/com/seatliberator/seatliberator/identity/application/seed/ApplicationSeedRunner.java
@@ -1,0 +1,28 @@
+package com.seatliberator.seatliberator.identity.application.seed;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("local")
+@ConditionalOnProperty(
+        prefix = "app.seed",
+        name = "enabled",
+        havingValue = "true"
+)
+@RequiredArgsConstructor
+public class ApplicationSeedRunner implements ApplicationRunner {
+    private final UserSeeder userSeeder;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        log.info("Seed runner enabled.");
+        userSeeder.seed();
+    }
+}

--- a/identity/identity-application/src/main/java/com/seatliberator/seatliberator/identity/application/seed/UserSeeder.java
+++ b/identity/identity-application/src/main/java/com/seatliberator/seatliberator/identity/application/seed/UserSeeder.java
@@ -1,0 +1,48 @@
+package com.seatliberator.seatliberator.identity.application.seed;
+
+import com.seatliberator.seatliberator.board.api.BoardApi;
+import com.seatliberator.seatliberator.identity.application.port.in.UserRegistrar;
+import com.seatliberator.seatliberator.identity.application.port.in.command.RegistrationCommand;
+import com.seatliberator.seatliberator.identity.core.role.NamespaceRole;
+import com.seatliberator.seatliberator.identity.core.role.Role;
+import com.seatliberator.seatliberator.identity.core.role.SimpleNamespaceRole;
+import com.seatliberator.seatliberator.kernel.ApplicationNamespace;
+import com.seatliberator.seatliberator.reservation.api.ReservationApi;
+import com.seatliberator.seatliberator.role.application.port.in.RoleGrantor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Locale;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserSeeder {
+    private static final String testNicknameFormat = "test_%s";
+    private static final String testEmailFormat = "test_%s@example.com";
+    private static final String testPasswordFormat = "1234!test_%s";
+    private static final List<ApplicationNamespace> grantTargetServices = List.of(ReservationApi.NAMESPACE, BoardApi.NAMESPACE);
+
+    private final UserRegistrar userRegistrar;
+    private final RoleGrantor roleGrantor;
+
+    public void seed() {
+        for (var role : Role.values()) {
+            var roleName = role.name().toLowerCase(Locale.ROOT);
+            var nickname = String.format(testNicknameFormat, roleName);
+            var email = String.format(testEmailFormat, roleName);
+            var password = String.format(testPasswordFormat, roleName);
+            log.info("Create test user nickname={}, email={}, password={}", nickname, email, password);
+
+            var command = new RegistrationCommand.Credential(nickname, email, password);
+            var auth = userRegistrar.register(command);
+            var userId = auth.userId().toString();
+            var namespaceRoles = grantTargetServices.stream()
+                    .<NamespaceRole>map(ns -> SimpleNamespaceRole.from(ns, role))
+                    .toList();
+            roleGrantor.grantAll(userId, namespaceRoles);
+        }
+    }
+}

--- a/identity/identity-application/src/main/resources/application-local.yml
+++ b/identity/identity-application/src/main/resources/application-local.yml
@@ -1,3 +1,7 @@
+app:
+  seed:
+    enabled: true
+
 spring:
   datasource:
     url: ${LOCAL_DB_URL:jdbc:h2:mem:${spring.application.name};MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}


### PR DESCRIPTION
## 관련 이슈

- 없음

## 변경 사항

identity 모듈에서 local 프로필용 테스트 사용자 seed를 추가하고, gateway에서 identity 인증 API 진입점을 현재 라우팅 구조에 맞게 수정했습니다.
이번 변경은 로컬 개발 환경에서 바로 인증용 테스트 계정을 준비할 수 있게 하고, gateway가 identity 인증 API를 안정적으로 전달하도록 정리하는 데 초점을 두었습니다.

### local 프로필 테스트 사용자 seed 추가

- `ApplicationSeedRunner`를 추가해 앱 시작 시 seed 실행 지점을 분리했습니다.
- `UserSeeder`를 추가해 local 프로필에서 테스트 사용자 데이터를 적재하도록 했습니다.
- `application-local.yml`에 seed 실행 플래그를 연결해 로컬에서만 동작하도록 했습니다.

### gateway 인증 진입점 수정

- gateway `application.yml`의 identity 인증 API 진입 경로를 현재 구조에 맞게 조정했습니다.
- 인증 관련 요청이 잘못된 upstream으로 향하지 않도록 라우팅을 정리했습니다.

## 배경 및 의도

기존에는 로컬 환경에서 인증용 테스트 사용자를 준비하는 경로가 명시적이지 않았고, gateway 쪽 identity 인증 진입점도 실제 호출 구조와 맞춰 다시 정리할 필요가 있었습니다.
이번 변경은 로컬 개발에서 seed 준비 과정을 단순화하고, identity 인증 API의 진입점을 gateway 설정 기준으로 맞추려는 목적입니다.

## 영향

- local profile에서 앱 시작 시 테스트 사용자 seed가 실행됩니다.
- gateway의 identity 인증 요청이 현재 라우팅 구조에 맞게 전달됩니다.
- 운영 환경에는 local seed 설정이 영향을 주지 않습니다.

## 검증

- `./gradlew :identity:identity-application:test :gateway:test`