### PR TITLE
Reservation 도메인 ID를 UUID로 전환

### DIFF
--- a/reservation/reservation-application/build.gradle.kts
+++ b/reservation/reservation-application/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
 
     implementation(project(":bootstrap:application-starter"))
 
+    testImplementation(project(":kernel:kernel-test"))
     testImplementation(testFixtures(project(":reservation:reservation-domain")))
     testImplementation(testFixtures(project(":identity:identity-core")))
 }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/availability/port/in/result/AvailableSeatResult.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/availability/port/in/result/AvailableSeatResult.java
@@ -2,8 +2,10 @@ package com.seatliberator.seatliberator.reservation.application.availability.por
 
 import com.seatliberator.seatliberator.reservation.domain.persistence.Seat;
 
+import java.util.UUID;
+
 public record AvailableSeatResult(
-        Long id,
+        UUID id,
         String roomId,
         String seatId
 ) {

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/port/in/result/ReservationResult.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/port/in/result/ReservationResult.java
@@ -4,9 +4,10 @@ import com.seatliberator.seatliberator.reservation.domain.ReservationStatus;
 import com.seatliberator.seatliberator.reservation.domain.persistence.Reservation;
 
 import java.time.Instant;
+import java.util.UUID;
 
 public record ReservationResult(
-        Long reservationId,
+        UUID reservationId,
         String actorId,
         String roomId,
         String seatId,

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/port/out/ReservationReader.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/port/out/ReservationReader.java
@@ -8,9 +8,10 @@ import com.seatliberator.seatliberator.reservation.domain.persistence.Reservatio
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface ReservationReader {
-    Optional<Reservation> findById(Long id);
+    Optional<Reservation> findById(UUID id);
 
     Optional<Reservation> findByUserId(String userId);
 

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/port/out/criteria/ReservationFilter.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/port/out/criteria/ReservationFilter.java
@@ -5,10 +5,11 @@ import com.seatliberator.seatliberator.reservation.domain.ReservationStatus;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 
 public record ReservationFilter(
         Set<String> userIds,
-        Set<Long> excludedIds,
+        Set<UUID> excludedIds,
         Set<ReservationStatus> statuses
 ) {
     public ReservationFilter {
@@ -29,11 +30,11 @@ public record ReservationFilter(
         return new ReservationFilter(Set.of(userIds), excludedIds, statuses);
     }
 
-    public ReservationFilter withExcludeIds(Collection<Long> ids) {
+    public ReservationFilter withExcludeIds(Collection<UUID> ids) {
         return new ReservationFilter(userIds, Set.copyOf(ids), statuses);
     }
 
-    public ReservationFilter withExcludeIds(Long... ids) {
+    public ReservationFilter withExcludeIds(UUID... ids) {
         return new ReservationFilter(userIds, Set.of(ids), statuses);
     }
 

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/room/port/out/criteria/SeatExclusion.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/room/port/out/criteria/SeatExclusion.java
@@ -1,18 +1,15 @@
 package com.seatliberator.seatliberator.reservation.application.room.port.out.criteria;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
 public record SeatExclusion(
-        Set<Long> ids
+        Set<UUID> ids
 ) {
     public SeatExclusion {
         Objects.requireNonNull(ids);
     }
 
-    public static SeatExclusion of(Collection<Long> ids) {
+    public static SeatExclusion of(Collection<UUID> ids) {
         return new SeatExclusion(new HashSet<>(ids));
     }
 

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/usage/port/in/command/UseReservationCommand.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/usage/port/in/command/UseReservationCommand.java
@@ -2,8 +2,10 @@ package com.seatliberator.seatliberator.reservation.application.usage.port.in.co
 
 import com.seatliberator.seatliberator.identity.core.actor.Actor;
 
+import java.util.UUID;
+
 public record UseReservationCommand(
-        Long reservationId,
+        UUID reservationId,
         Actor requestedUser
 ) {
 }

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/ReservationFilterTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/ReservationFilterTest.java
@@ -1,5 +1,7 @@
 package com.seatliberator.seatliberator.reservation.book.application.port.out.criteria;
 
+import com.seatliberator.seatliberator.kernel.test.SequenceCounter;
+import com.seatliberator.seatliberator.kernel.test.UuidGenerator;
 import com.seatliberator.seatliberator.reservation.application.booking.port.out.criteria.ReservationFilter;
 import com.seatliberator.seatliberator.reservation.domain.ReservationStatus;
 import org.junit.jupiter.api.DisplayName;
@@ -11,6 +13,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("Reservation Filter")
 public class ReservationFilterTest {
+
+    UuidGenerator uuid = new UuidGenerator(new SequenceCounter());
+
     @Test
     @DisplayName("empty는 모든 필터 조건이 비어있다")
     void empty() {
@@ -24,16 +29,19 @@ public class ReservationFilterTest {
     @Test
     @DisplayName("withUserId는 userIds만 교체하고 나머지는 유지한다")
     void with_user_ids() {
+        var reservationId1 = uuid.generate();
+        var reservationId2 = uuid.generate();
+
         var filter = new ReservationFilter(
                 Set.of("user-1"),
-                Set.of(1L, 2L),
+                Set.of(reservationId1, reservationId2),
                 Set.of(ReservationStatus.RESERVED)
         );
 
         var updated = filter.withUserIds("user-2", "user-3");
 
         assertThat(updated.userIds()).containsExactlyInAnyOrder("user-2", "user-3");
-        assertThat(updated.excludedIds()).containsExactlyInAnyOrder(1L, 2L);
+        assertThat(updated.excludedIds()).containsExactlyInAnyOrder(reservationId1, reservationId2);
         assertThat(updated.statuses()).containsExactly(ReservationStatus.RESERVED);
     }
 
@@ -42,30 +50,38 @@ public class ReservationFilterTest {
     void with_excluded_ids() {
         var filter = new ReservationFilter(
                 Set.of("user-1"),
-                Set.of(1L, 2L),
+                Set.of(uuid.generate()),
                 Set.of(ReservationStatus.RESERVED)
         );
 
-        var updated = filter.withExcludeIds(10L, 20L);
+        var updatedReservationId1 = uuid.generate();
+        var updatedReservationId2 = uuid.generate();
+
+        var updated = filter.withExcludeIds(
+                updatedReservationId1,
+                updatedReservationId2
+        );
 
         assertThat(updated.userIds()).containsExactlyInAnyOrder("user-1");
-        assertThat(updated.excludedIds()).containsExactlyInAnyOrder(10L, 20L);
+        assertThat(updated.excludedIds()).containsExactlyInAnyOrder(updatedReservationId1, updatedReservationId2);
         assertThat(updated.statuses()).containsExactlyInAnyOrder(ReservationStatus.RESERVED);
     }
 
     @Test
     @DisplayName("withStatuses는 statuses만 교체하고 나머지는 유지한다")
     void with_statuses() {
+        var reservationId = uuid.generate();
+
         var filter = new ReservationFilter(
                 Set.of("user-1"),
-                Set.of(1L),
+                Set.of(reservationId),
                 Set.of(ReservationStatus.RESERVED)
         );
 
         var updated = filter.withStatuses(ReservationStatus.CANCELED);
 
         assertThat(updated.userIds()).containsExactly("user-1");
-        assertThat(updated.excludedIds()).containsExactly(1L);
+        assertThat(updated.excludedIds()).containsExactly(reservationId);
         assertThat(updated.statuses()).containsExactly(ReservationStatus.CANCELED);
     }
 

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/usage/application/UseReservationUseCaseTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/usage/application/UseReservationUseCaseTest.java
@@ -1,6 +1,8 @@
 package com.seatliberator.seatliberator.reservation.usage.application;
 
 import com.seatliberator.seatliberator.identity.core.actor.ActorFixture;
+import com.seatliberator.seatliberator.kernel.test.SequenceCounter;
+import com.seatliberator.seatliberator.kernel.test.UuidGenerator;
 import com.seatliberator.seatliberator.reservation.application.booking.contract.ReservationOwnershipPolicy;
 import com.seatliberator.seatliberator.reservation.application.booking.contract.result.ReservationPolicyReason;
 import com.seatliberator.seatliberator.reservation.application.booking.contract.result.ReservationPolicyResult;
@@ -36,6 +38,8 @@ public class UseReservationUseCaseTest {
 
     UseReservationUseCase useCase;
 
+    UuidGenerator uuid = new UuidGenerator(new SequenceCounter());
+
     @BeforeEach
     void run() {
         useCase = new ReservationUsageService(reader, ownershipPolicy, fixedClock);
@@ -44,8 +48,9 @@ public class UseReservationUseCaseTest {
     @Test
     @DisplayName("예약 소유권 정책이 승인하면 예약을 사용 처리하고 승인 결과를 반환한다")
     void use_reservation_when_ownership_policy_accepts() {
+        var reservationId = uuid.generate();
         var actor = new ActorFixture.Builder().subject("user-1").build();
-        var command = new UseReservationCommand(1L, actor);
+        var command = new UseReservationCommand(reservationId, actor);
         var reservation = new ReservationFixture.Builder()
                 .userId(actor.subject())
                 .startAt(fixedClock.instant().minusSeconds(60))
@@ -71,8 +76,9 @@ public class UseReservationUseCaseTest {
     @Test
     @DisplayName("예약 소유권 정책이 거절하면 예약을 사용 처리하지 않고 거절 결과를 반환한다")
     void reject_use_reservation_when_ownership_policy_rejects() {
+        var reservationId = uuid.generate();
         var actor = new ActorFixture.Builder().subject("user-2").build();
-        var command = new UseReservationCommand(1L, actor);
+        var command = new UseReservationCommand(reservationId, actor);
         var reservation = new ReservationFixture.Builder()
                 .userId("user-1")
                 .startAt(fixedClock.instant().minusSeconds(60))
@@ -99,8 +105,9 @@ public class UseReservationUseCaseTest {
     @Test
     @DisplayName("예약이 없으면 RESERVATION_NOT_FOUND 예외를 던진다")
     void throw_exception_when_reservation_not_found() {
+        var reservationId = uuid.generate();
         var actor = new ActorFixture.Builder().subject("user-1").build();
-        var command = new UseReservationCommand(1L, actor);
+        var command = new UseReservationCommand(reservationId, actor);
 
         when(reader.findById(command.reservationId()))
                 .thenReturn(Optional.empty());

--- a/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/Reservation.java
+++ b/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/Reservation.java
@@ -15,10 +15,7 @@ import org.springframework.data.domain.AfterDomainEventPublication;
 import org.springframework.data.domain.DomainEvents;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 @Entity
 @Getter
@@ -29,8 +26,8 @@ public class Reservation {
     private final List<DomainEvent> events = new ArrayList<>();
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
 
     @Column(nullable = false, unique = true)
     private String userId;

--- a/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/Seat.java
+++ b/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/Seat.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.Instant;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -20,8 +21,8 @@ import java.time.Instant;
 )
 public class Seat {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "room_pk", nullable = false)

--- a/reservation/reservation-domain/src/testFixtures/java/com/seatliberator/seatliberator/reservation/domain/fixture/ReservationFixture.java
+++ b/reservation/reservation-domain/src/testFixtures/java/com/seatliberator/seatliberator/reservation/domain/fixture/ReservationFixture.java
@@ -5,6 +5,7 @@ import com.seatliberator.seatliberator.reservation.domain.persistence.Reservatio
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.UUID;
 
 import static com.seatliberator.seatliberator.reservation.domain.fixture.SeatLocatorFixture.createLocator;
 import static com.seatliberator.seatliberator.reservation.domain.fixture.TestSupport.fixedClock;
@@ -33,7 +34,7 @@ public class ReservationFixture {
         return Reservation.create(INITIAL_USER_ID, INITIAL_ROOM_ID, INITIAL_SEAT_ID, startTime, endTime, status);
     }
 
-    public static void stubReservationId(Reservation reservation, Long id) {
+    public static void stubReservationId(Reservation reservation, UUID id) {
         try {
             var idField = Reservation.class.getDeclaredField("id");
             idField.setAccessible(true);

--- a/reservation/reservation-persistence/src/main/java/com/seatliberator/seatliberator/reservation/persistence/book/jpa/JpaReservationPersistenceAdapter.java
+++ b/reservation/reservation-persistence/src/main/java/com/seatliberator/seatliberator/reservation/persistence/book/jpa/JpaReservationPersistenceAdapter.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -27,7 +28,7 @@ public class JpaReservationPersistenceAdapter implements ReservationStore, Reser
     }
 
     @Override
-    public Optional<Reservation> findById(Long reservationId) {
+    public Optional<Reservation> findById(UUID reservationId) {
         return repository.findById(reservationId);
     }
 

--- a/reservation/reservation-persistence/src/main/java/com/seatliberator/seatliberator/reservation/persistence/book/jpa/repository/ReservationRepository.java
+++ b/reservation/reservation-persistence/src/main/java/com/seatliberator/seatliberator/reservation/persistence/book/jpa/repository/ReservationRepository.java
@@ -8,8 +8,9 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.Instant;
 import java.util.Optional;
+import java.util.UUID;
 
-public interface ReservationRepository extends JpaRepository<Reservation, Long>, JpaSpecificationExecutor<Reservation> {
+public interface ReservationRepository extends JpaRepository<Reservation, UUID>, JpaSpecificationExecutor<Reservation> {
 
     Optional<Reservation> findByUserId(String userId);
 

--- a/reservation/reservation-persistence/src/main/java/com/seatliberator/seatliberator/reservation/persistence/room/jpa/repository/SeatRepository.java
+++ b/reservation/reservation-persistence/src/main/java/com/seatliberator/seatliberator/reservation/persistence/room/jpa/repository/SeatRepository.java
@@ -10,8 +10,9 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
-public interface SeatRepository extends JpaRepository<Seat, Long>, JpaSpecificationExecutor<Seat> {
+public interface SeatRepository extends JpaRepository<Seat, UUID>, JpaSpecificationExecutor<Seat> {
 
     Optional<Seat> findByRoom_RoomIdAndSeatId(String roomId, String seatId);
 

--- a/reservation/reservation-web-mvc/build.gradle.kts
+++ b/reservation/reservation-web-mvc/build.gradle.kts
@@ -13,5 +13,6 @@ dependencies {
 
     implementation(project(":bootstrap:resource-application-starter"))
 
+    testImplementation(project(":kernel:kernel-test"))
     testImplementation(testFixtures(project(":reservation:reservation-domain")))
 }

--- a/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/infrastructure/web/usage/controller/ReservationUsageController.java
+++ b/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/infrastructure/web/usage/controller/ReservationUsageController.java
@@ -17,6 +17,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.UUID;
+
 @Tag(name = "Reservations", description = "스터디룸 좌석 예약 관련 API")
 @Slf4j
 @RestController
@@ -34,8 +36,8 @@ public class ReservationUsageController {
     })
     @PostMapping("/{reservationId}")
     public ResponseEntity<UseReservationResult> use(
-            @Parameter(description = "예약 ID", example = "1")
-            @PathVariable("reservationId") Long reservationId
+            @Parameter(description = "예약 ID", example = "00000000-0000-0000-0000-000000000001")
+            @PathVariable("reservationId") UUID reservationId
     ) {
         var actor = actorContextHolder.getActor();
         var command = new UseReservationCommand(reservationId, actor);

--- a/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/infrastructure/web/usage/ReservationUsageControllerTest.java
+++ b/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/infrastructure/web/usage/ReservationUsageControllerTest.java
@@ -2,6 +2,8 @@ package com.seatliberator.seatliberator.reservation.infrastructure.web.usage;
 
 import com.seatliberator.seatliberator.identity.core.actor.ActorContextHolder;
 import com.seatliberator.seatliberator.identity.core.actor.SimpleActor;
+import com.seatliberator.seatliberator.kernel.test.SequenceCounter;
+import com.seatliberator.seatliberator.kernel.test.UuidGenerator;
 import com.seatliberator.seatliberator.reservation.application.usage.port.in.UseReservationUseCase;
 import com.seatliberator.seatliberator.reservation.application.usage.port.in.command.UseReservationCommand;
 import com.seatliberator.seatliberator.reservation.application.usage.port.in.result.UseReservationResult;
@@ -39,10 +41,13 @@ public class ReservationUsageControllerTest {
     @MockitoBean
     UseReservationUseCase useReservationUseCase;
 
+    UuidGenerator uuid = new UuidGenerator(new SequenceCounter());
+
     @Test
     @DisplayName("예약 사용 요청 시 path variable과 actor 정보를 기반으로 command를 만들어서 유스케이스에 전달한다")
     void use_build_command_and_calls_use_case() throws Exception {
         // given
+        var reservationId = uuid.generate();
         var actor = new SimpleActor("user-1", Set.of());
         var processedAt = Instant.parse("2026-04-14T10:00:00Z");
         var result = UseReservationResult.accept(processedAt);
@@ -52,7 +57,7 @@ public class ReservationUsageControllerTest {
                 .willReturn(result);
 
         // when
-        mockMvc.perform(post("/reservations/{reservationId}", 1L))
+        mockMvc.perform(post("/reservations/{reservationId}", reservationId))
                 .andExpect(status().isOk());
 
         // then
@@ -60,7 +65,7 @@ public class ReservationUsageControllerTest {
         verify(useReservationUseCase).use(captor.capture());
 
         var actual = captor.getValue();
-        assertThat(actual.reservationId()).isEqualTo(1L);
+        assertThat(actual.reservationId()).isEqualTo(reservationId);
         assertThat(actual.requestedUser()).isEqualTo(actor);
     }
 
@@ -68,6 +73,7 @@ public class ReservationUsageControllerTest {
     @DisplayName("예약 사용 요청 시 유스케이스 결과를 200 OK 응답으로 반환한다")
     void use_returns_ok_with_result() throws Exception {
         // given
+        var reservationId = uuid.generate();
         var actor = new SimpleActor("user-1", Set.of());
         var processedAt = Instant.parse("2026-04-14T10:00:00Z");
         var result = UseReservationResult.reject("해당 예약에 접근할 권한이 없습니다.", processedAt);
@@ -77,7 +83,7 @@ public class ReservationUsageControllerTest {
                 .willReturn(result);
 
         // when & then
-        mockMvc.perform(post("/reservations/{reservationId}", 1L)
+        mockMvc.perform(post("/reservations/{reservationId}", reservationId)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(result)));
@@ -87,7 +93,7 @@ public class ReservationUsageControllerTest {
     @DisplayName("reservationId path variable 형식이 잘못되면 400 Bad Request를 반환한다")
     void use_returns_bad_request_when_reservation_id_is_invalid() throws Exception {
         // when & then
-        mockMvc.perform(post("/reservations/{reservationId}", "not-a-number"))
+        mockMvc.perform(post("/reservations/{reservationId}", "not-a-uuid"))
                 .andExpect(status().isBadRequest());
 
         verifyNoInteractions(actorContextHolder);


### PR DESCRIPTION
## 관련 이슈
- 없음

## 변경 사항
- `Reservation` 엔티티의 ID 생성 전략과 타입을 `Long`에서 `UUID`로 변경
- 예약 ID를 다루는 application port/result/criteria와 persistence repository/adapter 타입을 UUID 기준으로 정리
- 예약 사용 API의 `reservationId` path variable과 관련 command/test를 UUID 기준으로 변경
- UUID 기반 테스트 값을 쓰기 위해 reservation application/web 테스트 의존성에 `kernel-test` 추가
- Seat 도메인 또한 Id를 UUID 로 변경

## 배경 및 의도
- 이후 예약 변경/취소 흐름에서 `reservationId`를 외부 API 식별자로 사용할 예정이라 추측 가능한 Long ID 노출을 먼저 제거합니다.
- userId unique 제거와 복수 예약 허용은 별도 PR에서 다루고, 이번 PR은 Reservation ID 스펙 변경에 범위를 제한합니다.
- 아직 운영 DB가 없으므로 별도 마이그레이션은 포함하지 않았습니다.

## 후속 작업
- update/cancel 유스케이스를 `reservationId + requester` 기반으로 전환
- userId unique 제거와 방별 예약 가능 횟수 정책 분리
- persistence 통합 테스트의 `ObjectMapper` test context 주입 실패 정리

## 검증
- `./gradlew :reservation:reservation-domain:test :reservation:reservation-application:test :reservation:reservation-web-mvc:test`
- `./gradlew :reservation:reservation-persistence:test`는 `tools.jackson.databind.ObjectMapper` 빈 누락으로 context 생성 단계에서 실패해 UUID persistence flow 검증은 진행하지 못함