### PR TITLE
Reservation Api를 openapi 문서 친화적으로 개선

### DIFF
--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/infrastructure/web/controller/SeatAvailabilityController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/availability/infrastructure/web/controller/SeatAvailabilityController.java
@@ -6,6 +6,8 @@ import com.seatliberator.seatliberator.reservation.availability.application.port
 import com.seatliberator.seatliberator.reservation.availability.application.port.in.query.FindAvailableSeatQuery;
 import com.seatliberator.seatliberator.reservation.availability.application.port.in.query.FindOccupancyRangesQuery;
 import com.seatliberator.seatliberator.reservation.availability.application.port.in.query.FindSeatStatusesQuery;
+import com.seatliberator.seatliberator.reservation.availability.application.port.in.result.AvailableSeatResult;
+import com.seatliberator.seatliberator.reservation.availability.application.port.in.result.SeatStatusesResult;
 import com.seatliberator.seatliberator.reservation.domain.SimpleSeatLocator;
 import com.seatliberator.seatliberator.reservation.domain.SimpleTimeRange;
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,6 +21,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.Instant;
+import java.util.List;
 
 @Tag(name = "Seat Availability", description = "스터디룸 좌석 가용 상태 조회 API")
 @RestController
@@ -35,7 +38,7 @@ public class SeatAvailabilityController {
             @ApiResponse(responseCode = "400", description = "잘못된 요청")
     })
     @GetMapping("/{roomId}/available-seats")
-    public ResponseEntity<?> getAvailableSeats(
+    public ResponseEntity<List<AvailableSeatResult>> getAvailableSeats(
             @Parameter(description = "방 ID", example = "room-1")
             @PathVariable("roomId") String roomId,
             @Parameter(description = "조회 시작 시각", example = "2026-04-20T13:00:00Z")
@@ -55,7 +58,7 @@ public class SeatAvailabilityController {
             @ApiResponse(responseCode = "400", description = "잘못된 요청")
     })
     @GetMapping("/{roomId}/seat-statuses")
-    public ResponseEntity<?> getSeatStatuses(
+    public ResponseEntity<List<SeatStatusesResult>> getSeatStatuses(
             @Parameter(description = "방 ID", example = "room-1")
             @PathVariable("roomId") String roomId,
             @Parameter(description = "조회 시작 시각", example = "2026-04-20T13:00:00Z")

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/in/result/ReservationResult.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/application/port/in/result/ReservationResult.java
@@ -1,12 +1,14 @@
 package com.seatliberator.seatliberator.reservation.book.application.port.in.result;
 
+import com.seatliberator.seatliberator.reservation.domain.ReservationStatus;
 import com.seatliberator.seatliberator.reservation.domain.persistence.Reservation;
 
 public record ReservationResult(
         Long reservationId,
         String actorId,
         String roomId,
-        String seatId
+        String seatId,
+        ReservationStatus status
 ) {
     public static ReservationResult of(Reservation reservation) {
         var locator = reservation.getLocator();
@@ -14,7 +16,8 @@ public record ReservationResult(
                 reservation.getId(),
                 reservation.getUserId(),
                 locator.roomId(),
-                locator.seatId()
+                locator.seatId(),
+                reservation.getStatus()
         );
     }
 }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/CreateReservationController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/CreateReservationController.java
@@ -31,9 +31,9 @@ public class CreateReservationController {
     })
     @PostMapping("/{roomId}/seats/{seatId}/reservations")
     public ResponseEntity<?> create(
-            @Parameter(description = "방 ID", example = "room-1")
+            @Parameter(description = "방 ID", example = "study-room-1")
             @PathVariable("roomId") String roomId,
-            @Parameter(description = "좌석 ID", example = "A-1")
+            @Parameter(description = "좌석 ID", example = "A1")
             @PathVariable("seatId") String seatId,
             @RequestBody ReservationCreateRequest request
     ) {

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/CreateReservationController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/CreateReservationController.java
@@ -3,6 +3,7 @@ package com.seatliberator.seatliberator.reservation.book.infrastructure.web.cont
 import com.seatliberator.seatliberator.identity.client.actor.ActorContextHolder;
 import com.seatliberator.seatliberator.reservation.book.application.port.in.CreateReservationUseCase;
 import com.seatliberator.seatliberator.reservation.book.application.port.in.command.CreateReservationCommand;
+import com.seatliberator.seatliberator.reservation.book.application.port.in.result.ReservationResult;
 import com.seatliberator.seatliberator.reservation.book.infrastructure.web.request.ReservationCreateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -30,7 +31,7 @@ public class CreateReservationController {
             @ApiResponse(responseCode = "401", description = "권한 없음")
     })
     @PostMapping("/{roomId}/seats/{seatId}/reservations")
-    public ResponseEntity<?> create(
+    public ResponseEntity<ReservationResult> create(
             @Parameter(description = "방 ID", example = "study-room-1")
             @PathVariable("roomId") String roomId,
             @Parameter(description = "좌석 ID", example = "A1")

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/ReservationController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/ReservationController.java
@@ -5,6 +5,7 @@ import com.seatliberator.seatliberator.reservation.book.application.port.in.Canc
 import com.seatliberator.seatliberator.reservation.book.application.port.in.UpdateReservationUseCase;
 import com.seatliberator.seatliberator.reservation.book.application.port.in.command.CancelReservationCommand;
 import com.seatliberator.seatliberator.reservation.book.application.port.in.command.UpdateReservationCommand;
+import com.seatliberator.seatliberator.reservation.book.application.port.in.result.ReservationResult;
 import com.seatliberator.seatliberator.reservation.book.infrastructure.web.request.ReservationUpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -33,7 +34,7 @@ public class ReservationController {
             @ApiResponse(responseCode = "401", description = "권한 없음")
     })
     @PutMapping
-    public ResponseEntity<?> update(
+    public ResponseEntity<ReservationResult> update(
             @RequestBody ReservationUpdateRequest request
     ) {
         var userId = actorContextHolder.getActor().subject();
@@ -57,7 +58,7 @@ public class ReservationController {
             @ApiResponse(responseCode = "401", description = "권한 없음")
     })
     @DeleteMapping
-    public ResponseEntity<?> delete() {
+    public ResponseEntity<ReservationResult> delete() {
         var userId = actorContextHolder.getActor().subject();
         var command = new CancelReservationCommand(userId);
         var result = cancelReservationUseCase.cancel(command);

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/ReservationQueryController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/ReservationQueryController.java
@@ -3,6 +3,7 @@ package com.seatliberator.seatliberator.reservation.book.infrastructure.web.cont
 import com.seatliberator.seatliberator.identity.client.actor.ActorContextHolder;
 import com.seatliberator.seatliberator.reservation.book.application.port.in.FindMyReservationUseCase;
 import com.seatliberator.seatliberator.reservation.book.application.port.in.query.FindMyReservationQuery;
+import com.seatliberator.seatliberator.reservation.book.application.port.in.result.ReservationResult;
 import com.seatliberator.seatliberator.reservation.domain.ReservationStatus;
 import com.seatliberator.seatliberator.reservation.domain.SimpleTimeRange;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,12 +21,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.Instant;
+import java.util.List;
 
 @Tag(name = "Reservations", description = "스터디룸 좌석 예약 관련 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/reservation")
+@RequestMapping("/reservations")
 public class ReservationQueryController {
 
     private final FindMyReservationUseCase findMyReservationUseCase;
@@ -39,17 +41,18 @@ public class ReservationQueryController {
             @ApiResponse(responseCode = "401", description = "권한 없음")
     })
     @GetMapping("/me")
-    public ResponseEntity<?> me(
+    public ResponseEntity<List<ReservationResult>> me(
             @Parameter(description = "조회 시작 시각", example = "2026-04-20T14:00:00Z")
             @RequestParam(name = "start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant startAt,
-            @Parameter(description = "조회 종료 시각", example = "2026-04-20T14:00:00Z")
+            @Parameter(description = "조회 종료 시각", example = "2026-04-20T15:00:00Z")
             @RequestParam(name = "end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant endAt,
-            @Parameter(description = "조회 대상 예약 상태")
+            @Parameter(description = "조회 대상 예약 상태", example = "RESERVED")
             @RequestParam(name = "status") ReservationStatus status
     ) {
         var userId = actorContextHolder.getActor().subject();
         var range = SimpleTimeRange.of(startAt, endAt);
         var query = new FindMyReservationQuery(userId, range, status);
+        log.info("내 예약 조회 API 호출됨. 쿼리={}", query);
         var result = findMyReservationUseCase.find(query);
         return ResponseEntity.ok(result);
     }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/request/ReservationUpdateRequest.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/request/ReservationUpdateRequest.java
@@ -6,9 +6,9 @@ import java.time.Instant;
 
 @Schema(description = "예약 변경 요청")
 public record ReservationUpdateRequest(
-        @Schema(description = "예약한 좌석의 방 ID", example = "room-1")
+        @Schema(description = "예약한 좌석의 방 ID", example = "study-room-1")
         String roomId,
-        @Schema(description = "예약한 좌석 ID", example = "A-1")
+        @Schema(description = "예약한 좌석 ID", example = "A1")
         String seatId,
         @Schema(description = "예약 시작 시간", example = "2026-01-01T13:00Z")
         Instant startAt,

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/controller/RoomCommandController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/controller/RoomCommandController.java
@@ -4,6 +4,7 @@ import com.seatliberator.seatliberator.reservation.room.application.port.in.Crea
 import com.seatliberator.seatliberator.reservation.room.application.port.in.DeleteRoomUseCase;
 import com.seatliberator.seatliberator.reservation.room.application.port.in.UpdateRoomUseCase;
 import com.seatliberator.seatliberator.reservation.room.application.port.in.command.DeleteRoomCommand;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.result.RoomResult;
 import com.seatliberator.seatliberator.reservation.room.infrastructure.web.request.CreateRoomRequest;
 import com.seatliberator.seatliberator.reservation.room.infrastructure.web.request.UpdateRoomRequest;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,7 +37,7 @@ public class RoomCommandController {
             @ApiResponse(responseCode = "401", description = "권한 없음")
     })
     @PostMapping
-    public ResponseEntity<?> createRoom(
+    public ResponseEntity<RoomResult> createRoom(
             @Valid @RequestBody CreateRoomRequest request
     ) {
         var command = request.toCommand();
@@ -51,7 +52,7 @@ public class RoomCommandController {
             @ApiResponse(responseCode = "401", description = "권한 없음")
     })
     @PutMapping("/{roomId}")
-    public ResponseEntity<?> updateRoomId(
+    public ResponseEntity<RoomResult> updateRoomId(
             @Parameter(description = "변경할 방 ID", example = "study-room-1")
             @PathVariable("roomId") String roomId,
             @Valid @RequestBody UpdateRoomRequest request
@@ -68,7 +69,7 @@ public class RoomCommandController {
             @ApiResponse(responseCode = "401", description = "권한 없음")
     })
     @DeleteMapping("/{roomId}")
-    public ResponseEntity<?> deleteRoom(
+    public ResponseEntity<Void> deleteRoom(
             @Parameter(description = "삭제할 방 ID", example = "study-room-1")
             @PathVariable("roomId") String roomId
     ) {

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/controller/RoomQueryController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/controller/RoomQueryController.java
@@ -3,6 +3,7 @@ package com.seatliberator.seatliberator.reservation.room.infrastructure.web.cont
 import com.seatliberator.seatliberator.reservation.room.application.port.in.FindRoomUseCase;
 import com.seatliberator.seatliberator.reservation.room.application.port.in.ListRoomUseCase;
 import com.seatliberator.seatliberator.reservation.room.application.port.in.query.FindRoomQuery;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.result.RoomResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -16,6 +17,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @Tag(name = "Rooms", description = "스터디룸 방 조회 관리 API")
 @Slf4j
@@ -33,7 +36,7 @@ public class RoomQueryController {
     })
     @GetMapping
     @PreAuthorize("hasAuthority('room.list')")
-    public ResponseEntity<?> findRooms() {
+    public ResponseEntity<List<RoomResult>> findRooms() {
         var result = listRoomUseCase.list();
         return ResponseEntity.ok(result);
     }
@@ -45,7 +48,7 @@ public class RoomQueryController {
     })
     @GetMapping("/{roomId}")
     @PreAuthorize("hasAuthority('room.read')")
-    public ResponseEntity<?> findRoom(
+    public ResponseEntity<RoomResult> findRoom(
             @Parameter(description = "조회할 방 ID", example = "study-room-1")
             @PathVariable("roomId") String roomId
     ) {

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/controller/SeatCommandController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/controller/SeatCommandController.java
@@ -37,7 +37,7 @@ public class SeatCommandController {
     })
     @PostMapping("/{roomId}/seats")
     public ResponseEntity<?> createSeat(
-            @Parameter(description = "방 ID", example = "room-1")
+            @Parameter(description = "방 ID", example = "study-room-1")
             @PathVariable("roomId") String roomId,
             @RequestBody SeatCreateRequest request
     ) {
@@ -55,9 +55,9 @@ public class SeatCommandController {
     })
     @PutMapping("/{roomId}/seats/{seatId}/id")
     public ResponseEntity<?> updateSeatId(
-            @Parameter(description = "방 ID", example = "room-1")
+            @Parameter(description = "방 ID", example = "study-room-1")
             @PathVariable("roomId") String roomId,
-            @Parameter(description = "좌석 ID", example = "A-1")
+            @Parameter(description = "좌석 ID", example = "A1")
             @PathVariable("seatId") String seatId,
             @RequestBody SeatUpdateRequest request
     ) {
@@ -75,9 +75,9 @@ public class SeatCommandController {
     })
     @DeleteMapping("/{roomId}/seats/{seatId}")
     public ResponseEntity<?> deleteSeat(
-            @Parameter(description = "방 ID", example = "room-1")
+            @Parameter(description = "방 ID", example = "study-room-1")
             @PathVariable("roomId") String roomId,
-            @Parameter(description = "좌석 ID", example = "A-1")
+            @Parameter(description = "좌석 ID", example = "A1")
             @PathVariable("seatId") String seatId
     ) {
         var command = new DeleteSeatCommand(roomId, seatId);

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/controller/SeatCommandController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/controller/SeatCommandController.java
@@ -6,6 +6,7 @@ import com.seatliberator.seatliberator.reservation.room.application.port.in.Upda
 import com.seatliberator.seatliberator.reservation.room.application.port.in.command.CreateSeatCommand;
 import com.seatliberator.seatliberator.reservation.room.application.port.in.command.DeleteSeatCommand;
 import com.seatliberator.seatliberator.reservation.room.application.port.in.command.UpdateSeatCommand;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.result.SeatResult;
 import com.seatliberator.seatliberator.reservation.room.infrastructure.web.request.SeatCreateRequest;
 import com.seatliberator.seatliberator.reservation.room.infrastructure.web.request.SeatUpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,7 +37,7 @@ public class SeatCommandController {
             @ApiResponse(responseCode = "401", description = "권한 없음")
     })
     @PostMapping("/{roomId}/seats")
-    public ResponseEntity<?> createSeat(
+    public ResponseEntity<SeatResult> createSeat(
             @Parameter(description = "방 ID", example = "study-room-1")
             @PathVariable("roomId") String roomId,
             @RequestBody SeatCreateRequest request
@@ -54,7 +55,7 @@ public class SeatCommandController {
             @ApiResponse(responseCode = "401", description = "권한 없음")
     })
     @PutMapping("/{roomId}/seats/{seatId}/id")
-    public ResponseEntity<?> updateSeatId(
+    public ResponseEntity<SeatResult> updateSeatId(
             @Parameter(description = "방 ID", example = "study-room-1")
             @PathVariable("roomId") String roomId,
             @Parameter(description = "좌석 ID", example = "A1")
@@ -74,7 +75,7 @@ public class SeatCommandController {
             @ApiResponse(responseCode = "401", description = "권한 없음")
     })
     @DeleteMapping("/{roomId}/seats/{seatId}")
-    public ResponseEntity<?> deleteSeat(
+    public ResponseEntity<Void> deleteSeat(
             @Parameter(description = "방 ID", example = "study-room-1")
             @PathVariable("roomId") String roomId,
             @Parameter(description = "좌석 ID", example = "A1")

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/controller/SeatQueryController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/controller/SeatQueryController.java
@@ -53,7 +53,7 @@ public class SeatQueryController {
     public ResponseEntity<?> findSeatInRoom(
             @Parameter(description = "조회할 방 ID", example = "study-room-1")
             @PathVariable("roomId") String roomId,
-            @Parameter(description = "조회할 좌석 ID", example = "seat-A")
+            @Parameter(description = "조회할 좌석 ID", example = "A1")
             @PathVariable("seatId") String seatId
     ) {
         var query = new FindSeatQuery(roomId, seatId);

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/controller/SeatQueryController.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/controller/SeatQueryController.java
@@ -4,6 +4,7 @@ import com.seatliberator.seatliberator.reservation.room.application.port.in.Find
 import com.seatliberator.seatliberator.reservation.room.application.port.in.ListSeatUseCase;
 import com.seatliberator.seatliberator.reservation.room.application.port.in.query.FindSeatQuery;
 import com.seatliberator.seatliberator.reservation.room.application.port.in.query.ListSeatQuery;
+import com.seatliberator.seatliberator.reservation.room.application.port.in.result.SeatResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -17,6 +18,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @Tag(name = "Seats", description = "스터디룸 좌석 조회 관리 API")
 @Slf4j
@@ -34,7 +37,7 @@ public class SeatQueryController {
     })
     @GetMapping("/{roomId}/seats")
     @PreAuthorize("hasAuthority('seat.list')")
-    public ResponseEntity<?> listSeatsInRoom(
+    public ResponseEntity<List<SeatResult>> listSeatsInRoom(
             @Parameter(description = "조회할 방 ID", example = "study-room-1")
             @PathVariable("roomId") String roomId
     ) {
@@ -50,7 +53,7 @@ public class SeatQueryController {
     })
     @GetMapping("/{roomId}/seats/{seatId}")
     @PreAuthorize("hasAuthority('seat.read')")
-    public ResponseEntity<?> findSeatInRoom(
+    public ResponseEntity<SeatResult> findSeatInRoom(
             @Parameter(description = "조회할 방 ID", example = "study-room-1")
             @PathVariable("roomId") String roomId,
             @Parameter(description = "조회할 좌석 ID", example = "A1")

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/request/SeatCreateRequest.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/request/SeatCreateRequest.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "좌석 생성 요청")
 public record SeatCreateRequest(
-        @Schema(description = "좌석 ID", example = "A-1")
+        @Schema(description = "좌석 ID", example = "A1")
         String seatId
 ) {
 }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/request/SeatUpdateRequest.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/request/SeatUpdateRequest.java
@@ -4,9 +4,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "좌석 정보 변경 요청")
 public record SeatUpdateRequest(
-        @Schema(description = "좌석이 속할 새로운 방 ID", example = "room-2")
+        @Schema(description = "좌석이 속할 새로운 방 ID", example = "study-room-2")
         String newRoomId,
-        @Schema(description = "좌석의 새로운 ID", example = "B-1")
+        @Schema(description = "좌석의 새로운 ID", example = "A2")
         String newSeatId
 ) {
 }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/request/UpdateRoomRequest.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/room/infrastructure/web/request/UpdateRoomRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "방 정보 변경 요청")
 public record UpdateRoomRequest(
-        @Schema(description = "새로운 방 ID", example = "new-study-room-1")
+        @Schema(description = "새로운 방 ID", example = "study-room-2")
         @NotBlank String newRoomId
 ) {
     public UpdateRoomCommand toCommand(String oldRoomId) {

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/shared/application/seed/RoomSeeder.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/shared/application/seed/RoomSeeder.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class RoomSeeder {
     public static final String roomIdPrefix = "study-room";
     public static final Integer roomNumber = 5;
-    public static final String seatIdPrefix = "seat";
+    public static final String seatIdPrefix = "A";
     public static final Integer seatNumber = 10;
 
     private final RoomStore roomStore;
@@ -46,7 +46,7 @@ public class RoomSeeder {
 
     private void seedSeat(Room room) {
         for (int i = 0; i < seatNumber; i++) {
-            var seatId = String.format("%s-%s", seatIdPrefix, i);
+            var seatId = String.format("%s%s", seatIdPrefix, i);
             var seat = Seat.of(room, seatId, clock.instant());
             seatStore.save(seat);
         }

--- a/reservation/reservation-application/src/main/resources/application-local.yml
+++ b/reservation/reservation-application/src/main/resources/application-local.yml
@@ -4,6 +4,10 @@ seatliberator:
       authorize:
         jwk-set-uri: ${LOCAL_JWKS_BASE_URL:http://localhost:8080}/.well-known/jwks.json
 
+app:
+  seed:
+    enabled: true
+
 spring:
   datasource:
     url: ${LOCAL_DB_URL:jdbc:h2:mem:${spring.application.name};MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/ReservationControllerTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/book/infrastructure/web/controller/ReservationControllerTest.java
@@ -54,7 +54,7 @@ public class ReservationControllerTest {
                 .willReturn(List.of());
 
         // when
-        mockMvc.perform(get("/reservation/me")
+        mockMvc.perform(get("/reservations/me")
                 .queryParam("start", startAt.toString())
                 .queryParam("end", endAt.toString())
                 .queryParam("status", ReservationStatus.RESERVED.name())
@@ -86,7 +86,7 @@ public class ReservationControllerTest {
                 .willReturn(result);
 
         // when & then
-        mockMvc.perform(get("/reservation/me")
+        mockMvc.perform(get("/reservations/me")
                         .queryParam("start", startAt.toString())
                         .queryParam("end", endAt.toString())
                         .queryParam("status", ReservationStatus.RESERVED.name())
@@ -106,7 +106,7 @@ public class ReservationControllerTest {
         given(actorContextHolder.getActor()).willReturn(actor);
 
         // when & then
-        mockMvc.perform(get("/reservation/me")
+        mockMvc.perform(get("/reservations/me")
                         .queryParam("start", startAt.toString())
                         .queryParam("end", endAt.toString())
                         .queryParam("status", "INVALID_STATUS"))
@@ -121,7 +121,7 @@ public class ReservationControllerTest {
         given(actorContextHolder.getActor()).willReturn(actor);
 
         // when & then
-        mockMvc.perform(get("/reservation/me")
+        mockMvc.perform(get("/reservations/me")
                         .queryParam("start", "not-a-date")
                         .queryParam("end", "2026-04-14T12:00:00Z")
                         .queryParam("status", ReservationStatus.RESERVED.name()))
@@ -136,7 +136,7 @@ public class ReservationControllerTest {
         given(actorContextHolder.getActor()).willReturn(actor);
 
         // when & then
-        mockMvc.perform(get("/reservation/me")
+        mockMvc.perform(get("/reservations/me")
                         .queryParam("start", "2026-04-14T10:00:00Z")
                         .queryParam("status", ReservationStatus.RESERVED.name()))
                 .andExpect(status().isBadRequest());


### PR DESCRIPTION
## 관련 이슈

- 없음

## 변경 사항

- `:reservation:reservation-application` 모듈의 컨트롤러 메서드의 `ResponseEntity` 반환 타입에서 와일드카드 제네릭 대신 구체 타입을 명시했습니다.

- `Room`, `Seat`, `Reservation` API 관련 요청 스키마의 `example` 값을 일관성 있게 변경했습니다.

- 일부 API의 진입점이 일치하지 않는 부분을 수정했습니다. (내 예약 조회 API만 `/reservation`으로 시작)

## 배경 및 의도

기존 컨트롤러 메서드 중 와일드카드 제네릭을 사용하는 메서드는 `springdoc-openapi` 에 의한 문서화 과정에서 응답 스키마가 제대로 표현되지 않았습니다.
이 상태에서는 Apidog와 같이 openapi 스펙의 문서를 import 할 수 있는 서드파티 프로그램에서 응답 스키마 검증 기능 등을 활용할 수 없는 문제가 있었습니다.

따라서 이번 변경에서는 응답 스키마 또한 문서화 가능하도록 변경하여 해당 API 문서를 활용하는 외부 프로그램에서도 응답 스키마를 적절히 추론할 수 있도록 개선했습니다.

## 영향

- `reservation` 애플리케이션의 API 문서에서 응답 스키마를 확인할 수 있습니다.
- 다른 애플리케이션(`board`, `notification`, `identity`)은 아직 적용되지 않았습니다.

## 검증

- `./gradlew :reservation:reservation-application:test :gateway:test`