### PR TITLE
Room 운영 정책과 좌석 시간 슬롯 도메인 추가

### DIFF
--- a/kernel/kernel-core/src/main/java/com/seatliberator/seatliberator/kernel/condition/Preconditions.java
+++ b/kernel/kernel-core/src/main/java/com/seatliberator/seatliberator/kernel/condition/Preconditions.java
@@ -13,4 +13,28 @@ public class Preconditions {
         if (value.isBlank()) throw new IllegalArgumentException(name + " must not be blank.");
         return value;
     }
+
+    public static Integer requireNegative(Integer value, String name) {
+        Objects.requireNonNull(value, name + " must not be null.");
+        if (value >= 0) throw new IllegalArgumentException(name + " must be negative.");
+        return value;
+    }
+
+    public static Integer requireNonNegative(Integer value, String name) {
+        Objects.requireNonNull(value, name + " must not be null.");
+        if (value < 0) throw new IllegalArgumentException(name + " must be non-negative.");
+        return value;
+    }
+
+    public static Integer requirePositive(Integer value, String name) {
+        Objects.requireNonNull(value, name + " must not be null.");
+        if (value <= 0) throw new IllegalArgumentException(name + " must be positive.");
+        return value;
+    }
+
+    public static Integer requireNonPositive(Integer value, String name) {
+        Objects.requireNonNull(value, name + " must not be null.");
+        if (value > 0) throw new IllegalArgumentException(name + " must be non-positive.");
+        return value;
+    }
 }

--- a/kernel/kernel-core/src/main/java/com/seatliberator/seatliberator/kernel/condition/Preconditions.java
+++ b/kernel/kernel-core/src/main/java/com/seatliberator/seatliberator/kernel/condition/Preconditions.java
@@ -1,0 +1,16 @@
+package com.seatliberator.seatliberator.kernel.condition;
+
+import java.util.Objects;
+
+public class Preconditions {
+    public static <T> T requireNonNull(T value, String name) {
+        Objects.requireNonNull(value, name + " must not be null.");
+        return value;
+    }
+
+    public static String requireNonBlank(String value, String name) {
+        Objects.requireNonNull(value, name + " must not be null.");
+        if (value.isBlank()) throw new IllegalArgumentException(name + " must not be blank.");
+        return value;
+    }
+}

--- a/kernel/kernel-core/src/main/java/com/seatliberator/seatliberator/kernel/condition/Preconditions.java
+++ b/kernel/kernel-core/src/main/java/com/seatliberator/seatliberator/kernel/condition/Preconditions.java
@@ -1,5 +1,6 @@
 package com.seatliberator.seatliberator.kernel.condition;
 
+import java.time.Duration;
 import java.util.Objects;
 
 public class Preconditions {
@@ -35,6 +36,30 @@ public class Preconditions {
     public static Integer requireNonPositive(Integer value, String name) {
         Objects.requireNonNull(value, name + " must not be null.");
         if (value > 0) throw new IllegalArgumentException(name + " must be non-positive.");
+        return value;
+    }
+
+    public static Duration requireNegative(Duration value, String name) {
+        Objects.requireNonNull(value, name + " must not be null.");
+        if (!value.isNegative()) throw new IllegalArgumentException(name + " must be negative.");
+        return value;
+    }
+
+    public static Duration requireNonNegative(Duration value, String name) {
+        Objects.requireNonNull(value, name + " must not be null.");
+        if (value.isNegative()) throw new IllegalArgumentException(name + " must be non-negative.");
+        return value;
+    }
+
+    public static Duration requirePositive(Duration value, String name) {
+        Objects.requireNonNull(value, name + " must not be null.");
+        if (!value.isPositive()) throw new IllegalArgumentException(name + " must be positive.");
+        return value;
+    }
+
+    public static Duration requireNonPositive(Duration value, String name) {
+        Objects.requireNonNull(value, name + " must not be null.");
+        if (value.isPositive()) throw new IllegalArgumentException(name + " must be non-positive.");
         return value;
     }
 }

--- a/kernel/kernel-core/src/test/java/com/seatliberator/seatliberator/kernel/condition/PreconditionsTest.java
+++ b/kernel/kernel-core/src/test/java/com/seatliberator/seatliberator/kernel/condition/PreconditionsTest.java
@@ -3,6 +3,8 @@ package com.seatliberator.seatliberator.kernel.condition;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -60,17 +62,86 @@ class PreconditionsTest {
     @Test
     @DisplayName("부호 검증 대상이 null이면 예외를 던진다")
     void throw_when_signed_value_is_null() {
-        assertThatThrownBy(() -> Preconditions.requireNegative(null, "value"))
+        assertThatThrownBy(() -> Preconditions.requireNegative((Integer) null, "value"))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessage("value must not be null.");
-        assertThatThrownBy(() -> Preconditions.requireNonNegative(null, "value"))
+        assertThatThrownBy(() -> Preconditions.requireNonNegative((Integer) null, "value"))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessage("value must not be null.");
-        assertThatThrownBy(() -> Preconditions.requirePositive(null, "value"))
+        assertThatThrownBy(() -> Preconditions.requirePositive((Integer) null, "value"))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessage("value must not be null.");
-        assertThatThrownBy(() -> Preconditions.requireNonPositive(null, "value"))
+        assertThatThrownBy(() -> Preconditions.requireNonPositive((Integer) null, "value"))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessage("value must not be null.");
+    }
+
+    @Test
+    @DisplayName("음수 Duration을 요구할 수 있다")
+    void require_negative_duration() {
+        var negative = Duration.ofSeconds(-1);
+
+        assertThat(Preconditions.requireNegative(negative, "duration")).isEqualTo(negative);
+
+        assertThatThrownBy(() -> Preconditions.requireNegative(Duration.ZERO, "duration"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("duration must be negative.");
+        assertThatThrownBy(() -> Preconditions.requireNegative(Duration.ofSeconds(1), "duration"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("duration must be negative.");
+    }
+
+    @Test
+    @DisplayName("0 이상의 Duration을 요구할 수 있다")
+    void require_non_negative_duration() {
+        assertThat(Preconditions.requireNonNegative(Duration.ZERO, "duration")).isEqualTo(Duration.ZERO);
+        assertThat(Preconditions.requireNonNegative(Duration.ofSeconds(1), "duration")).isEqualTo(Duration.ofSeconds(1));
+
+        assertThatThrownBy(() -> Preconditions.requireNonNegative(Duration.ofSeconds(-1), "duration"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("duration must be non-negative.");
+    }
+
+    @Test
+    @DisplayName("양수 Duration을 요구할 수 있다")
+    void require_positive_duration() {
+        var positive = Duration.ofSeconds(1);
+
+        assertThat(Preconditions.requirePositive(positive, "duration")).isEqualTo(positive);
+
+        assertThatThrownBy(() -> Preconditions.requirePositive(Duration.ZERO, "duration"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("duration must be positive.");
+        assertThatThrownBy(() -> Preconditions.requirePositive(Duration.ofSeconds(-1), "duration"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("duration must be positive.");
+    }
+
+    @Test
+    @DisplayName("0 이하의 Duration을 요구할 수 있다")
+    void require_non_positive_duration() {
+        assertThat(Preconditions.requireNonPositive(Duration.ofSeconds(-1), "duration")).isEqualTo(Duration.ofSeconds(-1));
+        assertThat(Preconditions.requireNonPositive(Duration.ZERO, "duration")).isEqualTo(Duration.ZERO);
+
+        assertThatThrownBy(() -> Preconditions.requireNonPositive(Duration.ofSeconds(1), "duration"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("duration must be non-positive.");
+    }
+
+    @Test
+    @DisplayName("Duration 부호 검증 대상이 null이면 예외를 던진다")
+    void throw_when_signed_duration_is_null() {
+        assertThatThrownBy(() -> Preconditions.requireNegative((Duration) null, "duration"))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("duration must not be null.");
+        assertThatThrownBy(() -> Preconditions.requireNonNegative((Duration) null, "duration"))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("duration must not be null.");
+        assertThatThrownBy(() -> Preconditions.requirePositive((Duration) null, "duration"))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("duration must not be null.");
+        assertThatThrownBy(() -> Preconditions.requireNonPositive((Duration) null, "duration"))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("duration must not be null.");
     }
 }

--- a/kernel/kernel-core/src/test/java/com/seatliberator/seatliberator/kernel/condition/PreconditionsTest.java
+++ b/kernel/kernel-core/src/test/java/com/seatliberator/seatliberator/kernel/condition/PreconditionsTest.java
@@ -1,0 +1,76 @@
+package com.seatliberator.seatliberator.kernel.condition;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Preconditions")
+class PreconditionsTest {
+
+    @Test
+    @DisplayName("음수 값을 요구할 수 있다")
+    void require_negative() {
+        assertThat(Preconditions.requireNegative(-1, "value")).isEqualTo(-1);
+
+        assertThatThrownBy(() -> Preconditions.requireNegative(0, "value"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("value must be negative.");
+        assertThatThrownBy(() -> Preconditions.requireNegative(1, "value"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("value must be negative.");
+    }
+
+    @Test
+    @DisplayName("0 이상의 값을 요구할 수 있다")
+    void require_non_negative() {
+        assertThat(Preconditions.requireNonNegative(0, "value")).isZero();
+        assertThat(Preconditions.requireNonNegative(1, "value")).isEqualTo(1);
+
+        assertThatThrownBy(() -> Preconditions.requireNonNegative(-1, "value"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("value must be non-negative.");
+    }
+
+    @Test
+    @DisplayName("양수 값을 요구할 수 있다")
+    void require_positive() {
+        assertThat(Preconditions.requirePositive(1, "value")).isEqualTo(1);
+
+        assertThatThrownBy(() -> Preconditions.requirePositive(0, "value"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("value must be positive.");
+        assertThatThrownBy(() -> Preconditions.requirePositive(-1, "value"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("value must be positive.");
+    }
+
+    @Test
+    @DisplayName("0 이하의 값을 요구할 수 있다")
+    void require_non_positive() {
+        assertThat(Preconditions.requireNonPositive(-1, "value")).isEqualTo(-1);
+        assertThat(Preconditions.requireNonPositive(0, "value")).isZero();
+
+        assertThatThrownBy(() -> Preconditions.requireNonPositive(1, "value"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("value must be non-positive.");
+    }
+
+    @Test
+    @DisplayName("부호 검증 대상이 null이면 예외를 던진다")
+    void throw_when_signed_value_is_null() {
+        assertThatThrownBy(() -> Preconditions.requireNegative(null, "value"))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("value must not be null.");
+        assertThatThrownBy(() -> Preconditions.requireNonNegative(null, "value"))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("value must not be null.");
+        assertThatThrownBy(() -> Preconditions.requirePositive(null, "value"))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("value must not be null.");
+        assertThatThrownBy(() -> Preconditions.requireNonPositive(null, "value"))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("value must not be null.");
+    }
+}

--- a/kernel/kernel-test/build.gradle.kts
+++ b/kernel/kernel-test/build.gradle.kts
@@ -6,6 +6,8 @@ group = "com.seatliberator.seatliberator"
 version = "0.0.1-SNAPSHOT"
 
 dependencies {
+    implementation(project(":kernel:kernel-core"))
+
     testImplementation("org.assertj:assertj-core")
     testImplementation(platform("org.junit:junit-bom:5.10.0"))
     testImplementation("org.junit.jupiter:junit-jupiter")

--- a/kernel/kernel-test/build.gradle.kts
+++ b/kernel/kernel-test/build.gradle.kts
@@ -7,9 +7,10 @@ version = "0.0.1-SNAPSHOT"
 
 dependencies {
     implementation(project(":kernel:kernel-core"))
+    implementation(libs.assertj.core)
+    testImplementation(libs.assertj.core)
 
-    testImplementation("org.assertj:assertj-core")
-    testImplementation(platform("org.junit:junit-bom:5.10.0"))
-    testImplementation("org.junit.jupiter:junit-jupiter")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
 }

--- a/kernel/kernel-test/src/main/java/com/seatliberator/seatliberator/kernel/test/UuidGenerator.java
+++ b/kernel/kernel-test/src/main/java/com/seatliberator/seatliberator/kernel/test/UuidGenerator.java
@@ -12,8 +12,12 @@ public class UuidGenerator implements Generator<UUID> {
         this.counter = counter;
     }
 
+    public static UUID generate(long value) {
+        return new UUID(0L, value);
+    }
+
     @Override
     public UUID generate() {
-        return new UUID(0L, counter.next());
+        return generate(counter.next());
     }
 }

--- a/kernel/kernel-test/src/main/java/com/seatliberator/seatliberator/kernel/test/assertion/DomainAssertions.java
+++ b/kernel/kernel-test/src/main/java/com/seatliberator/seatliberator/kernel/test/assertion/DomainAssertions.java
@@ -1,0 +1,39 @@
+package com.seatliberator.seatliberator.kernel.test.assertion;
+
+import org.assertj.core.api.AbstractThrowableAssert;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+
+public final class DomainAssertions {
+    public static DomainThrowableAssert assertThatDomainThrownBy(ThrowingCallable callable) {
+        return new DomainThrowableAssert(Assertions.catchThrowable(callable));
+    }
+
+    public static final class DomainThrowableAssert extends AbstractThrowableAssert<DomainThrowableAssert, Throwable> {
+        private DomainThrowableAssert(Throwable actual) {
+            super(actual, DomainThrowableAssert.class);
+        }
+
+        public DomainThrowableAssert hasNonNullMessage() {
+            hasMessageContaining("must not be null");
+            return this;
+        }
+
+        public DomainThrowableAssert hasNonNullMessageFor(String fieldName) {
+            hasMessageContaining(fieldName);
+            hasMessageContaining("must not be null");
+            return this;
+        }
+
+        public DomainThrowableAssert hasNonBlankMessage() {
+            hasMessageContaining("must not be blank");
+            return this;
+        }
+
+        public DomainThrowableAssert hasNonBlankMessageFor(String fieldName) {
+            hasMessageContaining(fieldName);
+            hasMessageContaining("must not be blank");
+            return this;
+        }
+    }
+}

--- a/kernel/kernel-test/src/main/java/com/seatliberator/seatliberator/kernel/test/assertion/DomainAssertions.java
+++ b/kernel/kernel-test/src/main/java/com/seatliberator/seatliberator/kernel/test/assertion/DomainAssertions.java
@@ -35,5 +35,49 @@ public final class DomainAssertions {
             hasMessageContaining("must not be blank");
             return this;
         }
+
+        public DomainThrowableAssert hasNegativeMessage() {
+            hasMessageContaining("must be negative");
+            return this;
+        }
+
+        public DomainThrowableAssert hasNegativeMessageFor(String fieldName) {
+            hasMessageContaining(fieldName);
+            hasMessageContaining("must be negative");
+            return this;
+        }
+
+        public DomainThrowableAssert hasNonNegativeMessage() {
+            hasMessageContaining("must be non-negative");
+            return this;
+        }
+
+        public DomainThrowableAssert hasNonNegativeMessageFor(String fieldName) {
+            hasMessageContaining(fieldName);
+            hasMessageContaining("must be non-negative");
+            return this;
+        }
+
+        public DomainThrowableAssert hasPositiveMessage() {
+            hasMessageContaining("must be positive");
+            return this;
+        }
+
+        public DomainThrowableAssert hasPositiveMessageFor(String fieldName) {
+            hasMessageContaining(fieldName);
+            hasMessageContaining("must be positive");
+            return this;
+        }
+
+        public DomainThrowableAssert hasNonPositiveMessage() {
+            hasMessageContaining("must be non-positive");
+            return this;
+        }
+
+        public DomainThrowableAssert hasNonPositiveMessageFor(String fieldName) {
+            hasMessageContaining(fieldName);
+            hasMessageContaining("must be non-positive");
+            return this;
+        }
     }
 }

--- a/kernel/kernel-test/src/main/java/com/seatliberator/seatliberator/kernel/test/concurrency/ConcurrencyRunner.java
+++ b/kernel/kernel-test/src/main/java/com/seatliberator/seatliberator/kernel/test/concurrency/ConcurrencyRunner.java
@@ -1,0 +1,69 @@
+package com.seatliberator.seatliberator.kernel.test.concurrency;
+
+import com.seatliberator.seatliberator.kernel.condition.Preconditions;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+public class ConcurrencyRunner {
+    private final Properties properties;
+
+    public ConcurrencyRunner(Properties properties) {
+        this.properties = Preconditions.requireNonNull(properties, "properties");
+    }
+
+    public <T> RunnerResult<T> run(Function<Integer, T> fn) throws InterruptedException {
+        var threadCount = properties.threadCount();
+        var ready = new CountDownLatch(threadCount);
+        var start = new CountDownLatch(1);
+        var done = new CountDownLatch(threadCount);
+
+        ConcurrentHashMap<Integer, T> success = new ConcurrentHashMap<>();
+        ConcurrentHashMap<Integer, Exception> failure = new ConcurrentHashMap<>();
+
+        var executor = Executors.newFixedThreadPool(threadCount);
+
+        try {
+            for (int i = 0; i < threadCount; i++) {
+                var threadId = i;
+
+                executor.submit(() -> {
+                    ready.countDown();
+
+                    try {
+                        start.await();
+                        var result = fn.apply(threadId);
+                        success.put(threadId, result);
+                    } catch (Exception e) {
+                        failure.put(threadId, e);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+
+            ready.await(3, TimeUnit.SECONDS);
+            start.countDown();
+            done.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            executor.shutdown();
+            executor.awaitTermination(5, TimeUnit.SECONDS);
+        }
+
+        return new RunnerResult<>(success, failure);
+    }
+
+    public record Properties(int threadCount) {
+    }
+
+    public record RunnerResult<T>(
+            ConcurrentHashMap<Integer, T> success,
+            ConcurrentHashMap<Integer, Exception> failure
+    ) {
+    }
+}

--- a/kernel/kernel-test/src/test/java/com/seatliberator/seatliberator/kernel/test/UuidGeneratorTest.java
+++ b/kernel/kernel-test/src/test/java/com/seatliberator/seatliberator/kernel/test/UuidGeneratorTest.java
@@ -36,5 +36,13 @@ public class UuidGeneratorTest {
             assertThat(generator.generate()).isEqualTo(new UUID(0L, 1L));
             assertThat(generator.generate()).isEqualTo(new UUID(0L, 2L));
         }
+
+        @Test
+        @DisplayName("int 값을 UUID 하위 비트로 사용한다")
+        void generate_uuid_with_int() {
+            var generated = UuidGenerator.generate(1);
+
+            assertThat(generated).isEqualTo(new UUID(0L, 1L));
+        }
     }
 }

--- a/kernel/kernel-test/src/test/java/com/seatliberator/seatliberator/kernel/test/assertion/DomainAssertionsTest.java
+++ b/kernel/kernel-test/src/test/java/com/seatliberator/seatliberator/kernel/test/assertion/DomainAssertionsTest.java
@@ -1,0 +1,74 @@
+package com.seatliberator.seatliberator.kernel.test.assertion;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.seatliberator.seatliberator.kernel.test.assertion.DomainAssertions.assertThatDomainThrownBy;
+
+@DisplayName("DomainAssertions")
+class DomainAssertionsTest {
+
+    @Test
+    @DisplayName("null 불가 메시지를 검증할 수 있다")
+    void assert_non_null_message() {
+        assertThatDomainThrownBy(() -> {
+            throw new NullPointerException("value must not be null.");
+        }).hasNonNullMessage();
+    }
+
+    @Test
+    @DisplayName("필드 이름을 포함한 null 불가 메시지를 검증할 수 있다")
+    void assert_non_null_message_for_field() {
+        assertThatDomainThrownBy(() -> {
+            throw new NullPointerException("value must not be null.");
+        }).hasNonNullMessageFor("value");
+    }
+
+    @Test
+    @DisplayName("공백 불가 메시지를 검증할 수 있다")
+    void assert_non_blank_message() {
+        assertThatDomainThrownBy(() -> {
+            throw new IllegalArgumentException("value must not be blank.");
+        }).hasNonBlankMessage();
+    }
+
+    @Test
+    @DisplayName("필드 이름을 포함한 공백 불가 메시지를 검증할 수 있다")
+    void assert_non_blank_message_for_field() {
+        assertThatDomainThrownBy(() -> {
+            throw new IllegalArgumentException("value must not be blank.");
+        }).hasNonBlankMessageFor("value");
+    }
+
+    @Test
+    @DisplayName("음수 메시지를 검증할 수 있다")
+    void assert_negative_message() {
+        assertThatDomainThrownBy(() -> {
+            throw new IllegalArgumentException("value must be negative.");
+        }).hasNegativeMessageFor("value");
+    }
+
+    @Test
+    @DisplayName("0 이상 메시지를 검증할 수 있다")
+    void assert_non_negative_message() {
+        assertThatDomainThrownBy(() -> {
+            throw new IllegalArgumentException("value must be non-negative.");
+        }).hasNonNegativeMessageFor("value");
+    }
+
+    @Test
+    @DisplayName("양수 메시지를 검증할 수 있다")
+    void assert_positive_message() {
+        assertThatDomainThrownBy(() -> {
+            throw new IllegalArgumentException("value must be positive.");
+        }).hasPositiveMessageFor("value");
+    }
+
+    @Test
+    @DisplayName("0 이하 메시지를 검증할 수 있다")
+    void assert_non_positive_message() {
+        assertThatDomainThrownBy(() -> {
+            throw new IllegalArgumentException("value must be non-positive.");
+        }).hasNonPositiveMessageFor("value");
+    }
+}

--- a/reservation/reservation-application/build.gradle.kts
+++ b/reservation/reservation-application/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
 
     implementation(project(":bootstrap:application-starter"))
 
+    testImplementation(project(":kernel:kernel-test"))
     testImplementation(testFixtures(project(":reservation:reservation-domain")))
     testImplementation(testFixtures(project(":identity:identity-core")))
 }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/availability/port/in/result/AvailableSeatResult.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/availability/port/in/result/AvailableSeatResult.java
@@ -2,8 +2,10 @@ package com.seatliberator.seatliberator.reservation.application.availability.por
 
 import com.seatliberator.seatliberator.reservation.domain.persistence.Seat;
 
+import java.util.UUID;
+
 public record AvailableSeatResult(
-        Long id,
+        UUID id,
         String roomId,
         String seatId
 ) {

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/port/in/result/ReservationResult.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/port/in/result/ReservationResult.java
@@ -4,9 +4,10 @@ import com.seatliberator.seatliberator.reservation.domain.ReservationStatus;
 import com.seatliberator.seatliberator.reservation.domain.persistence.Reservation;
 
 import java.time.Instant;
+import java.util.UUID;
 
 public record ReservationResult(
-        Long reservationId,
+        UUID reservationId,
         String actorId,
         String roomId,
         String seatId,

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/port/out/ReservationReader.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/port/out/ReservationReader.java
@@ -8,9 +8,10 @@ import com.seatliberator.seatliberator.reservation.domain.persistence.Reservatio
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface ReservationReader {
-    Optional<Reservation> findById(Long id);
+    Optional<Reservation> findById(UUID id);
 
     Optional<Reservation> findByUserId(String userId);
 

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/port/out/criteria/ReservationFilter.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/port/out/criteria/ReservationFilter.java
@@ -5,10 +5,11 @@ import com.seatliberator.seatliberator.reservation.domain.ReservationStatus;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 
 public record ReservationFilter(
         Set<String> userIds,
-        Set<Long> excludedIds,
+        Set<UUID> excludedIds,
         Set<ReservationStatus> statuses
 ) {
     public ReservationFilter {
@@ -29,11 +30,11 @@ public record ReservationFilter(
         return new ReservationFilter(Set.of(userIds), excludedIds, statuses);
     }
 
-    public ReservationFilter withExcludeIds(Collection<Long> ids) {
+    public ReservationFilter withExcludeIds(Collection<UUID> ids) {
         return new ReservationFilter(userIds, Set.copyOf(ids), statuses);
     }
 
-    public ReservationFilter withExcludeIds(Long... ids) {
+    public ReservationFilter withExcludeIds(UUID... ids) {
         return new ReservationFilter(userIds, Set.of(ids), statuses);
     }
 

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/room/port/out/criteria/SeatExclusion.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/room/port/out/criteria/SeatExclusion.java
@@ -1,18 +1,15 @@
 package com.seatliberator.seatliberator.reservation.application.room.port.out.criteria;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
 public record SeatExclusion(
-        Set<Long> ids
+        Set<UUID> ids
 ) {
     public SeatExclusion {
         Objects.requireNonNull(ids);
     }
 
-    public static SeatExclusion of(Collection<Long> ids) {
+    public static SeatExclusion of(Collection<UUID> ids) {
         return new SeatExclusion(new HashSet<>(ids));
     }
 

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/usage/port/in/command/UseReservationCommand.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/usage/port/in/command/UseReservationCommand.java
@@ -2,8 +2,10 @@ package com.seatliberator.seatliberator.reservation.application.usage.port.in.co
 
 import com.seatliberator.seatliberator.identity.core.actor.Actor;
 
+import java.util.UUID;
+
 public record UseReservationCommand(
-        Long reservationId,
+        UUID reservationId,
         Actor requestedUser
 ) {
 }

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/ReservationFilterTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/book/application/port/out/criteria/ReservationFilterTest.java
@@ -1,5 +1,7 @@
 package com.seatliberator.seatliberator.reservation.book.application.port.out.criteria;
 
+import com.seatliberator.seatliberator.kernel.test.SequenceCounter;
+import com.seatliberator.seatliberator.kernel.test.UuidGenerator;
 import com.seatliberator.seatliberator.reservation.application.booking.port.out.criteria.ReservationFilter;
 import com.seatliberator.seatliberator.reservation.domain.ReservationStatus;
 import org.junit.jupiter.api.DisplayName;
@@ -11,6 +13,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("Reservation Filter")
 public class ReservationFilterTest {
+
+    UuidGenerator uuid = new UuidGenerator(new SequenceCounter());
+
     @Test
     @DisplayName("empty는 모든 필터 조건이 비어있다")
     void empty() {
@@ -24,16 +29,19 @@ public class ReservationFilterTest {
     @Test
     @DisplayName("withUserId는 userIds만 교체하고 나머지는 유지한다")
     void with_user_ids() {
+        var reservationId1 = uuid.generate();
+        var reservationId2 = uuid.generate();
+
         var filter = new ReservationFilter(
                 Set.of("user-1"),
-                Set.of(1L, 2L),
+                Set.of(reservationId1, reservationId2),
                 Set.of(ReservationStatus.RESERVED)
         );
 
         var updated = filter.withUserIds("user-2", "user-3");
 
         assertThat(updated.userIds()).containsExactlyInAnyOrder("user-2", "user-3");
-        assertThat(updated.excludedIds()).containsExactlyInAnyOrder(1L, 2L);
+        assertThat(updated.excludedIds()).containsExactlyInAnyOrder(reservationId1, reservationId2);
         assertThat(updated.statuses()).containsExactly(ReservationStatus.RESERVED);
     }
 
@@ -42,30 +50,38 @@ public class ReservationFilterTest {
     void with_excluded_ids() {
         var filter = new ReservationFilter(
                 Set.of("user-1"),
-                Set.of(1L, 2L),
+                Set.of(uuid.generate()),
                 Set.of(ReservationStatus.RESERVED)
         );
 
-        var updated = filter.withExcludeIds(10L, 20L);
+        var updatedReservationId1 = uuid.generate();
+        var updatedReservationId2 = uuid.generate();
+
+        var updated = filter.withExcludeIds(
+                updatedReservationId1,
+                updatedReservationId2
+        );
 
         assertThat(updated.userIds()).containsExactlyInAnyOrder("user-1");
-        assertThat(updated.excludedIds()).containsExactlyInAnyOrder(10L, 20L);
+        assertThat(updated.excludedIds()).containsExactlyInAnyOrder(updatedReservationId1, updatedReservationId2);
         assertThat(updated.statuses()).containsExactlyInAnyOrder(ReservationStatus.RESERVED);
     }
 
     @Test
     @DisplayName("withStatuses는 statuses만 교체하고 나머지는 유지한다")
     void with_statuses() {
+        var reservationId = uuid.generate();
+
         var filter = new ReservationFilter(
                 Set.of("user-1"),
-                Set.of(1L),
+                Set.of(reservationId),
                 Set.of(ReservationStatus.RESERVED)
         );
 
         var updated = filter.withStatuses(ReservationStatus.CANCELED);
 
         assertThat(updated.userIds()).containsExactly("user-1");
-        assertThat(updated.excludedIds()).containsExactly(1L);
+        assertThat(updated.excludedIds()).containsExactly(reservationId);
         assertThat(updated.statuses()).containsExactly(ReservationStatus.CANCELED);
     }
 

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/usage/application/UseReservationUseCaseTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/usage/application/UseReservationUseCaseTest.java
@@ -1,6 +1,8 @@
 package com.seatliberator.seatliberator.reservation.usage.application;
 
 import com.seatliberator.seatliberator.identity.core.actor.ActorFixture;
+import com.seatliberator.seatliberator.kernel.test.SequenceCounter;
+import com.seatliberator.seatliberator.kernel.test.UuidGenerator;
 import com.seatliberator.seatliberator.reservation.application.booking.contract.ReservationOwnershipPolicy;
 import com.seatliberator.seatliberator.reservation.application.booking.contract.result.ReservationPolicyReason;
 import com.seatliberator.seatliberator.reservation.application.booking.contract.result.ReservationPolicyResult;
@@ -36,6 +38,8 @@ public class UseReservationUseCaseTest {
 
     UseReservationUseCase useCase;
 
+    UuidGenerator uuid = new UuidGenerator(new SequenceCounter());
+
     @BeforeEach
     void run() {
         useCase = new ReservationUsageService(reader, ownershipPolicy, fixedClock);
@@ -44,8 +48,9 @@ public class UseReservationUseCaseTest {
     @Test
     @DisplayName("예약 소유권 정책이 승인하면 예약을 사용 처리하고 승인 결과를 반환한다")
     void use_reservation_when_ownership_policy_accepts() {
+        var reservationId = uuid.generate();
         var actor = new ActorFixture.Builder().subject("user-1").build();
-        var command = new UseReservationCommand(1L, actor);
+        var command = new UseReservationCommand(reservationId, actor);
         var reservation = new ReservationFixture.Builder()
                 .userId(actor.subject())
                 .startAt(fixedClock.instant().minusSeconds(60))
@@ -71,8 +76,9 @@ public class UseReservationUseCaseTest {
     @Test
     @DisplayName("예약 소유권 정책이 거절하면 예약을 사용 처리하지 않고 거절 결과를 반환한다")
     void reject_use_reservation_when_ownership_policy_rejects() {
+        var reservationId = uuid.generate();
         var actor = new ActorFixture.Builder().subject("user-2").build();
-        var command = new UseReservationCommand(1L, actor);
+        var command = new UseReservationCommand(reservationId, actor);
         var reservation = new ReservationFixture.Builder()
                 .userId("user-1")
                 .startAt(fixedClock.instant().minusSeconds(60))
@@ -99,8 +105,9 @@ public class UseReservationUseCaseTest {
     @Test
     @DisplayName("예약이 없으면 RESERVATION_NOT_FOUND 예외를 던진다")
     void throw_exception_when_reservation_not_found() {
+        var reservationId = uuid.generate();
         var actor = new ActorFixture.Builder().subject("user-1").build();
-        var command = new UseReservationCommand(1L, actor);
+        var command = new UseReservationCommand(reservationId, actor);
 
         when(reader.findById(command.reservationId()))
                 .thenReturn(Optional.empty());

--- a/reservation/reservation-domain/build.gradle.kts
+++ b/reservation/reservation-domain/build.gradle.kts
@@ -7,4 +7,5 @@ version = "0.0.1-SNAPSHOT"
 
 dependencies {
     implementation(project(":kernel:kernel-core"))
+    testImplementation(project(":kernel:kernel-test"))
 }

--- a/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/TimeRange.java
+++ b/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/TimeRange.java
@@ -14,4 +14,8 @@ public interface TimeRange {
     default boolean isEnded(Instant time) {
         return !time.isBefore(endAt());
     }
+
+    default boolean isSame(TimeRange other) {
+        return startAt().equals(other.startAt()) && endAt().equals(other.endAt());
+    }
 }

--- a/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/Reservation.java
+++ b/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/Reservation.java
@@ -29,7 +29,7 @@ public class Reservation {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String userId;
 
     @Embedded

--- a/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/Reservation.java
+++ b/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/Reservation.java
@@ -15,10 +15,7 @@ import org.springframework.data.domain.AfterDomainEventPublication;
 import org.springframework.data.domain.DomainEvents;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 @Entity
 @Getter
@@ -29,8 +26,8 @@ public class Reservation {
     private final List<DomainEvent> events = new ArrayList<>();
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
 
     @Column(nullable = false, unique = true)
     private String userId;

--- a/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/Room.java
+++ b/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/Room.java
@@ -1,13 +1,12 @@
 package com.seatliberator.seatliberator.reservation.domain.persistence;
 
+import com.seatliberator.seatliberator.kernel.condition.Preconditions;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -22,9 +21,6 @@ public class Room {
     @Column(name = "room_id", nullable = false, unique = true)
     private String roomId;
 
-    @OneToMany(mappedBy = "room", fetch = FetchType.LAZY)
-    private final List<Seat> seats = new ArrayList<>();
-
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 
@@ -32,11 +28,8 @@ public class Room {
             String roomId,
             Instant createdAt
     ) {
-        if (roomId == null || roomId.isBlank()) throw new IllegalArgumentException("roomId must not be null or blank.");
-        if (createdAt == null) throw new IllegalArgumentException("createdAt must not be null.");
-
-        this.roomId = roomId;
-        this.createdAt = createdAt;
+        this.roomId = Preconditions.requireNonBlank(roomId, "roomId");
+        this.createdAt = Preconditions.requireNonNull(createdAt, "createdAt");
     }
 
     public static Room of(String roomId, Instant createdAt) {
@@ -44,18 +37,7 @@ public class Room {
     }
 
     public void updateRoomId(String roomId) {
-        if (roomId == null || roomId.isBlank()) throw new IllegalArgumentException("roomId must not be null or blank.");
+        Preconditions.requireNonBlank(roomId, "roomId");
         this.roomId = roomId;
-    }
-
-    protected void attachSeat(Seat seat) {
-        if (seat == null) throw new IllegalArgumentException("seat must not be null.");
-        if (seats.contains(seat)) return;
-        this.seats.add(seat);
-    }
-
-    protected void detachSeat(Seat seat) {
-        if (seat == null) throw new IllegalArgumentException("seat must not be null.");
-        seats.remove(seat);
     }
 }

--- a/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/RoomOperationPolicy.java
+++ b/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/RoomOperationPolicy.java
@@ -1,0 +1,74 @@
+package com.seatliberator.seatliberator.reservation.domain.persistence;
+
+import com.seatliberator.seatliberator.kernel.condition.Preconditions;
+import com.seatliberator.seatliberator.reservation.domain.EmbeddableTimeRange;
+import com.seatliberator.seatliberator.reservation.domain.TimeRange;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Duration;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RoomOperationPolicy {
+
+    @Column(name = "max_reservation_per_user", nullable = false)
+    private Integer maxReservationPerUser;
+
+    @Column(name = "max_reservation_duration", nullable = false)
+    private Duration maxReservationDuration;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "operation_status", nullable = false)
+    private RoomOperationStatus operationStatus;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "startAt", column = @Column(name = "operation_start_at", nullable = false)),
+            @AttributeOverride(name = "endAt", column = @Column(name = "operation_end_at", nullable = false))
+    })
+    private EmbeddableTimeRange operationRange;
+
+    private RoomOperationPolicy(
+            Integer maxReservationPerUser,
+            Duration maxReservationDuration,
+            RoomOperationStatus operationStatus,
+            EmbeddableTimeRange operationRange
+    ) {
+        this.maxReservationDuration = Preconditions.requirePositive(maxReservationDuration, "maxReservationDuration");
+        this.maxReservationPerUser = Preconditions.requirePositive(maxReservationPerUser, "maxReservationPerUser");
+        this.operationStatus = Preconditions.requireNonNull(operationStatus, "operationStatus");
+        this.operationRange = Preconditions.requireNonNull(operationRange, "operationRange");
+    }
+
+    public static RoomOperationPolicy of(Integer maxReservationPerUser, Duration maxReservationDuration, RoomOperationStatus operationStatus, TimeRange operationRange) {
+        Preconditions.requireNonNull(operationRange, "operationRange");
+        return new RoomOperationPolicy(
+                maxReservationPerUser,
+                maxReservationDuration,
+                operationStatus,
+                EmbeddableTimeRange.of(operationRange)
+        );
+    }
+
+    public void updateMaxReservationDuration(Duration maxReservationDuration) {
+        this.maxReservationDuration = Preconditions.requirePositive(maxReservationDuration, "maxReservationDuration");
+    }
+
+    public void updateMaxReservationPerUser(Integer maxReservationPerUser) {
+        this.maxReservationPerUser = Preconditions.requirePositive(maxReservationPerUser, "maxReservationPerUser");
+    }
+
+    public void updateOperationStatus(RoomOperationStatus operationStatus) {
+        this.operationStatus = Preconditions.requireNonNull(operationStatus, "operationStatus");
+    }
+
+    public void updateOperationRange(TimeRange operationRange) {
+        this.operationRange = EmbeddableTimeRange.of(
+                Preconditions.requireNonNull(operationRange, "operationRange")
+        );
+    }
+}

--- a/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/RoomOperationStatus.java
+++ b/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/RoomOperationStatus.java
@@ -1,0 +1,6 @@
+package com.seatliberator.seatliberator.reservation.domain.persistence;
+
+public enum RoomOperationStatus {
+    OPEN,
+    CLOSE
+}

--- a/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/Seat.java
+++ b/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/Seat.java
@@ -1,5 +1,6 @@
 package com.seatliberator.seatliberator.reservation.domain.persistence;
 
+import com.seatliberator.seatliberator.kernel.condition.Preconditions;
 import com.seatliberator.seatliberator.reservation.domain.SeatLocator;
 import com.seatliberator.seatliberator.reservation.domain.SeatStatus;
 import com.seatliberator.seatliberator.reservation.domain.SimpleSeatLocator;
@@ -50,17 +51,10 @@ public class Seat {
             SeatStatus status,
             Instant createdAt
     ) {
-        if (room == null) throw new IllegalArgumentException("room must not be null.");
-        if (seatId == null || seatId.isBlank()) throw new IllegalArgumentException("seatId must not be null or blank.");
-        if (status == null) throw new IllegalArgumentException("status must not be null.");
-        if (createdAt == null) throw new IllegalArgumentException("createdAt must not be null.");
-
-        this.room = room;
-        this.seatId = seatId;
-        this.status = status;
-        this.createdAt = createdAt;
-
-        room.attachSeat(this);
+        this.room = Preconditions.requireNonNull(room, "room");
+        this.seatId = Preconditions.requireNonBlank(seatId, "seatId");
+        this.status = Preconditions.requireNonNull(status, "status");
+        this.createdAt = Preconditions.requireNonNull(createdAt, "createdAt");
 
         switch (status) {
             case ACTIVE -> this.lastActivatedAt = createdAt;
@@ -81,22 +75,18 @@ public class Seat {
     }
 
     public void updateSeatId(String seatId) {
-        if (seatId == null || seatId.isBlank()) throw new IllegalArgumentException("seatId must not be null or blank.");
+        Preconditions.requireNonBlank(seatId, "seatId");
         this.seatId = seatId;
     }
 
     public void updateRoom(Room room) {
-        if (room == null) throw new IllegalArgumentException("room must not be null.");
+        Preconditions.requireNonNull(room, "room");
         if (this.room.equals(room)) return;
-
-        var oldRoom = this.room;
-        oldRoom.detachSeat(this);
         this.room = room;
-        room.attachSeat(this);
     }
 
     public void active(Instant activatedAt) {
-        if (activatedAt == null) throw new IllegalArgumentException("activatedAt must not be null.");
+        Preconditions.requireNonNull(activatedAt, "activatedAt");
 
         ensureDifferentStatus(SeatStatus.ACTIVE);
         ensureNotBefore(activatedAt, "activatedAt", createdAt, "createdAt");
@@ -107,7 +97,7 @@ public class Seat {
     }
 
     public void inactive(Instant inactivatedAt) {
-        if (inactivatedAt == null) throw new IllegalArgumentException("inactivatedAt must not be null.");
+        Preconditions.requireNonNull(inactivatedAt, "inactivatedAt");
 
         ensureDifferentStatus(SeatStatus.INACTIVE);
         ensureNotBefore(inactivatedAt, "inactivatedAt", createdAt, "createdAt");

--- a/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/Seat.java
+++ b/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/Seat.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.Instant;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -20,8 +21,8 @@ import java.time.Instant;
 )
 public class Seat {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "room_pk", nullable = false)

--- a/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/SeatTimeSlot.java
+++ b/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/SeatTimeSlot.java
@@ -1,0 +1,129 @@
+package com.seatliberator.seatliberator.reservation.domain.persistence;
+
+import com.seatliberator.seatliberator.kernel.condition.Preconditions;
+import com.seatliberator.seatliberator.reservation.domain.EmbeddableTimeRange;
+import com.seatliberator.seatliberator.reservation.domain.TimeRange;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "seat_time_slot",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_seat_time_slot_seat_id_and_slot_start_at_slot_and_end_at",
+                        columnNames = {"seat_id", "slot_start_at", "slot_end_at"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SeatTimeSlot {
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "slot_status", nullable = false)
+    SeatTimeSlotStatus slotStatus;
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "seat_id", nullable = false)
+    private Seat seat;
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "startAt", column = @Column(name = "slot_start_at", nullable = false)),
+            @AttributeOverride(name = "endAt", column = @Column(name = "slot_end_at", nullable = false))
+    })
+    private EmbeddableTimeRange slotRange;
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "last_activated_at")
+    private Instant lastActivatedAt;
+
+    @Column(name = "last_inactivated_at")
+    private Instant lastInactivatedAt;
+
+    private SeatTimeSlot(
+            Seat seat,
+            EmbeddableTimeRange slotRange,
+            SeatTimeSlotStatus slotStatus,
+            Instant createdAt
+    ) {
+        this.seat = Preconditions.requireNonNull(seat, "seat");
+        this.slotRange = Preconditions.requireNonNull(slotRange, "slotRange");
+        this.slotStatus = Preconditions.requireNonNull(slotStatus, "slotStatus");
+        this.createdAt = Preconditions.requireNonNull(createdAt, "createdAt");
+
+        switch (slotStatus) {
+            case ACTIVE -> this.lastActivatedAt = createdAt;
+            case INACTIVE -> this.lastInactivatedAt = createdAt;
+        }
+    }
+
+    public static SeatTimeSlot of(
+            Seat seat,
+            TimeRange slotRange,
+            SeatTimeSlotStatus slotStatus,
+            Instant createdAt
+    ) {
+        Preconditions.requireNonNull(slotRange, "slotRange");
+        return new SeatTimeSlot(
+                seat,
+                EmbeddableTimeRange.of(slotRange),
+                slotStatus,
+                createdAt
+        );
+    }
+
+    public void updateSlotRange(TimeRange slotRange) {
+        Preconditions.requireNonNull(slotRange, "slotRange");
+        this.slotRange = EmbeddableTimeRange.of(slotRange);
+    }
+
+
+    public void active(Instant activatedAt) {
+        Preconditions.requireNonNull(activatedAt, "activatedAt");
+
+        ensureDifferentStatus(SeatTimeSlotStatus.ACTIVE);
+        ensureNotBefore(activatedAt, "activatedAt", createdAt, "createdAt");
+        ensureNotBefore(activatedAt, "activatedAt", lastInactivatedAt, "lastInactivatedAt");
+
+        this.lastActivatedAt = activatedAt;
+        this.slotStatus = SeatTimeSlotStatus.ACTIVE;
+    }
+
+    public void inactive(Instant inactivatedAt) {
+        Preconditions.requireNonNull(inactivatedAt, "inactivatedAt");
+
+        ensureDifferentStatus(SeatTimeSlotStatus.INACTIVE);
+        ensureNotBefore(inactivatedAt, "inactivatedAt", createdAt, "createdAt");
+        ensureNotBefore(inactivatedAt, "inactivatedAt", lastActivatedAt, "lastActivatedAt");
+
+        this.lastInactivatedAt = inactivatedAt;
+        this.slotStatus = SeatTimeSlotStatus.INACTIVE;
+    }
+
+    private void ensureNotBefore(Instant at, String fieldName, Instant ref, String refFieldName) {
+        if (at.isBefore(ref)) throw new IllegalArgumentException(String.format(
+                "%s can not be earlier than %s.",
+                fieldName,
+                refFieldName
+        ));
+    }
+
+    private void ensureDifferentStatus(SeatTimeSlotStatus slotStatus) {
+        if (this.slotStatus == slotStatus) {
+            throw new IllegalStateException(String.format(
+                    "Can not transition to %s from %s",
+                    slotStatus.name().toLowerCase(),
+                    this.slotStatus.name().toLowerCase()
+            ));
+        }
+    }
+}

--- a/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/SeatTimeSlotStatus.java
+++ b/reservation/reservation-domain/src/main/java/com/seatliberator/seatliberator/reservation/domain/persistence/SeatTimeSlotStatus.java
@@ -1,0 +1,6 @@
+package com.seatliberator.seatliberator.reservation.domain.persistence;
+
+public enum SeatTimeSlotStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/ActiveInactiveTransitionContractTest.java
+++ b/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/ActiveInactiveTransitionContractTest.java
@@ -1,0 +1,185 @@
+package com.seatliberator.seatliberator.reservation.domain;
+
+import com.seatliberator.seatliberator.reservation.domain.fixture.TestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public interface ActiveInactiveTransitionContractTest<T> {
+    Instant now = TestSupport.fixedClock.instant();
+
+    T createActive(Instant createdAt);
+
+    T createInactive(Instant createdAt);
+
+    T activate(T domain, Instant activatedAt);
+
+    T inactivate(T domain, Instant inactivatedAt);
+
+    boolean isActive(T domain);
+
+    Instant getCreatedAt(T domain);
+
+    Instant getLastActivatedAt(T domain);
+
+    Instant getLastInactivatedAt(T domain);
+
+    @Test
+    @DisplayName("활성화 상태에서 비활성화 가능")
+    default void transition_active_to_inactive() {
+        var d = createActive(now);
+        inactivate(d, now.plusSeconds(5));
+        assertThat(isActive(d)).isFalse();
+    }
+
+    @Test
+    @DisplayName("활성화 상태에서 다시 활성화시 예외")
+    default void throw_exception_when_transition_active_to_active() {
+        var d = createActive(now);
+        var s = snapshot(d);
+
+        assertThatThrownBy(() -> activate(d, now.plusSeconds(5)))
+                .isInstanceOf(IllegalStateException.class);
+        assertUnchanged(d, s);
+    }
+
+    @Test
+    @DisplayName("활성화 시 직전 활성화 시각은 새로운 활성화 시각으로 갱신된다.")
+    default void update_lastActivatedAt_to_activatedAt_when_activate() {
+        var d = createInactive(now);
+        var beforeLastInactivatedAt = getLastInactivatedAt(d);
+        var activatedAt = now.plusSeconds(5);
+
+        activate(d, activatedAt);
+
+        assertThat(isActive(d)).isTrue();
+        assertThat(getLastActivatedAt(d)).isEqualTo(activatedAt);
+        assertThat(getLastInactivatedAt(d)).isEqualTo(beforeLastInactivatedAt);
+    }
+
+    @Test
+    @DisplayName("활성화 시, 활성화 시각이 직전 비활성화 시각보다 과거면 예외")
+    default void throw_exception_when_activatedAt_is_before_than_lastInactivatedAt() {
+        var d = createActive(now);
+        var inactivatedAt = now.plusSeconds(5);
+        inactivate(d, inactivatedAt);
+        var s = snapshot(d);
+
+        assertThatThrownBy(() -> activate(d, inactivatedAt.minusSeconds(3)))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertUnchanged(d, s);
+    }
+
+    @Test
+    @DisplayName("활성화 시 활성 시각이 생성 시각보다 과거면 예외")
+    default void throw_exception_when_activatedAt_is_before_than_createdAt() {
+        var d = createInactive(now);
+        var before = snapshot(d);
+
+        assertThatThrownBy(() -> activate(d, now.minusSeconds(5)))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertUnchanged(d, before);
+    }
+
+    @Test
+    @DisplayName("생성 시각과 같은 시각에 활성화 가능")
+    default void activate_with_activatedAt_as_same_as_createdAt() {
+        var d = createInactive(now);
+
+        activate(d, now);
+
+        assertThat(isActive(d)).isTrue();
+        assertThat(getLastActivatedAt(d)).isEqualTo(now);
+    }
+
+    @Test
+    @DisplayName("비활성화 상태에서 활성화 가능")
+    default void transition_inactive_to_active() {
+        var d = createInactive(now);
+        activate(d, now.plusSeconds(5));
+        assertThat(isActive(d)).isTrue();
+    }
+
+    @Test
+    @DisplayName("비활성화 상태에서 다시 비활성화시 예외")
+    default void throw_exception_when_transition_inactive_to_inactive() {
+        var d = createInactive(now);
+        var s = snapshot(d);
+
+        assertThatThrownBy(() -> inactivate(d, now.plusSeconds(5)))
+                .isInstanceOf(IllegalStateException.class);
+        assertUnchanged(d, s);
+    }
+
+    @Test
+    @DisplayName("비활성화 시 직전 비활성화 시각은 새로운 비활성화 시각으로 갱신된다.")
+    default void update_lastInactivatedAt_to_inactivatedAt_when_inactivate() {
+        var d = createActive(now);
+        var beforeLastActivatedAt = getLastActivatedAt(d);
+        var inactivatedAt = now.plusSeconds(5);
+
+        inactivate(d, inactivatedAt);
+
+        assertThat(isActive(d)).isFalse();
+        assertThat(getLastInactivatedAt(d)).isEqualTo(inactivatedAt);
+        assertThat(getLastActivatedAt(d)).isEqualTo(beforeLastActivatedAt);
+    }
+
+    @Test
+    @DisplayName("비활성화 시, 비활성화 시각이 직전 활활성화 시각보다 과거면 예외")
+    default void throw_exception_when_inactivatedAt_is_before_than_lastActivatedAt() {
+        var d = createInactive(now);
+        var activatedAt = now.plusSeconds(5);
+        activate(d, activatedAt);
+        var s = snapshot(d);
+
+        assertThatThrownBy(() -> inactivate(d, activatedAt.minusSeconds(3)))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertUnchanged(d, s);
+    }
+
+    @Test
+    @DisplayName("비활성화 시 비활성 시각이 생성 시각보다 과거면 예외")
+    default void throw_exception_when_inactivatedAt_is_before_than_createdAt() {
+        var d = createActive(now);
+        var before = snapshot(d);
+
+        assertThatThrownBy(() -> inactivate(d, now.minusSeconds(5)))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertUnchanged(d, before);
+    }
+
+    @Test
+    @DisplayName("생성 시각과 같은 시각에 비활성화 가능")
+    default void inactivate_with_inactivatedAt_as_same_as_createdAt() {
+        var d = createActive(now);
+
+        inactivate(d, now);
+
+        assertThat(isActive(d)).isFalse();
+        assertThat(getLastInactivatedAt(d)).isEqualTo(now);
+    }
+
+    private ActiveInactiveSnapshot snapshot(T domain) {
+        return new ActiveInactiveSnapshot(
+                isActive(domain),
+                getLastActivatedAt(domain),
+                getLastInactivatedAt(domain)
+        );
+    }
+
+    private void assertUnchanged(T domain, ActiveInactiveSnapshot before) {
+        assertThat(snapshot(domain)).isEqualTo(before);
+    }
+
+    record ActiveInactiveSnapshot(
+            boolean active,
+            Instant lastActivatedAt,
+            Instant lastInactivatedAt
+    ) {
+    }
+}

--- a/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/EmbeddableTimeRangeTest.java
+++ b/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/EmbeddableTimeRangeTest.java
@@ -7,15 +7,31 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 
+import static com.seatliberator.seatliberator.kernel.test.assertion.DomainAssertions.assertThatDomainThrownBy;
 import static com.seatliberator.seatliberator.reservation.domain.fixture.TestSupport.fixedClock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("Domain: Embeddable Time Range")
-public class EmbeddableTimeRangeTest {
+public class EmbeddableTimeRangeTest implements TimeRangeContractTest<EmbeddableTimeRange> {
 
     Instant startAt = fixedClock.instant();
     Instant endAt = startAt.plusSeconds(60 * 30);
+
+    @Override
+    public EmbeddableTimeRange create(Instant startAt, Instant endAt) {
+        return EmbeddableTimeRange.from(startAt, endAt);
+    }
+
+    @Override
+    public Instant getStartAt() {
+        return startAt;
+    }
+
+    @Override
+    public Instant getEndAt() {
+        return endAt;
+    }
 
     @Nested
     @DisplayName("Creation")
@@ -32,17 +48,15 @@ public class EmbeddableTimeRangeTest {
         @Test
         @DisplayName("시작 시간이 null이면 예외를 던진다")
         void throw_exception_when_start_at_is_null() {
-            assertThatThrownBy(() -> new EmbeddableTimeRange(null, endAt))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("startAt must not be null.");
+            assertThatDomainThrownBy(() -> new EmbeddableTimeRange(null, endAt))
+                    .hasNonNullMessageFor("startAt");
         }
 
         @Test
         @DisplayName("종료 시간이 null이면 예외를 던진다")
         void throw_exception_when_end_at_is_null() {
-            assertThatThrownBy(() -> new EmbeddableTimeRange(startAt, null))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("endAt must not be null.");
+            assertThatDomainThrownBy(() -> new EmbeddableTimeRange(startAt, null))
+                    .hasNonNullMessageFor("endAt");
         }
 
         @Test

--- a/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/SimpleTimeRangeTest.java
+++ b/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/SimpleTimeRangeTest.java
@@ -11,10 +11,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("Domain: Simple Time Range")
-public class SimpleTimeRangeTest {
+public class SimpleTimeRangeTest implements TimeRangeContractTest<SimpleTimeRange> {
 
     Instant startAt = fixedClock.instant();
     Instant endAt = startAt.plusSeconds(60 * 30);
+
+    @Override
+    public SimpleTimeRange create(Instant startAt, Instant endAt) {
+        return SimpleTimeRange.of(startAt, endAt);
+    }
+
+    @Override
+    public Instant getStartAt() {
+        return startAt;
+    }
+
+    @Override
+    public Instant getEndAt() {
+        return endAt;
+    }
 
     @Nested
     @DisplayName("Creation")

--- a/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/TimeRangeContractTest.java
+++ b/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/TimeRangeContractTest.java
@@ -1,0 +1,99 @@
+package com.seatliberator.seatliberator.reservation.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public interface TimeRangeContractTest<T extends TimeRange> {
+
+    T create(Instant startAt, Instant endAt);
+
+    Instant getStartAt();
+
+    Instant getEndAt();
+
+    @Test
+    @DisplayName("시작 시간과 종료 시간을 가진 TimeRange를 만들 수 있다")
+    default void create_range_when_arguments_are_valid() {
+        var startAt = getStartAt();
+        var endAt = getEndAt();
+
+        var range = create(startAt, endAt);
+
+        assertThat(range.startAt()).isEqualTo(startAt);
+        assertThat(range.endAt()).isEqualTo(endAt);
+    }
+
+    @Test
+    @DisplayName("시작 시간 이상 종료 시간 미만이면 포함한다")
+    default void contains_time_within_range() {
+        var startAt = getStartAt();
+        var endAt = getEndAt();
+        var range = create(startAt, endAt);
+
+        assertThat(range.contains(startAt)).isTrue();
+        assertThat(range.contains(endAt.minusNanos(1))).isTrue();
+    }
+
+    @Test
+    @DisplayName("시작 시간 이전과 종료 시간 이후는 포함하지 않는다")
+    default void does_not_contain_time_outside_range() {
+        var startAt = getStartAt();
+        var endAt = getEndAt();
+        var range = create(startAt, endAt);
+
+        assertThat(range.contains(startAt.minusNanos(1))).isFalse();
+        assertThat(range.contains(endAt)).isFalse();
+    }
+
+    @Test
+    @DisplayName("종료 시간 이상이면 종료된 상태다")
+    default void return_true_when_time_is_on_or_after_end_at() {
+        var startAt = getStartAt();
+        var endAt = getEndAt();
+        var range = create(startAt, endAt);
+
+        assertThat(range.isEnded(endAt.minusNanos(1))).isFalse();
+        assertThat(range.isEnded(endAt)).isTrue();
+        assertThat(range.isEnded(endAt.plusSeconds(1))).isTrue();
+    }
+
+    @Test
+    @DisplayName("시작 시간과 종료 시간이 같으면 isSame은 true다")
+    default void is_same_with_same_value() {
+        var startAt = getStartAt();
+        var endAt = getEndAt();
+        var range = create(startAt, endAt);
+        var other = create(startAt, endAt);
+
+        assertThat(range.isSame(other)).isTrue();
+    }
+
+    @Test
+    @DisplayName("시작 시간 또는 종료 시간이 다르면 isSame은 false다")
+    default void is_not_same_when_value_is_different() {
+        var startAt = getStartAt();
+        var endAt = getEndAt();
+        var range = create(startAt, endAt);
+        var differentStart = create(startAt.plusSeconds(1), endAt.plusSeconds(1));
+        var differentEnd = create(startAt, endAt.plusSeconds(1));
+
+        assertThat(range.isSame(differentStart)).isFalse();
+        assertThat(range.isSame(differentEnd)).isFalse();
+    }
+
+    @Test
+    @DisplayName("서로 다른 TimeRange 구현체라도 같은 시간이면 isSame은 true다")
+    default void is_same_across_different_implementations() {
+        var startAt = getStartAt();
+        var endAt = getEndAt();
+        var simple = SimpleTimeRange.of(startAt, endAt);
+        var embeddable = EmbeddableTimeRange.from(startAt, endAt);
+
+        assertThat(simple.isSame(embeddable)).isTrue();
+        assertThat(embeddable.isSame(simple)).isTrue();
+    }
+}

--- a/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/persistence/RoomOperationPolicyTest.java
+++ b/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/persistence/RoomOperationPolicyTest.java
@@ -1,0 +1,128 @@
+package com.seatliberator.seatliberator.reservation.domain.persistence;
+
+import com.seatliberator.seatliberator.reservation.domain.fixture.RoomOperationPolicyFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static com.seatliberator.seatliberator.kernel.test.assertion.DomainAssertions.assertThatDomainThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+@DisplayName("RoomOperationPolicy 도메인 테스트")
+public class RoomOperationPolicyTest {
+
+    @Nested
+    @DisplayName("생성 테스트")
+    class CreationTest {
+        static Stream<Arguments> nullArgumentCases() {
+            return Stream.of(
+                    arguments("maxReservationPerUser = null", (Supplier<RoomOperationPolicy>) () -> new RoomOperationPolicyFixture.Builder().maxReservationPerUser(null).build(), "maxReservationPerUser"),
+                    arguments("maxReservationDuration = null", (Supplier<RoomOperationPolicy>) () -> new RoomOperationPolicyFixture.Builder().maxReservationDuration(null).build(), "maxReservationDuration"),
+                    arguments("operationStatus = null", (Supplier<RoomOperationPolicy>) () -> new RoomOperationPolicyFixture.Builder().operationStatus(null).build(), "operationStatus"),
+                    arguments("operationRange = null", (Supplier<RoomOperationPolicy>) () -> new RoomOperationPolicyFixture.Builder().operationRange(null).build(), "operationRange")
+            );
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("nullArgumentCases")
+        @DisplayName("인자가 null이면 예외")
+        void throw_exception_when_required_argument_is_null(
+                String displayName,
+                Supplier<RoomOperationPolicy> supplier,
+                String fieldName
+        ) {
+            assertThatDomainThrownBy(supplier::get)
+                    .hasNonNullMessageFor(fieldName);
+        }
+
+        @ParameterizedTest(name = "maxReservationPerUser = {0}")
+        @ValueSource(ints = {0, -2, -1})
+        @DisplayName("maxReservationPerUser가 음수 또는 0이면 예외")
+        void throw_exception_when_maxReservationPerUser_is_negative(int maxReservationPerUser) {
+            assertThatDomainThrownBy(() -> new RoomOperationPolicyFixture.Builder().maxReservationPerUser(maxReservationPerUser).build())
+                    .hasPositiveMessageFor("maxReservationPerUser");
+        }
+
+        static Stream<Arguments> nonPositiveDurationCases() {
+            return Stream.of(
+                    arguments("maxReservationDuration = zero", Duration.ZERO),
+                    arguments("maxReservationDuration = negative", Duration.ofMinutes(-1))
+            );
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("nonPositiveDurationCases")
+        @DisplayName("maxReservationDuration이 0 또는 음수이면 예외")
+        void throw_exception_when_maxReservationDuration_is_not_positive(
+                String displayName,
+                Duration maxReservationDuration
+        ) {
+            assertThatDomainThrownBy(() -> new RoomOperationPolicyFixture.Builder().maxReservationDuration(maxReservationDuration).build())
+                    .hasPositiveMessageFor("maxReservationDuration");
+        }
+    }
+
+    @Nested
+    @DisplayName("변경 테스트")
+    class UpdateTest {
+        static Stream<Arguments> nullArgumentCases() {
+            return Stream.of(
+                    arguments("maxReservationPerUser = null", (Consumer<RoomOperationPolicy>) (policy) -> policy.updateMaxReservationPerUser(null), "maxReservationPerUser"),
+                    arguments("maxReservationDuration = null", (Consumer<RoomOperationPolicy>) (policy) -> policy.updateMaxReservationDuration(null), "maxReservationDuration"),
+                    arguments("operationStatus = null", (Consumer<RoomOperationPolicy>) (policy) -> policy.updateOperationStatus(null), "operationStatus"),
+                    arguments("operationRange = null", (Consumer<RoomOperationPolicy>) (policy) -> policy.updateOperationRange(null), "operationRange")
+            );
+        }
+
+        static Stream<Arguments> nonPositiveDurationCases() {
+            return Stream.of(
+                    arguments("maxReservationDuration = zero", Duration.ZERO),
+                    arguments("maxReservationDuration = negative", Duration.ofMinutes(-1))
+            );
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("nullArgumentCases")
+        @DisplayName("null 인자로 변경 시 예외")
+        void throw_exception_when_update_with_null(
+                String displayName,
+                Consumer<RoomOperationPolicy> consumer,
+                String fieldName
+        ) {
+            var policy = RoomOperationPolicyFixture.get();
+            assertThatDomainThrownBy(() -> consumer.accept(policy))
+                    .hasNonNullMessageFor(fieldName);
+        }
+
+        @ParameterizedTest(name = "maxReservationPerUser = {0}")
+        @ValueSource(ints = {0, -2, -1})
+        @DisplayName("maxReservationPerUser를 0 또는 음수로 변경하면 예외")
+        void throw_exception_when_update_maxReservationPerUser_when_non_positive_value(int maxReservationPerUser) {
+            var policy = RoomOperationPolicyFixture.get();
+
+            assertThatDomainThrownBy(() -> policy.updateMaxReservationPerUser(maxReservationPerUser))
+                    .hasPositiveMessageFor("maxReservationPerUser");
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("nonPositiveDurationCases")
+        @DisplayName("maxReservationDuration을 0 또는 음수로 변경하면 예외")
+        void throw_exception_when_update_maxReservationDuration_with_non_positive_value(
+                String displayName,
+                Duration maxReservationDuration
+        ) {
+            var policy = RoomOperationPolicyFixture.get();
+
+            assertThatDomainThrownBy(() -> policy.updateMaxReservationDuration(maxReservationDuration))
+                    .hasPositiveMessageFor("maxReservationDuration");
+        }
+    }
+}

--- a/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/persistence/RoomTest.java
+++ b/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/persistence/RoomTest.java
@@ -3,21 +3,31 @@ package com.seatliberator.seatliberator.reservation.domain.persistence;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Instant;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
+import static com.seatliberator.seatliberator.kernel.test.assertion.DomainAssertions.assertThatDomainThrownBy;
+import static com.seatliberator.seatliberator.reservation.domain.fixture.RoomFixture.INITIAL_ROOM_ID;
+import static com.seatliberator.seatliberator.reservation.domain.fixture.SeatFixture.INITIAL_CREATED_AT;
 import static com.seatliberator.seatliberator.reservation.domain.fixture.TestSupport.fixedClock;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-@DisplayName("Room")
+@DisplayName("Room 도메인 테스트")
 public class RoomTest {
 
     Instant now = fixedClock.instant();
 
     @Nested
-    @DisplayName("Creation")
-    class Creation {
+    @DisplayName("생성 테스트")
+    class CreationTest {
         @Test
         @DisplayName("유효한 Id와 현재 시각으로 생성한다")
         void create_with_valid_name_and_created_at() {
@@ -29,30 +39,37 @@ public class RoomTest {
             assertThat(room.getCreatedAt()).isEqualTo(now);
         }
 
-        @Test
-        @DisplayName("유효하지 않은 Id 전달하면 예외")
-        void throw_exception_when_invalid_name() {
-            var roomId = " ";
-
-            assertThatThrownBy(() -> Room.of(roomId, now))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("roomId must not be null or blank.");
+        static Stream<Arguments> nullArgumentCases() {
+            return Stream.of(
+                    arguments("roomId = null", (Supplier<Room>) () -> Room.of(null, INITIAL_CREATED_AT), "roomId"),
+                    arguments("createdAt = null", (Supplier<Room>) () -> Room.of(INITIAL_ROOM_ID, null), "createdAt")
+            );
         }
 
-        @Test
-        @DisplayName("유효하지 않은 현재 시각 전달하면 예외")
-        void throw_exception_when_invalid_created_at() {
-            var roomId = "study-room-1";
+        @ParameterizedTest(name = "roomId = {0}")
+        @ValueSource(strings = {" ", "  ", "\t", "\n"})
+        @DisplayName("공백 roomId 전달하면 예외")
+        void throw_exception_when_invalid_name(String roomId) {
+            assertThatDomainThrownBy(() -> Room.of(roomId, now))
+                    .hasNonBlankMessageFor("roomId");
+        }
 
-            assertThatThrownBy(() -> Room.of(roomId, null))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("createdAt must not be null.");
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("nullArgumentCases")
+        @DisplayName("인자가 null이면 예외")
+        void throw_exception_when_required_argument_is_null(
+                String displayName,
+                Supplier<Room> supplier,
+                String fieldName
+        ) {
+            assertThatDomainThrownBy(supplier::get)
+                    .hasNonNullMessageFor(fieldName);
         }
     }
 
     @Nested
-    @DisplayName("Update")
-    class Update {
+    @DisplayName("변경 테스트")
+    class UpdateTest {
         @Test
         @DisplayName("방 ID를 변경할 수 있다")
         void update_room_id() {
@@ -67,26 +84,30 @@ public class RoomTest {
             assertThat(room.getRoomId()).isEqualTo(newRoomId);
         }
 
-        @Test
-        @DisplayName("유효하지 않은 방 ID로 변경하면 예외")
-        void throw_exception_when_update_with_invalid_roomId() {
+        @ParameterizedTest(name = "newRoomId = {0}")
+        @ValueSource(strings = {" ", "  ", "\t", "\n"})
+        @DisplayName("roomId가 공백이면 예외, 값은 안바뀐다")
+        void throw_exception_when_update_with_empty_roomId(String newRoomId) {
             var roomId = "study-room-1";
             var room = Room.of(roomId, now);
 
-            assertThat(room.getRoomId()).isEqualTo(roomId);
-
-            assertThatThrownBy(() -> room.updateRoomId(null))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("roomId must not be null or blank.");
-
-            var newRoomId = " ";
-            assertThatThrownBy(() -> room.updateRoomId(newRoomId))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("roomId must not be null or blank.");
+            assertThatDomainThrownBy(() -> room.updateRoomId(newRoomId))
+                    .hasNonBlankMessageFor("roomId");
 
             assertThat(room.getRoomId()).isEqualTo(roomId);
         }
 
+        @ParameterizedTest(name = "newRoomId = {0}")
+        @NullSource
+        @DisplayName("roomId가 null이면 예외, 값은 안바뀐다")
+        void throw_exception_when_update_with_null_roomId(String newRoomId) {
+            var roomId = "study-room-1";
+            var room = Room.of(roomId, now);
 
+            assertThatDomainThrownBy(() -> room.updateRoomId(newRoomId))
+                    .hasNonNullMessageFor("roomId");
+
+            assertThat(room.getRoomId()).isEqualTo(roomId);
+        }
     }
 }

--- a/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/persistence/SeatTest.java
+++ b/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/persistence/SeatTest.java
@@ -1,49 +1,40 @@
 package com.seatliberator.seatliberator.reservation.domain.persistence;
 
 import com.seatliberator.seatliberator.reservation.domain.SeatStatus;
-import com.seatliberator.seatliberator.reservation.domain.SimpleSeatLocator;
 import com.seatliberator.seatliberator.reservation.domain.fixture.RoomFixture;
 import com.seatliberator.seatliberator.reservation.domain.fixture.SeatFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
+import static com.seatliberator.seatliberator.kernel.test.assertion.DomainAssertions.assertThatDomainThrownBy;
 import static com.seatliberator.seatliberator.reservation.domain.fixture.RoomFixture.createRoom;
-import static com.seatliberator.seatliberator.reservation.domain.fixture.SeatFixture.createSeat;
+import static com.seatliberator.seatliberator.reservation.domain.fixture.SeatFixture.*;
 import static com.seatliberator.seatliberator.reservation.domain.fixture.TestSupport.fixedClock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-@DisplayName("Seat")
+@DisplayName("Seat 도메인 테스트")
 public class SeatTest {
 
     Clock clock = fixedClock;
 
     Instant now = clock.instant();
 
-    @Test
-    @DisplayName("seatId와 속한 Room의 Id로 SeatLocator를 생성한다")
-    void create_seat_locator() {
-        var roomId = "study-room-1";
-        var seatId = "seat-A";
-
-        var room = createRoom(roomId, now);
-        var seat = new SeatFixture.Builder()
-                .room(room)
-                .seatId(seatId)
-                .build();
-
-        var locator = seat.getLocator();
-
-        assertThat(locator.key()).isEqualTo(SimpleSeatLocator.of(roomId, seatId).key());
-    }
-
     @Nested
-    @DisplayName("Creation")
-    class Creation {
+    @DisplayName("생성 테스트")
+    class CreationTest {
         @Test
         @DisplayName("room과 seatId를 넘겨서 Seat 생성 가능")
         void create_with_roomId_and_seatId() {
@@ -55,37 +46,28 @@ public class SeatTest {
             assertThat(seat.getCreatedAt()).isEqualTo(now);
         }
 
-        @Test
-        @DisplayName("room이 null이면 예외")
-        void throw_exception_when_room_is_null() {
-            var seatId = "seat-A";
-            assertThatThrownBy(() -> Seat.of(null, seatId, now))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("room must not be null.");
+        static Stream<Arguments> nullArgumentCases() {
+            var room = createRoom();
+            var seatId = INITIAL_SEAT_ID;
+            var now = INITIAL_CREATED_AT;
+
+            return Stream.of(
+                    arguments("room = null", (Supplier<Seat>) () -> Seat.of(null, seatId, now), "room"),
+                    arguments("seatId = null", (Supplier<Seat>) () -> Seat.of(room, null, now), "seatId"),
+                    arguments("createdAt = null", (Supplier<Seat>) () -> Seat.of(room, seatId, null), "createdAt")
+            );
         }
 
-        @Test
-        @DisplayName("seatId가 유효하지않으면 예외")
-        void throw_exception_when_seatId_is_null() {
-            var room = createRoom();
-
-            assertThatThrownBy(() -> Seat.of(room, null, now))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("seatId must not be null or blank.");
-
-            assertThatThrownBy(() -> Seat.of(room, " ", now))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("seatId must not be null or blank.");
-        }
-
-        @Test
-        @DisplayName("createAt이 null이면 예외")
-        void throw_exception_when_createdAt_is_null() {
-            var room = createRoom();
-            var seatId = "seat-A";
-            assertThatThrownBy(() -> Seat.of(room, seatId, null))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("createdAt must not be null.");
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("nullArgumentCases")
+        @DisplayName("인자가 null이면 예외")
+        void throw_exception_when_required_argument_is_null(
+                String displayName,
+                Supplier<Seat> supplier,
+                String fieldName
+        ) {
+            assertThatDomainThrownBy(supplier::get)
+                    .hasNonNullMessageFor(fieldName);
         }
 
         @Test
@@ -109,11 +91,21 @@ public class SeatTest {
             assertThat(seat.getStatus()).isEqualTo(SeatStatus.INACTIVE);
             assertThat(seat.getCreatedAt()).isEqualTo(seat.getLastInactivatedAt());
         }
+
+        @ParameterizedTest(name = "seatId = {0}")
+        @ValueSource(strings = {" ", "  ", "\t", "\n"})
+        @DisplayName("seatId가 공백이면 예외")
+        void throw_exception_when_empty_seatId(String seatId) {
+            var room = createRoom();
+
+            assertThatDomainThrownBy(() -> Seat.of(room, seatId, now))
+                    .hasNonBlankMessageFor("seatId");
+        }
     }
 
     @Nested
-    @DisplayName("Update")
-    class Update {
+    @DisplayName("변경 테스트")
+    class UpdateTest {
         @Test
         @DisplayName("새로운 seatId로 변경 가능")
         void update_with_new_seatId() {
@@ -129,24 +121,24 @@ public class SeatTest {
             assertThat(seat.getSeatId()).isEqualTo(newSeatId);
         }
 
-        @Test
-        @DisplayName("유효하지 않은 seatId를 넘기면 예외")
-        void throw_exception_when_update_with_invalid_seatId() {
-            var room = createRoom();
-            var seatId = "seat-A";
-            var seat = Seat.of(room, seatId, now);
+        static Stream<Arguments> nullArgumentCases() {
+            return Stream.of(
+                    arguments("room = null", (Consumer<Seat>) (seat) -> seat.updateRoom(null), "room"),
+                    arguments("seatId = null", (Consumer<Seat>) (seat) -> seat.updateSeatId(null), "seatId")
+            );
+        }
 
-            assertThat(seat.getSeatId()).isEqualTo(seatId);
-
-            assertThatThrownBy(() -> seat.updateSeatId(null))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("seatId must not be null or blank.");
-
-            assertThatThrownBy(() -> seat.updateSeatId(" "))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("seatId must not be null or blank.");
-
-            assertThat(seat.getSeatId()).isEqualTo(seatId);
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("nullArgumentCases")
+        @DisplayName("null 인자로 변경 시 예외")
+        void throw_exception_when_update_with_null(
+                String displayName,
+                Consumer<Seat> consumer,
+                String fieldName
+        ) {
+            var seat = createSeat();
+            assertThatDomainThrownBy(() -> consumer.accept(seat))
+                    .hasNonNullMessageFor(fieldName);
         }
 
         @Test
@@ -170,31 +162,10 @@ public class SeatTest {
                     .build();
 
             assertThat(seat.getRoom()).isEqualTo(oldRoom);
-            assertThat(oldRoom.getSeats())
-                    .extracting(Seat::getSeatId)
-                    .containsExactly(seatId);
 
             seat.updateRoom(newRoom);
 
             assertThat(seat.getRoom()).isEqualTo(newRoom);
-
-            assertThat(oldRoom.getSeats())
-                    .extracting(Seat::getSeatId)
-                    .doesNotContain(seatId);
-
-            assertThat(newRoom.getSeats())
-                    .extracting(Seat::getSeatId)
-                    .containsExactly(seatId);
-        }
-
-        @Test
-        @DisplayName("유효하지 않은 방으로 변경하면 예외")
-        void throw_exception_when_update_invalid_room() {
-            var seat = createSeat();
-
-            assertThatThrownBy(() -> seat.updateRoom(null))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("room must not be null.");
         }
 
         @Test
@@ -208,15 +179,25 @@ public class SeatTest {
             seat.updateRoom(room);
 
             assertThat(seat.getRoom()).isEqualTo(room);
-            assertThat(room.getSeats())
-                    .extracting(Seat::getSeatId)
-                    .containsExactly(seatId);
+        }
+
+        @ParameterizedTest(name = "newSeatId = {0}")
+        @ValueSource(strings = {" ", "  ", "\t", "\n"})
+        @DisplayName("seatId가 공백이면 예외, 값은 안바뀐다.")
+        void throw_exception_when_update_with_empty_seatId(String newSeatId) {
+            var seat = createSeat();
+            var seatId = seat.getSeatId();
+
+            assertThatDomainThrownBy(() -> seat.updateSeatId(newSeatId))
+                    .hasNonBlankMessageFor("seatId");
+
+            assertThat(seat.getSeatId()).isEqualTo(seatId);
         }
     }
 
     @Nested
-    @DisplayName("Transition")
-    class Transition {
+    @DisplayName("상태 전이 테스트")
+    class TransitionTest {
         @Test
         @DisplayName("좌석을 비활성화 상태로 변경할 수 있다")
         void can_transition_inactive() {
@@ -275,8 +256,8 @@ public class SeatTest {
     }
 
     @Nested
-    @DisplayName("Time")
-    class Time {
+    @DisplayName("시간 불변식 테스트")
+    class TimeInvariantTest {
         @Test
         @DisplayName("좌석 비활성화 시, 비활성화 시각이 null이면 예외")
         void throw_exception_when_inactive_with_null_inactivated_at() {
@@ -285,9 +266,8 @@ public class SeatTest {
                     .createdAt(now)
                     .build();
 
-            assertThatThrownBy(() -> seat.inactive(null))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("inactivatedAt must not be null.");
+            assertThatDomainThrownBy(() -> seat.inactive(null))
+                    .hasNonNullMessageFor("inactivatedAt");
         }
 
         @Test
@@ -360,9 +340,8 @@ public class SeatTest {
 
             assertThat(seat.getStatus()).isEqualTo(SeatStatus.INACTIVE);
 
-            assertThatThrownBy(() -> seat.active(null))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("activatedAt must not be null.");
+            assertThatDomainThrownBy(() -> seat.active(null))
+                    .hasNonNullMessageFor("activatedAt");
         }
 
         @Test

--- a/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/persistence/SeatTest.java
+++ b/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/persistence/SeatTest.java
@@ -1,5 +1,6 @@
 package com.seatliberator.seatliberator.reservation.domain.persistence;
 
+import com.seatliberator.seatliberator.reservation.domain.ActiveInactiveTransitionContractTest;
 import com.seatliberator.seatliberator.reservation.domain.SeatStatus;
 import com.seatliberator.seatliberator.reservation.domain.fixture.RoomFixture;
 import com.seatliberator.seatliberator.reservation.domain.fixture.SeatFixture;
@@ -22,7 +23,6 @@ import static com.seatliberator.seatliberator.reservation.domain.fixture.RoomFix
 import static com.seatliberator.seatliberator.reservation.domain.fixture.SeatFixture.*;
 import static com.seatliberator.seatliberator.reservation.domain.fixture.TestSupport.fixedClock;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @DisplayName("Seat 도메인 테스트")
@@ -124,7 +124,9 @@ public class SeatTest {
         static Stream<Arguments> nullArgumentCases() {
             return Stream.of(
                     arguments("room = null", (Consumer<Seat>) (seat) -> seat.updateRoom(null), "room"),
-                    arguments("seatId = null", (Consumer<Seat>) (seat) -> seat.updateSeatId(null), "seatId")
+                    arguments("seatId = null", (Consumer<Seat>) (seat) -> seat.updateSeatId(null), "seatId"),
+                    arguments("activatedAt = null", (Consumer<Seat>) (seat) -> seat.active(null), "activatedAt"),
+                    arguments("inactivatedAt = null", (Consumer<Seat>) (seat) -> seat.inactive(null), "inactivatedAt")
             );
         }
 
@@ -197,200 +199,47 @@ public class SeatTest {
 
     @Nested
     @DisplayName("상태 전이 테스트")
-    class TransitionTest {
-        @Test
-        @DisplayName("좌석을 비활성화 상태로 변경할 수 있다")
-        void can_transition_inactive() {
-            var seat = new SeatFixture.Builder()
-                    .status(SeatStatus.ACTIVE)
-                    .createdAt(now)
-                    .build();
-
-            var inactivatedAt = now.plusSeconds(5);
-            seat.inactive(inactivatedAt);
-
-            assertThat(seat.getStatus()).isEqualTo(SeatStatus.INACTIVE);
+    class TransitionTest implements ActiveInactiveTransitionContractTest<Seat> {
+        @Override
+        public Seat createActive(Instant createdAt) {
+            return new SeatFixture.Builder().createdAt(createdAt).status(SeatStatus.ACTIVE).build();
         }
 
-        @Test
-        @DisplayName("비활성화된 좌석을 또 비활성화할 수 없다")
-        void can_not_transition_to_inactive_from_inactive() {
-            var seat = new SeatFixture.Builder()
-                    .status(SeatStatus.INACTIVE)
-                    .createdAt(now)
-                    .build();
-
-            assertThatThrownBy(() -> seat.inactive(now))
-                    .isInstanceOf(IllegalStateException.class)
-                    .hasMessage("Can not transition to inactive from inactive");
+        @Override
+        public Seat createInactive(Instant createdAt) {
+            return new SeatFixture.Builder().createdAt(createdAt).status(SeatStatus.INACTIVE).build();
         }
 
-        @Test
-        @DisplayName("비활성화된 좌석은 다시 활성화할 수 있다")
-        void can_transition_to_active_from_inactive() {
-            var seat = new SeatFixture.Builder()
-                    .status(SeatStatus.INACTIVE)
-                    .createdAt(now)
-                    .build();
-
-            assertThat(seat.getStatus()).isEqualTo(SeatStatus.INACTIVE);
-
-            var activatedAt = now.plusSeconds(5);
-            seat.active(activatedAt);
-
-            assertThat(seat.getStatus()).isEqualTo(SeatStatus.ACTIVE);
+        @Override
+        public Seat activate(Seat domain, Instant activatedAt) {
+            domain.active(activatedAt);
+            return domain;
         }
 
-        @Test
-        @DisplayName("활성화된 좌석은 다시 활성화할 수 없다")
-        void can_not_transition_to_active_from_active() {
-            var seat = new SeatFixture.Builder()
-                    .status(SeatStatus.ACTIVE)
-                    .createdAt(now)
-                    .build();
-
-            assertThatThrownBy(() -> seat.active(now.plusSeconds(5)))
-                    .isInstanceOf(IllegalStateException.class)
-                    .hasMessage("Can not transition to active from active");
-        }
-    }
-
-    @Nested
-    @DisplayName("시간 불변식 테스트")
-    class TimeInvariantTest {
-        @Test
-        @DisplayName("좌석 비활성화 시, 비활성화 시각이 null이면 예외")
-        void throw_exception_when_inactive_with_null_inactivated_at() {
-            var seat = new SeatFixture.Builder()
-                    .status(SeatStatus.ACTIVE)
-                    .createdAt(now)
-                    .build();
-
-            assertThatDomainThrownBy(() -> seat.inactive(null))
-                    .hasNonNullMessageFor("inactivatedAt");
+        @Override
+        public Seat inactivate(Seat domain, Instant inactivatedAt) {
+            domain.inactive(inactivatedAt);
+            return domain;
         }
 
-        @Test
-        @DisplayName("좌석 비활성화 시, 비활성화 시각이 생성 시각보다 과거면 예외")
-        void throw_exception_when_inactivated_at_is_before_than_created_at() {
-            var seat = new SeatFixture.Builder()
-                    .status(SeatStatus.ACTIVE)
-                    .createdAt(now)
-                    .build();
-
-            var inactivatedAt = now.minusSeconds(5);
-            assertThatThrownBy(() -> seat.inactive(inactivatedAt))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("inactivatedAt can not be earlier than createdAt.");
+        @Override
+        public boolean isActive(Seat domain) {
+            return domain.getStatus() == SeatStatus.ACTIVE;
         }
 
-        @Test
-        @DisplayName("좌석 비활성화 시, 비활성화 시각이 직전 활성화 시각보다 과거면 예외")
-        void throw_exception_when_inactivated_at_is_before_than_last_activated_at() {
-            var seat = new SeatFixture.Builder()
-                    .status(SeatStatus.INACTIVE)
-                    .createdAt(now)
-                    .build();
-
-            var activatedAt = now.plusSeconds(5);
-            seat.active(activatedAt);
-
-            var inactivatedAt = activatedAt.minusSeconds(2);
-            assertThatThrownBy(() -> seat.inactive(inactivatedAt))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("inactivatedAt can not be earlier than lastActivatedAt.");
+        @Override
+        public Instant getCreatedAt(Seat domain) {
+            return domain.getCreatedAt();
         }
 
-        @Test
-        @DisplayName("비활성화 시각이 생성 시각과 같으면 허용된다")
-        void can_inactive_with_inactivatedAt_same_as_createdAt() {
-            var seat = new SeatFixture.Builder()
-                    .status(SeatStatus.ACTIVE)
-                    .createdAt(now)
-                    .build();
-
-            seat.inactive(now);
-
-            assertThat(seat.getLastInactivatedAt()).isEqualTo(now);
+        @Override
+        public Instant getLastActivatedAt(Seat domain) {
+            return domain.getLastActivatedAt();
         }
 
-        @Test
-        @DisplayName("활성화된 좌석은 activatedAt을 갖는다")
-        void store_activated_at_when_active_seat() {
-            var seat = new SeatFixture.Builder()
-                    .status(SeatStatus.INACTIVE)
-                    .createdAt(now)
-                    .build();
-
-            assertThat(seat.getStatus()).isEqualTo(SeatStatus.INACTIVE);
-
-            var activatedAt = now.plusSeconds(5);
-            seat.active(activatedAt);
-
-            assertThat(seat.getLastActivatedAt()).isEqualTo(activatedAt);
-        }
-
-        @Test
-        @DisplayName("좌석 활성화 시, activatedAt이 null이면 예외")
-        void throw_exception_when_active_with_null_activated_at() {
-            var seat = new SeatFixture.Builder()
-                    .status(SeatStatus.INACTIVE)
-                    .createdAt(now)
-                    .build();
-
-            assertThat(seat.getStatus()).isEqualTo(SeatStatus.INACTIVE);
-
-            assertThatDomainThrownBy(() -> seat.active(null))
-                    .hasNonNullMessageFor("activatedAt");
-        }
-
-        @Test
-        @DisplayName("좌석 활성화 시, activatedAt이 createdAt보다 과거면 예외")
-        void throw_exception_when_activated_at_is_before_than_created_at() {
-            var seat = new SeatFixture.Builder()
-                    .status(SeatStatus.INACTIVE)
-                    .createdAt(now)
-                    .build();
-
-            assertThat(seat.getStatus()).isEqualTo(SeatStatus.INACTIVE);
-
-            var activatedAt = now.minusSeconds(5);
-            assertThatThrownBy(() -> seat.active(activatedAt))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("activatedAt can not be earlier than createdAt.");
-        }
-
-        @Test
-        @DisplayName("좌석 활성화 시, 활성화 시각이 직전 비활성화 시각보다 과거면 예외")
-        void throw_exception_when_activated_at_is_before_than_last_inactivated_at() {
-            var seat = new SeatFixture.Builder()
-                    .status(SeatStatus.ACTIVE)
-                    .createdAt(now)
-                    .build();
-
-            var inactivatedAt = now.plusSeconds(5);
-            seat.inactive(inactivatedAt);
-
-            var activatedAt = inactivatedAt.minusSeconds(2);
-            assertThatThrownBy(() -> seat.active(activatedAt))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("activatedAt can not be earlier than lastInactivatedAt.");
-        }
-
-        @Test
-        @DisplayName("활성화 시각이 생성 시각과 같으면 허용된다")
-        void can_active_with_activatedAt_same_as_createdAt() {
-            var seat = new SeatFixture.Builder()
-                    .status(SeatStatus.ACTIVE)
-                    .createdAt(now)
-                    .build();
-
-            assertThat(seat.getStatus()).isEqualTo(SeatStatus.ACTIVE);
-
-            seat.inactive(now);
-            seat.active(now);
-
-            assertThat(seat.getLastActivatedAt()).isEqualTo(now);
+        @Override
+        public Instant getLastInactivatedAt(Seat domain) {
+            return domain.getLastInactivatedAt();
         }
     }
 }

--- a/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/persistence/SeatTimeSlotTest.java
+++ b/reservation/reservation-domain/src/test/java/com/seatliberator/seatliberator/reservation/domain/persistence/SeatTimeSlotTest.java
@@ -1,0 +1,116 @@
+package com.seatliberator.seatliberator.reservation.domain.persistence;
+
+import com.seatliberator.seatliberator.reservation.domain.ActiveInactiveTransitionContractTest;
+import com.seatliberator.seatliberator.reservation.domain.fixture.SeatTimeSlotFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Instant;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static com.seatliberator.seatliberator.kernel.test.assertion.DomainAssertions.assertThatDomainThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+@DisplayName("SeatTimeSlot 도메인 테스트")
+public class SeatTimeSlotTest {
+
+    @Nested
+    @DisplayName("생성 테스트")
+    class CreationTest {
+        static Stream<Arguments> nullArgumentCases() {
+            return Stream.of(
+                    arguments("seat = null", (Supplier<SeatTimeSlot>) () -> new SeatTimeSlotFixture.Builder().seat(null).build(), "seat"),
+                    arguments("slotRange = null", (Supplier<SeatTimeSlot>) () -> new SeatTimeSlotFixture.Builder().slotRange(null).build(), "slotRange"),
+                    arguments("slotStatus = null", (Supplier<SeatTimeSlot>) () -> new SeatTimeSlotFixture.Builder().slotStatus(null).build(), "slotStatus"),
+                    arguments("createdAt = null", (Supplier<SeatTimeSlot>) () -> new SeatTimeSlotFixture.Builder().createdAt(null).build(), "createdAt")
+            );
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("nullArgumentCases")
+        @DisplayName("인자가 null이면 예외")
+        void throw_exception_when_required_argument_is_null(
+                String displayName,
+                Supplier<SeatTimeSlot> supplier,
+                String fieldName
+        ) {
+            assertThatDomainThrownBy(supplier::get)
+                    .hasNonNullMessageFor(fieldName);
+        }
+    }
+
+    @Nested
+    @DisplayName("변경 테스트")
+    class UpdateTest {
+        static Stream<Arguments> nullArgumentCases() {
+            return Stream.of(
+                    arguments("updateSlotRange = null", (Consumer<SeatTimeSlot>) (slot) -> slot.updateSlotRange(null), "slotRange")
+            );
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("nullArgumentCases")
+        @DisplayName("null 인자로 변경 시 예외")
+        void throw_exception_when_update_with_null(
+                String displayName,
+                Consumer<SeatTimeSlot> consumer,
+                String fieldName
+        ) {
+            var slot = SeatTimeSlotFixture.get();
+            assertThatDomainThrownBy(() -> consumer.accept(slot))
+                    .hasNonNullMessageFor(fieldName);
+        }
+    }
+
+    @Nested
+    @DisplayName("상태 전이 테스트")
+    class TransitionTest implements ActiveInactiveTransitionContractTest<SeatTimeSlot> {
+
+        @Override
+        public SeatTimeSlot createActive(Instant createdAt) {
+            return new SeatTimeSlotFixture.Builder().createdAt(createdAt).slotStatus(SeatTimeSlotStatus.ACTIVE).build();
+        }
+
+        @Override
+        public SeatTimeSlot createInactive(Instant createdAt) {
+            return new SeatTimeSlotFixture.Builder().createdAt(createdAt).slotStatus(SeatTimeSlotStatus.INACTIVE).build();
+        }
+
+        @Override
+        public SeatTimeSlot activate(SeatTimeSlot domain, Instant activatedAt) {
+            domain.active(activatedAt);
+            return domain;
+        }
+
+        @Override
+        public SeatTimeSlot inactivate(SeatTimeSlot domain, Instant inactivatedAt) {
+            domain.inactive(inactivatedAt);
+            return domain;
+        }
+
+        @Override
+        public boolean isActive(SeatTimeSlot domain) {
+            return domain.getSlotStatus() == SeatTimeSlotStatus.ACTIVE;
+        }
+
+        @Override
+        public Instant getCreatedAt(SeatTimeSlot domain) {
+            return domain.getCreatedAt();
+        }
+
+        @Override
+        public Instant getLastActivatedAt(SeatTimeSlot domain) {
+            return domain.getLastActivatedAt();
+        }
+
+        @Override
+        public Instant getLastInactivatedAt(SeatTimeSlot domain) {
+            return domain.getLastInactivatedAt();
+        }
+    }
+}

--- a/reservation/reservation-domain/src/testFixtures/java/com/seatliberator/seatliberator/reservation/domain/fixture/ReservationFixture.java
+++ b/reservation/reservation-domain/src/testFixtures/java/com/seatliberator/seatliberator/reservation/domain/fixture/ReservationFixture.java
@@ -5,6 +5,7 @@ import com.seatliberator.seatliberator.reservation.domain.persistence.Reservatio
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.UUID;
 
 import static com.seatliberator.seatliberator.reservation.domain.fixture.SeatLocatorFixture.createLocator;
 import static com.seatliberator.seatliberator.reservation.domain.fixture.TestSupport.fixedClock;
@@ -33,7 +34,7 @@ public class ReservationFixture {
         return Reservation.create(INITIAL_USER_ID, INITIAL_ROOM_ID, INITIAL_SEAT_ID, startTime, endTime, status);
     }
 
-    public static void stubReservationId(Reservation reservation, Long id) {
+    public static void stubReservationId(Reservation reservation, UUID id) {
         try {
             var idField = Reservation.class.getDeclaredField("id");
             idField.setAccessible(true);

--- a/reservation/reservation-domain/src/testFixtures/java/com/seatliberator/seatliberator/reservation/domain/fixture/RoomOperationPolicyFixture.java
+++ b/reservation/reservation-domain/src/testFixtures/java/com/seatliberator/seatliberator/reservation/domain/fixture/RoomOperationPolicyFixture.java
@@ -1,0 +1,55 @@
+package com.seatliberator.seatliberator.reservation.domain.fixture;
+
+import com.seatliberator.seatliberator.reservation.domain.TimeRange;
+import com.seatliberator.seatliberator.reservation.domain.persistence.RoomOperationPolicy;
+import com.seatliberator.seatliberator.reservation.domain.persistence.RoomOperationStatus;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+import static com.seatliberator.seatliberator.reservation.domain.fixture.TimeRangeFixture.createRange;
+
+public class RoomOperationPolicyFixture {
+    public static final Integer MAX_RESERVATION_PER_USER = 5;
+    public static final Duration MAX_RESERVATION_DURATION = Duration.ofMinutes(30);
+    public static final TimeRange OPERATION_RANGE = createRange(
+            TestSupport.fixedClock.instant(),
+            TestSupport.fixedClock.instant().plus(12, ChronoUnit.HOURS)
+    );
+    public static final RoomOperationStatus OPERATION_STATUS = RoomOperationStatus.OPEN;
+
+    public static RoomOperationPolicy get() {
+        return RoomOperationPolicy.of(MAX_RESERVATION_PER_USER, MAX_RESERVATION_DURATION, OPERATION_STATUS, OPERATION_RANGE);
+    }
+
+    public static class Builder {
+        private Integer maxReservationPerUser = MAX_RESERVATION_PER_USER;
+        private Duration maxReservationDuration = MAX_RESERVATION_DURATION;
+        private RoomOperationStatus operationStatus = OPERATION_STATUS;
+        private TimeRange operationRange = OPERATION_RANGE;
+
+        public Builder maxReservationPerUser(Integer maxReservationPerUser) {
+            this.maxReservationPerUser = maxReservationPerUser;
+            return this;
+        }
+
+        public Builder maxReservationDuration(Duration maxReservationDuration) {
+            this.maxReservationDuration = maxReservationDuration;
+            return this;
+        }
+
+        public Builder operationRange(TimeRange operationRange) {
+            this.operationRange = operationRange;
+            return this;
+        }
+
+        public Builder operationStatus(RoomOperationStatus operationStatus) {
+            this.operationStatus = operationStatus;
+            return this;
+        }
+
+        public RoomOperationPolicy build() {
+            return RoomOperationPolicy.of(maxReservationPerUser, maxReservationDuration, operationStatus, operationRange);
+        }
+    }
+}

--- a/reservation/reservation-domain/src/testFixtures/java/com/seatliberator/seatliberator/reservation/domain/fixture/SeatTimeSlotFixture.java
+++ b/reservation/reservation-domain/src/testFixtures/java/com/seatliberator/seatliberator/reservation/domain/fixture/SeatTimeSlotFixture.java
@@ -1,0 +1,57 @@
+package com.seatliberator.seatliberator.reservation.domain.fixture;
+
+import com.seatliberator.seatliberator.reservation.domain.TimeRange;
+import com.seatliberator.seatliberator.reservation.domain.persistence.Seat;
+import com.seatliberator.seatliberator.reservation.domain.persistence.SeatTimeSlot;
+import com.seatliberator.seatliberator.reservation.domain.persistence.SeatTimeSlotStatus;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static com.seatliberator.seatliberator.reservation.domain.fixture.SeatFixture.createSeat;
+import static com.seatliberator.seatliberator.reservation.domain.fixture.TimeRangeFixture.createRange;
+
+public class SeatTimeSlotFixture {
+    public static final Seat SEAT = createSeat();
+    public static final TimeRange SLOT_RANGE = createRange(
+            TestSupport.fixedClock.instant(),
+            TestSupport.fixedClock.instant().plus(30, ChronoUnit.MINUTES)
+    );
+    public static final SeatTimeSlotStatus SLOT_STATUS = SeatTimeSlotStatus.ACTIVE;
+    public static final Instant CREATED_AT = TestSupport.fixedClock.instant();
+
+    public static SeatTimeSlot get() {
+        return SeatTimeSlot.of(SEAT, SLOT_RANGE, SLOT_STATUS, CREATED_AT);
+    }
+
+    public static class Builder {
+        private Seat seat = SEAT;
+        private TimeRange slotRange = SLOT_RANGE;
+        private SeatTimeSlotStatus slotStatus = SLOT_STATUS;
+        private Instant createdAt = CREATED_AT;
+
+        public Builder seat(Seat seat) {
+            this.seat = seat;
+            return this;
+        }
+
+        public Builder slotRange(TimeRange slotRange) {
+            this.slotRange = slotRange;
+            return this;
+        }
+
+        public Builder slotStatus(SeatTimeSlotStatus slotStatus) {
+            this.slotStatus = slotStatus;
+            return this;
+        }
+
+        public Builder createdAt(Instant createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public SeatTimeSlot build() {
+            return SeatTimeSlot.of(seat, slotRange, slotStatus, createdAt);
+        }
+    }
+}

--- a/reservation/reservation-domain/src/testFixtures/java/com/seatliberator/seatliberator/reservation/domain/fixture/TestSupport.java
+++ b/reservation/reservation-domain/src/testFixtures/java/com/seatliberator/seatliberator/reservation/domain/fixture/TestSupport.java
@@ -3,7 +3,10 @@ package com.seatliberator.seatliberator.reservation.domain.fixture;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.UUID;
 
 public class TestSupport {
     public static final Clock fixedClock = Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneOffset.UTC);
+
+    public static final UUID INITIAL_UUID = new UUID(0L, 1L);
 }

--- a/reservation/reservation-persistence/src/main/java/com/seatliberator/seatliberator/reservation/persistence/book/jpa/JpaReservationPersistenceAdapter.java
+++ b/reservation/reservation-persistence/src/main/java/com/seatliberator/seatliberator/reservation/persistence/book/jpa/JpaReservationPersistenceAdapter.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -27,7 +28,7 @@ public class JpaReservationPersistenceAdapter implements ReservationStore, Reser
     }
 
     @Override
-    public Optional<Reservation> findById(Long reservationId) {
+    public Optional<Reservation> findById(UUID reservationId) {
         return repository.findById(reservationId);
     }
 

--- a/reservation/reservation-persistence/src/main/java/com/seatliberator/seatliberator/reservation/persistence/book/jpa/repository/ReservationRepository.java
+++ b/reservation/reservation-persistence/src/main/java/com/seatliberator/seatliberator/reservation/persistence/book/jpa/repository/ReservationRepository.java
@@ -8,8 +8,9 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.Instant;
 import java.util.Optional;
+import java.util.UUID;
 
-public interface ReservationRepository extends JpaRepository<Reservation, Long>, JpaSpecificationExecutor<Reservation> {
+public interface ReservationRepository extends JpaRepository<Reservation, UUID>, JpaSpecificationExecutor<Reservation> {
 
     Optional<Reservation> findByUserId(String userId);
 

--- a/reservation/reservation-persistence/src/main/java/com/seatliberator/seatliberator/reservation/persistence/room/jpa/repository/SeatRepository.java
+++ b/reservation/reservation-persistence/src/main/java/com/seatliberator/seatliberator/reservation/persistence/room/jpa/repository/SeatRepository.java
@@ -10,8 +10,9 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
-public interface SeatRepository extends JpaRepository<Seat, Long>, JpaSpecificationExecutor<Seat> {
+public interface SeatRepository extends JpaRepository<Seat, UUID>, JpaSpecificationExecutor<Seat> {
 
     Optional<Seat> findByRoom_RoomIdAndSeatId(String roomId, String seatId);
 

--- a/reservation/reservation-web-mvc/build.gradle.kts
+++ b/reservation/reservation-web-mvc/build.gradle.kts
@@ -13,5 +13,6 @@ dependencies {
 
     implementation(project(":bootstrap:resource-application-starter"))
 
+    testImplementation(project(":kernel:kernel-test"))
     testImplementation(testFixtures(project(":reservation:reservation-domain")))
 }

--- a/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/infrastructure/web/usage/controller/ReservationUsageController.java
+++ b/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/infrastructure/web/usage/controller/ReservationUsageController.java
@@ -17,6 +17,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.UUID;
+
 @Tag(name = "Reservations", description = "스터디룸 좌석 예약 관련 API")
 @Slf4j
 @RestController
@@ -34,8 +36,8 @@ public class ReservationUsageController {
     })
     @PostMapping("/{reservationId}")
     public ResponseEntity<UseReservationResult> use(
-            @Parameter(description = "예약 ID", example = "1")
-            @PathVariable("reservationId") Long reservationId
+            @Parameter(description = "예약 ID", example = "00000000-0000-0000-0000-000000000001")
+            @PathVariable("reservationId") UUID reservationId
     ) {
         var actor = actorContextHolder.getActor();
         var command = new UseReservationCommand(reservationId, actor);

--- a/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/infrastructure/web/usage/ReservationUsageControllerTest.java
+++ b/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/infrastructure/web/usage/ReservationUsageControllerTest.java
@@ -2,6 +2,8 @@ package com.seatliberator.seatliberator.reservation.infrastructure.web.usage;
 
 import com.seatliberator.seatliberator.identity.core.actor.ActorContextHolder;
 import com.seatliberator.seatliberator.identity.core.actor.SimpleActor;
+import com.seatliberator.seatliberator.kernel.test.SequenceCounter;
+import com.seatliberator.seatliberator.kernel.test.UuidGenerator;
 import com.seatliberator.seatliberator.reservation.application.usage.port.in.UseReservationUseCase;
 import com.seatliberator.seatliberator.reservation.application.usage.port.in.command.UseReservationCommand;
 import com.seatliberator.seatliberator.reservation.application.usage.port.in.result.UseReservationResult;
@@ -39,10 +41,13 @@ public class ReservationUsageControllerTest {
     @MockitoBean
     UseReservationUseCase useReservationUseCase;
 
+    UuidGenerator uuid = new UuidGenerator(new SequenceCounter());
+
     @Test
     @DisplayName("예약 사용 요청 시 path variable과 actor 정보를 기반으로 command를 만들어서 유스케이스에 전달한다")
     void use_build_command_and_calls_use_case() throws Exception {
         // given
+        var reservationId = uuid.generate();
         var actor = new SimpleActor("user-1", Set.of());
         var processedAt = Instant.parse("2026-04-14T10:00:00Z");
         var result = UseReservationResult.accept(processedAt);
@@ -52,7 +57,7 @@ public class ReservationUsageControllerTest {
                 .willReturn(result);
 
         // when
-        mockMvc.perform(post("/reservations/{reservationId}", 1L))
+        mockMvc.perform(post("/reservations/{reservationId}", reservationId))
                 .andExpect(status().isOk());
 
         // then
@@ -60,7 +65,7 @@ public class ReservationUsageControllerTest {
         verify(useReservationUseCase).use(captor.capture());
 
         var actual = captor.getValue();
-        assertThat(actual.reservationId()).isEqualTo(1L);
+        assertThat(actual.reservationId()).isEqualTo(reservationId);
         assertThat(actual.requestedUser()).isEqualTo(actor);
     }
 
@@ -68,6 +73,7 @@ public class ReservationUsageControllerTest {
     @DisplayName("예약 사용 요청 시 유스케이스 결과를 200 OK 응답으로 반환한다")
     void use_returns_ok_with_result() throws Exception {
         // given
+        var reservationId = uuid.generate();
         var actor = new SimpleActor("user-1", Set.of());
         var processedAt = Instant.parse("2026-04-14T10:00:00Z");
         var result = UseReservationResult.reject("해당 예약에 접근할 권한이 없습니다.", processedAt);
@@ -77,7 +83,7 @@ public class ReservationUsageControllerTest {
                 .willReturn(result);
 
         // when & then
-        mockMvc.perform(post("/reservations/{reservationId}", 1L)
+        mockMvc.perform(post("/reservations/{reservationId}", reservationId)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(result)));
@@ -87,7 +93,7 @@ public class ReservationUsageControllerTest {
     @DisplayName("reservationId path variable 형식이 잘못되면 400 Bad Request를 반환한다")
     void use_returns_bad_request_when_reservation_id_is_invalid() throws Exception {
         // when & then
-        mockMvc.perform(post("/reservations/{reservationId}", "not-a-number"))
+        mockMvc.perform(post("/reservations/{reservationId}", "not-a-uuid"))
                 .andExpect(status().isBadRequest());
 
         verifyNoInteractions(actorContextHolder);


### PR DESCRIPTION
## 관련 이슈
- 없음

## 변경 사항
- Reservation의 `userId` 유니크 제약을 제거하고 도메인 Id 스펙을 정리했습니다.
- kernel-core에 파라미터 및 Integer/Duration 범위 검증용 `Preconditions`를 추가하고, kernel-test에 도메인 assertion, 동시성 테스트 지원, UUID 테스트 유틸을 추가했습니다.
- `TimeRange` 동등성 검사 스펙과 Contract 테스트를 추가했습니다.
- Room과 Seat 관계를 좌석이 방을 참조하는 단방향 관계로 정리했습니다.
- Room 운영 정책을 표현하는 `RoomOperationPolicy`, `RoomOperationStatus` embedded 도메인과 테스트 fixture를 추가했습니다.
- 좌석의 예약 가능한 시간 구간을 표현하는 `SeatTimeSlot`, `SeatTimeSlotStatus` 도메인과 상태 전이 Contract 테스트를 추가했습니다.

## 배경 및 의도
- 한 사용자가 여러 예약을 가질 수 있도록 Reservation 도메인의 사용자 단위 유니크 제약을 제거하는 기반을 먼저 정리했습니다.
- 예약 가능 시간과 좌석 점유 가능 구간을 도메인에서 명시적으로 표현하기 위해 Room 운영 정책과 SeatTimeSlot을 도입했습니다.
- Room-Seat 양방향 관계 동기화 비용을 줄이고, 이후 애플리케이션 계층에서 예약 생성/조회 스펙을 전파하기 전에 도메인 스펙을 고정하려는 목적입니다.
- 도메인 검증 로직을 커널 `Preconditions`와 테스트 지원 유틸로 정리해 후속 도메인 스펙 추가 시 재사용할 수 있게 했습니다.

## 후속 작업
- reservation-application 계층에서 Room 운영 정책과 SeatTimeSlot을 사용하는 예약 생성/조회 흐름을 별도 PR에서 연결합니다.
- persistence 및 API 레벨에서 Room 운영 정책, SeatTimeSlot 관리/조회 기능을 별도 PR에서 추가합니다.
- waitlist, usage 등 기존 Reservation 협력 객체에 새 예약 생성 스펙을 후속으로 전파합니다.

## 검증
- `./gradlew :kernel:kernel-core:test :reservation:reservation-domain:test`