### PR TITLE
Reservation Api 에러 응답 스키마 문서화

### DIFF
--- a/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/infrastructure/web/shared/openapi/ReservationProblemDetailOpenApiConfiguration.java
+++ b/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/infrastructure/web/shared/openapi/ReservationProblemDetailOpenApiConfiguration.java
@@ -1,0 +1,99 @@
+package com.seatliberator.seatliberator.reservation.infrastructure.web.shared.openapi;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class ReservationProblemDetailOpenApiConfiguration {
+    static final String PROBLEM_DETAIL_SCHEMA = "ProblemDetail";
+    static final String PROBLEM_DETAIL_REF = "#/components/schemas/" + PROBLEM_DETAIL_SCHEMA;
+    static final String PROBLEM_DETAIL_MEDIA_TYPE = "application/problem+json";
+
+    @Bean
+    OpenApiCustomizer reservationProblemDetailSchemaCustomizer() {
+        return openApi -> {
+            var components = openApi.getComponents();
+            if (components == null) {
+                components = new Components();
+                openApi.setComponents(components);
+            }
+
+            components.addSchemas(PROBLEM_DETAIL_SCHEMA, problemDetailSchema());
+        };
+    }
+
+    @Bean
+    OperationCustomizer reservationProblemDetailResponseCustomizer() {
+        return (operation, handlerMethod) -> {
+            var responses = operation.getResponses();
+            if (responses == null) return operation;
+
+            responses.forEach((responseCode, response) -> {
+                if (isErrorResponseCode(responseCode)) {
+                    applyProblemDetailContent(response);
+                }
+            });
+
+            return operation;
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Schema<?> problemDetailSchema() {
+        return new ObjectSchema()
+                .name(PROBLEM_DETAIL_SCHEMA)
+                .description("RFC 9457 Problem Detail error response")
+                .addProperty("type", new StringSchema()
+                        .format("uri")
+                        .description("문제 유형을 식별하는 URI")
+                        .example("https://seatliberator/errors/bad-request"))
+                .addProperty("title", new StringSchema()
+                        .description("에러를 식별하는 짧은 제목")
+                        .example("BAD_REQUEST"))
+                .addProperty("status", new IntegerSchema()
+                        .format("int32")
+                        .description("HTTP 상태 코드")
+                        .example(400))
+                .addProperty("detail", new StringSchema()
+                        .description("에러 상세 메시지")
+                        .example("잘못된 요청입니다."))
+                .addProperty("instance", new StringSchema()
+                        .format("uri")
+                        .description("문제가 발생한 요청 URI")
+                        .example("/reservation"))
+                .addProperty("code", new StringSchema()
+                        .description("애플리케이션 에러 코드")
+                        .example("BAD_REQUEST"))
+                .required(List.of("type", "title", "status", "detail", "code"));
+    }
+
+    private static void applyProblemDetailContent(ApiResponse response) {
+        var content = response.getContent();
+        if (content == null) {
+            content = new Content();
+            response.setContent(content);
+        }
+
+        content.addMediaType(PROBLEM_DETAIL_MEDIA_TYPE, new MediaType()
+                .schema(new Schema<>().$ref(PROBLEM_DETAIL_REF)));
+    }
+
+    private static boolean isErrorResponseCode(String responseCode) {
+        if (responseCode == null || responseCode.isBlank()) return false;
+        if ("default".equals(responseCode)) return true;
+
+        return responseCode.charAt(0) == '4' || responseCode.charAt(0) == '5';
+    }
+}

--- a/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/infrastructure/web/shared/openapi/ReservationProblemDetailOpenApiConfigurationTest.java
+++ b/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/infrastructure/web/shared/openapi/ReservationProblemDetailOpenApiConfigurationTest.java
@@ -1,0 +1,65 @@
+package com.seatliberator.seatliberator.reservation.infrastructure.web.shared.openapi;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.seatliberator.seatliberator.reservation.infrastructure.web.shared.openapi.ReservationProblemDetailOpenApiConfiguration.PROBLEM_DETAIL_MEDIA_TYPE;
+import static com.seatliberator.seatliberator.reservation.infrastructure.web.shared.openapi.ReservationProblemDetailOpenApiConfiguration.PROBLEM_DETAIL_REF;
+import static com.seatliberator.seatliberator.reservation.infrastructure.web.shared.openapi.ReservationProblemDetailOpenApiConfiguration.PROBLEM_DETAIL_SCHEMA;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Reservation ProblemDetail OpenAPI Configuration")
+class ReservationProblemDetailOpenApiConfigurationTest {
+    private final ReservationProblemDetailOpenApiConfiguration configuration =
+            new ReservationProblemDetailOpenApiConfiguration();
+
+    @Test
+    @DisplayName("ProblemDetail schema를 OpenAPI components에 등록한다")
+    @SuppressWarnings("unchecked")
+    void register_problem_detail_schema() {
+        var openApi = new OpenAPI();
+
+        configuration.reservationProblemDetailSchemaCustomizer().customise(openApi);
+
+        var schema = openApi.getComponents().getSchemas().get(PROBLEM_DETAIL_SCHEMA);
+
+        assertThat(schema).isNotNull();
+        assertThat(schema.getProperties())
+                .containsKeys("type", "title", "status", "detail", "instance", "code");
+        assertThat(schema.getRequired())
+                .containsExactly("type", "title", "status", "detail", "code");
+    }
+
+    @Test
+    @DisplayName("4xx, 5xx 응답에 ProblemDetail content를 추가한다")
+    void apply_problem_detail_content_to_error_responses() {
+        var operation = new Operation()
+                .responses(new ApiResponses()
+                        .addApiResponse("200", new ApiResponse().description("조회 성공"))
+                        .addApiResponse("400", new ApiResponse().description("잘못된 요청"))
+                        .addApiResponse("500", new ApiResponse().description("서버 오류")));
+
+        configuration.reservationProblemDetailResponseCustomizer()
+                .customize(operation, null);
+
+        var success = operation.getResponses().get("200");
+        var badRequest = operation.getResponses().get("400");
+        var internalServerError = operation.getResponses().get("500");
+
+        assertThat(success.getContent()).isNull();
+        assertProblemDetailResponse(badRequest);
+        assertProblemDetailResponse(internalServerError);
+    }
+
+    private static void assertProblemDetailResponse(ApiResponse response) {
+        var problemDetail = response.getContent().get(PROBLEM_DETAIL_MEDIA_TYPE);
+
+        assertThat(problemDetail).isNotNull();
+        assertThat(problemDetail.getSchema().get$ref())
+                .isEqualTo(PROBLEM_DETAIL_REF);
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- 없음

## 변경 사항

- `:reservation:reservation-web-mvc` 모듈의 OpenAPI components에 `ProblemDetail` 스키마를 등록했습니다.

- 기존 `@ApiResponse`에 선언된 `4xx`, `5xx`, `default` 응답에 `application/problem+json` content와 `ProblemDetail` schema reference가 자동으로 추가되도록 했습니다.

- `ProblemDetail` 스키마에는 `type`, `title`, `status`, `detail`, `instance`, `code` 필드가 표현되도록 정리했습니다.

- OpenAPI customizer가 `ProblemDetail` 스키마를 등록하고 에러 응답 content를 보강하는 동작을 단위 테스트로 검증했습니다.

## 배경 및 의도

현재 reservation web-mvc 모듈은 global controller advice에서 에러 응답을 Spring `ProblemDetail`로 반환하고 있습니다.
하지만 기존 OpenAPI 문서에서는 에러 응답 본문이 `ProblemDetail` 형태라는 점과 실제 응답에 포함되는 필드가 드러나지 않았습니다.

이 상태에서는 Apidog와 같이 openapi 스펙을 import하는 도구에서 에러 응답 스키마를 확인하거나 검증하기 어려운 문제가 있었습니다.
따라서 런타임 응답은 기존 `ProblemDetail`을 유지하면서, OpenAPI 문서에 에러 응답 구조가 표현되도록 개선했습니다.

## 영향

- `reservation` 애플리케이션의 API 문서에서 에러 응답 스키마를 확인할 수 있습니다.
- 기존 controller advice의 런타임 응답 형식은 변경하지 않습니다.
- 기존 컨트롤러의 `@ApiResponse` 선언을 개별적으로 수정하지 않고, OpenAPI customizer를 통해 공통 에러 응답 content를 보강합니다.
- 다른 애플리케이션(`board`, `notification`, `identity`)은 아직 적용되지 않았습니다.

## 검증

- `./gradlew :reservation:reservation-web-mvc:compileJava :reservation:reservation-web-mvc:compileTestJava :reservation:reservation-web-mvc:test`