### PR TITLE
Booking 단건 조회 기능 추가

### DIFF
--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/port/in/FindBookingUseCase.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/port/in/FindBookingUseCase.java
@@ -1,0 +1,8 @@
+package com.seatliberator.seatliberator.reservation.application.booking.port.in;
+
+import com.seatliberator.seatliberator.reservation.application.booking.port.in.query.FindBookingQuery;
+import com.seatliberator.seatliberator.reservation.application.booking.port.in.result.BookingDetailResult;
+
+public interface FindBookingUseCase {
+    BookingDetailResult find(FindBookingQuery query);
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/port/in/query/FindBookingQuery.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/port/in/query/FindBookingQuery.java
@@ -1,0 +1,17 @@
+package com.seatliberator.seatliberator.reservation.application.booking.port.in.query;
+
+import com.seatliberator.seatliberator.kernel.condition.Preconditions;
+
+import java.util.UUID;
+
+public record FindBookingQuery(
+        UUID reservationId
+) {
+    public FindBookingQuery {
+        Preconditions.requireNonNull(reservationId, "reservationId");
+    }
+
+    public static FindBookingQuery of(UUID reservationId) {
+        return new FindBookingQuery(reservationId);
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/port/in/result/BookingDetailResult.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/port/in/result/BookingDetailResult.java
@@ -1,0 +1,47 @@
+package com.seatliberator.seatliberator.reservation.application.booking.port.in.result;
+
+import com.seatliberator.seatliberator.kernel.condition.Preconditions;
+import com.seatliberator.seatliberator.reservation.application.reservation.port.in.result.ReservationStateResult;
+import com.seatliberator.seatliberator.reservation.domain.seat.SeatTimeSlotStatus;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+public record BookingDetailResult(
+        UUID reservationId,
+        String userId,
+        ReservationStateResult reservationState,
+        List<BookingSlotResult> slots
+) {
+    public BookingDetailResult {
+        Preconditions.requireNonNull(reservationId, "reservationId");
+        Preconditions.requireNonBlank(userId, "userId");
+        Preconditions.requireNonNull(reservationState, "reservationState");
+        slots = List.copyOf(Preconditions.requireNonNull(slots, "slots"));
+    }
+
+    public record BookingSlotResult(
+            UUID seatOccupancyId,
+            UUID seatTimeSlotId,
+            LocalDate occupancyDate,
+            String roomId,
+            String seatId,
+            LocalTime startAt,
+            Duration duration,
+            SeatTimeSlotStatus status
+    ) {
+        public BookingSlotResult {
+            Preconditions.requireNonNull(seatOccupancyId, "seatOccupancyId");
+            Preconditions.requireNonNull(seatTimeSlotId, "seatTimeSlotId");
+            Preconditions.requireNonNull(occupancyDate, "occupancyDate");
+            Preconditions.requireNonBlank(roomId, "roomId");
+            Preconditions.requireNonNull(seatId, "seatId");
+            Preconditions.requireNonNull(startAt, "startAt");
+            Preconditions.requireNonNull(duration, "duration");
+            Preconditions.requireNonNull(status, "status");
+        }
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/port/out/BookingDetailReader.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/port/out/BookingDetailReader.java
@@ -1,0 +1,10 @@
+package com.seatliberator.seatliberator.reservation.application.booking.port.out;
+
+import com.seatliberator.seatliberator.reservation.application.booking.port.in.result.BookingDetailResult;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface BookingDetailReader {
+    Optional<BookingDetailResult> findByReservationId(UUID reservationId);
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/service/FindBookingService.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/service/FindBookingService.java
@@ -1,0 +1,22 @@
+package com.seatliberator.seatliberator.reservation.application.booking.service;
+
+import com.seatliberator.seatliberator.reservation.application.booking.port.in.FindBookingUseCase;
+import com.seatliberator.seatliberator.reservation.application.booking.port.in.query.FindBookingQuery;
+import com.seatliberator.seatliberator.reservation.application.booking.port.in.result.BookingDetailResult;
+import com.seatliberator.seatliberator.reservation.application.booking.port.out.BookingDetailReader;
+import com.seatliberator.seatliberator.reservation.application.shared.exception.ReservationApplicationErrorCode;
+import com.seatliberator.seatliberator.reservation.application.shared.exception.ReservationApplicationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FindBookingService implements FindBookingUseCase {
+    private final BookingDetailReader bookingDetailReader;
+
+    @Override
+    public BookingDetailResult find(FindBookingQuery query) {
+        return bookingDetailReader.findByReservationId(query.reservationId())
+                .orElseThrow(() -> new ReservationApplicationException(ReservationApplicationErrorCode.RESERVATION_NOT_FOUND));
+    }
+}

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/service/FindBookingService.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/booking/service/FindBookingService.java
@@ -1,9 +1,11 @@
 package com.seatliberator.seatliberator.reservation.application.booking.service;
 
+import com.seatliberator.seatliberator.identity.core.actor.ActorContextHolder;
 import com.seatliberator.seatliberator.reservation.application.booking.port.in.FindBookingUseCase;
 import com.seatliberator.seatliberator.reservation.application.booking.port.in.query.FindBookingQuery;
 import com.seatliberator.seatliberator.reservation.application.booking.port.in.result.BookingDetailResult;
 import com.seatliberator.seatliberator.reservation.application.booking.port.out.BookingDetailReader;
+import com.seatliberator.seatliberator.reservation.application.reservation.contract.ReservationOwnershipPolicy;
 import com.seatliberator.seatliberator.reservation.application.shared.exception.ReservationApplicationErrorCode;
 import com.seatliberator.seatliberator.reservation.application.shared.exception.ReservationApplicationException;
 import lombok.RequiredArgsConstructor;
@@ -14,8 +16,16 @@ import org.springframework.stereotype.Service;
 public class FindBookingService implements FindBookingUseCase {
     private final BookingDetailReader bookingDetailReader;
 
+    private final ReservationOwnershipPolicy ownershipPolicy;
+    private final ActorContextHolder actorContextHolder;
+
     @Override
     public BookingDetailResult find(FindBookingQuery query) {
+        var actor = actorContextHolder.getActor();
+        var reservationId = query.reservationId();
+
+        ownershipPolicy.validate(reservationId, actor);
+
         return bookingDetailReader.findByReservationId(query.reservationId())
                 .orElseThrow(() -> new ReservationApplicationException(ReservationApplicationErrorCode.RESERVATION_NOT_FOUND));
     }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/reservation/port/in/result/ReservationResult.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/reservation/port/in/result/ReservationResult.java
@@ -1,10 +1,8 @@
 package com.seatliberator.seatliberator.reservation.application.reservation.port.in.result;
 
+import com.seatliberator.seatliberator.kernel.condition.Preconditions;
 import com.seatliberator.seatliberator.reservation.domain.reservation.Reservation;
-import com.seatliberator.seatliberator.reservation.domain.reservation.ReservationState;
-import com.seatliberator.seatliberator.reservation.domain.reservation.ReservationStatus;
 
-import java.time.Instant;
 import java.util.UUID;
 
 public record ReservationResult(
@@ -12,29 +10,17 @@ public record ReservationResult(
         String userId,
         ReservationStateResult state
 ) {
+    public ReservationResult {
+        Preconditions.requireNonNull(reservationId, "reservationId");
+        Preconditions.requireNonBlank(userId, "userId");
+        Preconditions.requireNonNull(state, "state");
+    }
+
     public static ReservationResult from(Reservation reservation) {
         return new ReservationResult(
                 reservation.getId(),
                 reservation.getUserId(),
                 ReservationStateResult.from(reservation.getState())
         );
-    }
-
-    public record ReservationStateResult(
-            ReservationStatus status,
-            Instant reservedAt,
-            Instant usedAt,
-            Instant cancelledAt,
-            Instant expiredAt
-    ) {
-        public static ReservationStateResult from(ReservationState state) {
-            return new ReservationStateResult(
-                    state.getStatus(),
-                    state.getReservedAt(),
-                    state.getUsedAt(),
-                    state.getCancelledAt(),
-                    state.getExpiredAt()
-            );
-        }
     }
 }

--- a/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/reservation/port/in/result/ReservationStateResult.java
+++ b/reservation/reservation-application/src/main/java/com/seatliberator/seatliberator/reservation/application/reservation/port/in/result/ReservationStateResult.java
@@ -1,0 +1,30 @@
+package com.seatliberator.seatliberator.reservation.application.reservation.port.in.result;
+
+import com.seatliberator.seatliberator.kernel.condition.Preconditions;
+import com.seatliberator.seatliberator.reservation.domain.reservation.ReservationState;
+import com.seatliberator.seatliberator.reservation.domain.reservation.ReservationStatus;
+
+import java.time.Instant;
+
+public record ReservationStateResult(
+        ReservationStatus status,
+        Instant reservedAt,
+        Instant usedAt,
+        Instant cancelledAt,
+        Instant expiredAt
+) {
+    public ReservationStateResult {
+        Preconditions.requireNonNull(status, "status");
+        Preconditions.requireNonNull(reservedAt, "reservedAt");
+    }
+
+    public static ReservationStateResult from(ReservationState state) {
+        return new ReservationStateResult(
+                state.getStatus(),
+                state.getReservedAt(),
+                state.getUsedAt(),
+                state.getCancelledAt(),
+                state.getExpiredAt()
+        );
+    }
+}

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/application/booking/service/FindBookingUseCaseTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/application/booking/service/FindBookingUseCaseTest.java
@@ -1,12 +1,16 @@
 package com.seatliberator.seatliberator.reservation.application.booking.service;
 
+import com.seatliberator.seatliberator.identity.core.actor.ActorContextHolder;
 import com.seatliberator.seatliberator.reservation.application.booking.port.in.FindBookingUseCase;
 import com.seatliberator.seatliberator.reservation.application.booking.port.in.query.FindBookingQuery;
 import com.seatliberator.seatliberator.reservation.application.booking.port.in.result.BookingDetailResult;
 import com.seatliberator.seatliberator.reservation.application.booking.port.out.BookingDetailReader;
+import com.seatliberator.seatliberator.reservation.application.reservation.contract.ReservationOwnershipPolicy;
+import com.seatliberator.seatliberator.reservation.application.reservation.contract.ReservationPolicyReason;
 import com.seatliberator.seatliberator.reservation.application.reservation.port.in.result.ReservationStateResult;
 import com.seatliberator.seatliberator.reservation.application.shared.exception.ReservationApplicationErrorCode;
 import com.seatliberator.seatliberator.reservation.application.shared.exception.ReservationApplicationException;
+import com.seatliberator.seatliberator.reservation.application.shared.exception.ReservationApplicationPolicyException;
 import com.seatliberator.seatliberator.reservation.domain.reservation.ReservationStatus;
 import com.seatliberator.seatliberator.reservation.domain.seat.SeatTimeSlotStatus;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,6 +28,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static com.seatliberator.seatliberator.reservation.application.DefaultTestSupport.ACTOR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
@@ -37,35 +42,44 @@ public class FindBookingUseCaseTest {
 
     @Mock
     BookingDetailReader bookingDetailReader;
+    @Mock
+    ReservationOwnershipPolicy ownershipPolicy;
+    @Mock
+    ActorContextHolder actorContextHolder;
 
     FindBookingUseCase useCase;
 
     @BeforeEach
     void run() {
-        useCase = new FindBookingService(bookingDetailReader);
+        useCase = new FindBookingService(bookingDetailReader, ownershipPolicy, actorContextHolder);
     }
 
     @Test
-    @DisplayName("예약 Id로 booking 상세 projection을 조회한다")
+    @DisplayName("예약 ID 조회 시 현재 actor의 소유권을 검증하고 booking 상세 projection을 조회한다")
     void should_find_booking_detail_by_reservation_id() {
         var query = FindBookingQuery.of(RESERVATION_ID);
         var detail = bookingDetailResult();
 
+        when(actorContextHolder.getActor()).thenReturn(ACTOR);
         when(bookingDetailReader.findByReservationId(query.reservationId()))
                 .thenReturn(Optional.of(detail));
 
         var actual = useCase.find(query);
 
         assertThat(actual).isEqualTo(detail);
-        verify(bookingDetailReader).findByReservationId(query.reservationId());
-        verifyNoMoreInteractions(bookingDetailReader);
+        var inOrder = inOrder(actorContextHolder, ownershipPolicy, bookingDetailReader);
+        inOrder.verify(actorContextHolder).getActor();
+        inOrder.verify(ownershipPolicy).validate(query.reservationId(), ACTOR);
+        inOrder.verify(bookingDetailReader).findByReservationId(query.reservationId());
+        verifyNoMoreInteractions(actorContextHolder, ownershipPolicy, bookingDetailReader);
     }
 
     @Test
-    @DisplayName("예약 Id에 해당하는 booking 상세가 없으면 예약 없음 예외를 던진다")
+    @DisplayName("소유권 검증 후 예약 ID에 해당하는 booking 상세가 없으면 예약 없음 예외를 던진다")
     void should_throw_when_booking_detail_not_found() {
         var query = FindBookingQuery.of(RESERVATION_ID);
 
+        when(actorContextHolder.getActor()).thenReturn(ACTOR);
         when(bookingDetailReader.findByReservationId(query.reservationId()))
                 .thenReturn(Optional.empty());
 
@@ -73,8 +87,29 @@ public class FindBookingUseCaseTest {
                 .isInstanceOfSatisfying(ReservationApplicationException.class, exception ->
                         assertThat(exception.getErrorCode()).isEqualTo(ReservationApplicationErrorCode.RESERVATION_NOT_FOUND));
 
-        verify(bookingDetailReader).findByReservationId(query.reservationId());
-        verifyNoMoreInteractions(bookingDetailReader);
+        var inOrder = inOrder(actorContextHolder, ownershipPolicy, bookingDetailReader);
+        inOrder.verify(actorContextHolder).getActor();
+        inOrder.verify(ownershipPolicy).validate(query.reservationId(), ACTOR);
+        inOrder.verify(bookingDetailReader).findByReservationId(query.reservationId());
+        verifyNoMoreInteractions(actorContextHolder, ownershipPolicy, bookingDetailReader);
+    }
+
+    @Test
+    @DisplayName("현재 actor가 예약 소유자가 아니면 booking 상세를 조회하지 않는다")
+    void should_not_find_booking_detail_when_actor_is_not_reservation_owner() {
+        var query = FindBookingQuery.of(RESERVATION_ID);
+        var exception = new ReservationApplicationPolicyException(ReservationPolicyReason.UNAUTHORIZED_RESERVATION_ACCESS);
+
+        when(actorContextHolder.getActor()).thenReturn(ACTOR);
+        doThrow(exception).when(ownershipPolicy).validate(query.reservationId(), ACTOR);
+
+        assertThatThrownBy(() -> useCase.find(query))
+                .isSameAs(exception);
+
+        verify(actorContextHolder).getActor();
+        verify(ownershipPolicy).validate(query.reservationId(), ACTOR);
+        verifyNoInteractions(bookingDetailReader);
+        verifyNoMoreInteractions(actorContextHolder, ownershipPolicy);
     }
 
     private BookingDetailResult bookingDetailResult() {

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/application/booking/service/FindBookingUseCaseTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/application/booking/service/FindBookingUseCaseTest.java
@@ -1,0 +1,105 @@
+package com.seatliberator.seatliberator.reservation.application.booking.service;
+
+import com.seatliberator.seatliberator.reservation.application.booking.port.in.FindBookingUseCase;
+import com.seatliberator.seatliberator.reservation.application.booking.port.in.query.FindBookingQuery;
+import com.seatliberator.seatliberator.reservation.application.booking.port.in.result.BookingDetailResult;
+import com.seatliberator.seatliberator.reservation.application.booking.port.out.BookingDetailReader;
+import com.seatliberator.seatliberator.reservation.application.reservation.port.in.result.ReservationStateResult;
+import com.seatliberator.seatliberator.reservation.application.shared.exception.ReservationApplicationErrorCode;
+import com.seatliberator.seatliberator.reservation.application.shared.exception.ReservationApplicationException;
+import com.seatliberator.seatliberator.reservation.domain.reservation.ReservationStatus;
+import com.seatliberator.seatliberator.reservation.domain.seat.SeatTimeSlotStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FindBookingUseCase 테스트")
+public class FindBookingUseCaseTest {
+    private static final UUID RESERVATION_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID OCCUPANCY_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    private static final UUID SLOT_ID = UUID.fromString("00000000-0000-0000-0000-000000000003");
+
+    @Mock
+    BookingDetailReader bookingDetailReader;
+
+    FindBookingUseCase useCase;
+
+    @BeforeEach
+    void run() {
+        useCase = new FindBookingService(bookingDetailReader);
+    }
+
+    @Test
+    @DisplayName("예약 Id로 booking 상세 projection을 조회한다")
+    void should_find_booking_detail_by_reservation_id() {
+        var query = FindBookingQuery.of(RESERVATION_ID);
+        var detail = bookingDetailResult();
+
+        when(bookingDetailReader.findByReservationId(query.reservationId()))
+                .thenReturn(Optional.of(detail));
+
+        var actual = useCase.find(query);
+
+        assertThat(actual).isEqualTo(detail);
+        verify(bookingDetailReader).findByReservationId(query.reservationId());
+        verifyNoMoreInteractions(bookingDetailReader);
+    }
+
+    @Test
+    @DisplayName("예약 Id에 해당하는 booking 상세가 없으면 예약 없음 예외를 던진다")
+    void should_throw_when_booking_detail_not_found() {
+        var query = FindBookingQuery.of(RESERVATION_ID);
+
+        when(bookingDetailReader.findByReservationId(query.reservationId()))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> useCase.find(query))
+                .isInstanceOfSatisfying(ReservationApplicationException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(ReservationApplicationErrorCode.RESERVATION_NOT_FOUND));
+
+        verify(bookingDetailReader).findByReservationId(query.reservationId());
+        verifyNoMoreInteractions(bookingDetailReader);
+    }
+
+    private BookingDetailResult bookingDetailResult() {
+        var reservedAt = Instant.parse("2026-04-14T09:00:00Z");
+
+        return new BookingDetailResult(
+                RESERVATION_ID,
+                "user-1",
+                new ReservationStateResult(
+                        ReservationStatus.RESERVED,
+                        reservedAt,
+                        null,
+                        null,
+                        null
+                ),
+                List.of(new BookingDetailResult.BookingSlotResult(
+                        OCCUPANCY_ID,
+                        SLOT_ID,
+                        LocalDate.parse("2026-04-14"),
+                        "study-room-1",
+                        "seat-a",
+                        LocalTime.of(9, 0),
+                        Duration.ofHours(2),
+                        SeatTimeSlotStatus.ACTIVE
+                ))
+        );
+    }
+}

--- a/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/application/reservation/service/ListReservationUseCaseTest.java
+++ b/reservation/reservation-application/src/test/java/com/seatliberator/seatliberator/reservation/application/reservation/service/ListReservationUseCaseTest.java
@@ -44,7 +44,7 @@ public class ListReservationUseCaseTest {
     @Test
     @DisplayName("예약 목록 조회 시 현재 actor의 조회 권한을 검증하고 필터 조회 결과를 ReservationResult로 반환한다")
     void list_reservations_validates_actor_and_returns_results() {
-        var reservation = reservation();
+        var reservation = reservationWithId();
         var query = ListReservationQuery.of(USER_ID, ReservationStatus.RESERVED);
         var filter = ReservationFilter.empty()
                 .userId(query.userId())

--- a/reservation/reservation-persistence/src/main/java/com/seatliberator/seatliberator/reservation/persistence/booking/jpa/JpaBookingDetailPersistenceAdapter.java
+++ b/reservation/reservation-persistence/src/main/java/com/seatliberator/seatliberator/reservation/persistence/booking/jpa/JpaBookingDetailPersistenceAdapter.java
@@ -1,0 +1,37 @@
+package com.seatliberator.seatliberator.reservation.persistence.booking.jpa;
+
+import com.seatliberator.seatliberator.reservation.application.booking.port.in.result.BookingDetailResult;
+import com.seatliberator.seatliberator.reservation.application.booking.port.out.BookingDetailReader;
+import com.seatliberator.seatliberator.reservation.persistence.booking.jpa.repository.BookingDetailRepository;
+import com.seatliberator.seatliberator.reservation.persistence.booking.jpa.row.BookingDetailRow;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class JpaBookingDetailPersistenceAdapter implements BookingDetailReader {
+    private final BookingDetailRepository repository;
+
+    @Override
+    public Optional<BookingDetailResult> findByReservationId(UUID reservationId) {
+        var rows = repository.findRowsByReservationId(reservationId);
+        if (rows.isEmpty()) return Optional.empty();
+
+        var first = rows.getFirst();
+        var state = first.toReservationStateResult();
+        var slots = rows.stream()
+                .filter(row -> row.seatTimeSlotId() != null)
+                .map(BookingDetailRow::toSlotResult)
+                .toList();
+
+        return Optional.of(new BookingDetailResult(
+                first.reservationId(),
+                first.userId(),
+                state,
+                slots
+        ));
+    }
+}

--- a/reservation/reservation-persistence/src/main/java/com/seatliberator/seatliberator/reservation/persistence/booking/jpa/repository/BookingDetailRepository.java
+++ b/reservation/reservation-persistence/src/main/java/com/seatliberator/seatliberator/reservation/persistence/booking/jpa/repository/BookingDetailRepository.java
@@ -1,0 +1,39 @@
+package com.seatliberator.seatliberator.reservation.persistence.booking.jpa.repository;
+
+import com.seatliberator.seatliberator.reservation.domain.reservation.Reservation;
+import com.seatliberator.seatliberator.reservation.persistence.booking.jpa.row.BookingDetailRow;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface BookingDetailRepository extends Repository<Reservation, UUID> {
+    @Query("""
+            SELECT
+                reservation.id AS reservationId,
+                reservation.userId AS userId,
+                reservation.state.status AS status,
+                reservation.state.reservedAt AS reservedAt,
+                reservation.state.usedAt AS usedAt,
+                reservation.state.cancelledAt AS cancelledAt,
+                reservation.state.expiredAt AS expiredAt,
+                occupancy.id AS occupancyId,
+                occupancy.occupancyDate AS occupancyDate,
+                slot.id AS seatTimeSlotId,
+                room.roomId AS roomId,
+                seat.seatId AS seatId,
+                slot.slotRange.startNanoOfDay AS slotStartNanoOfDay,
+                slot.slotRange.endNanoOfDay AS slotEndNanoOfDay,
+                slot.slotStatus AS slotStatus
+            FROM Reservation reservation
+            LEFT JOIN SeatOccupancy occupancy ON occupancy.reservationId = reservation.id
+            LEFT JOIN occupancy.seatTimeSlot slot
+            LEFT JOIN slot.seat seat
+            LEFT JOIN seat.room room
+            WHERE reservation.id = :reservationId
+            ORDER BY occupancy.occupancyDate ASC, slot.slotRange.startNanoOfDay ASC, slot.id ASC
+            """)
+    List<BookingDetailRow> findRowsByReservationId(@Param("reservationId") UUID reservationId);
+}

--- a/reservation/reservation-persistence/src/main/java/com/seatliberator/seatliberator/reservation/persistence/booking/jpa/row/BookingDetailRow.java
+++ b/reservation/reservation-persistence/src/main/java/com/seatliberator/seatliberator/reservation/persistence/booking/jpa/row/BookingDetailRow.java
@@ -1,0 +1,47 @@
+package com.seatliberator.seatliberator.reservation.persistence.booking.jpa.row;
+
+import com.seatliberator.seatliberator.reservation.application.booking.port.in.result.BookingDetailResult;
+import com.seatliberator.seatliberator.reservation.application.reservation.port.in.result.ReservationStateResult;
+import com.seatliberator.seatliberator.reservation.domain.reservation.ReservationStatus;
+import com.seatliberator.seatliberator.reservation.domain.seat.SeatTimeSlotStatus;
+import com.seatliberator.seatliberator.reservation.domain.shared.temporal.SimpleDailyNanoRange;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record BookingDetailRow(
+        UUID reservationId,
+        String userId,
+        ReservationStatus status,
+        Instant reservedAt,
+        Instant usedAt,
+        Instant cancelledAt,
+        Instant expiredAt,
+        UUID occupancyId,
+        LocalDate occupancyDate,
+        UUID seatTimeSlotId,
+        String roomId,
+        String seatId,
+        Long slotStartNanoOfDay,
+        Long slotEndNanoOfDay,
+        SeatTimeSlotStatus slotStatus
+) {
+    public ReservationStateResult toReservationStateResult() {
+        return new ReservationStateResult(status, reservedAt, usedAt, cancelledAt, expiredAt);
+    }
+
+    public BookingDetailResult.BookingSlotResult toSlotResult() {
+        var range = SimpleDailyNanoRange.of(slotStartNanoOfDay, slotEndNanoOfDay);
+        return new BookingDetailResult.BookingSlotResult(
+                occupancyId,
+                seatTimeSlotId,
+                occupancyDate,
+                roomId,
+                seatId,
+                range.startAt(),
+                range.duration(),
+                slotStatus
+        );
+    }
+}

--- a/reservation/reservation-persistence/src/test/java/com/seatliberator/seatliberator/reservation/persistence/booking/jpa/JpaBookingDetailPersistenceAdapterTest.java
+++ b/reservation/reservation-persistence/src/test/java/com/seatliberator/seatliberator/reservation/persistence/booking/jpa/JpaBookingDetailPersistenceAdapterTest.java
@@ -1,0 +1,177 @@
+package com.seatliberator.seatliberator.reservation.persistence.booking.jpa;
+
+import com.seatliberator.seatliberator.reservation.application.booking.port.in.result.BookingDetailResult;
+import com.seatliberator.seatliberator.reservation.application.booking.port.out.BookingDetailReader;
+import com.seatliberator.seatliberator.reservation.domain.reservation.Reservation;
+import com.seatliberator.seatliberator.reservation.domain.reservation.ReservationStatus;
+import com.seatliberator.seatliberator.reservation.domain.reservation.SeatOccupancy;
+import com.seatliberator.seatliberator.reservation.domain.room.Room;
+import com.seatliberator.seatliberator.reservation.domain.seat.Seat;
+import com.seatliberator.seatliberator.reservation.domain.seat.SeatTimeSlot;
+import com.seatliberator.seatliberator.reservation.domain.seat.SeatTimeSlotStatus;
+import com.seatliberator.seatliberator.reservation.domain.shared.temporal.SimpleDailyNanoRange;
+import com.seatliberator.seatliberator.reservation.persistence.AbstractPersistenceAdapterTest;
+import com.seatliberator.seatliberator.reservation.persistence.book.jpa.repository.ReservationRepository;
+import com.seatliberator.seatliberator.reservation.persistence.occupancy.jpa.repository.SeatOccupancyRepository;
+import com.seatliberator.seatliberator.reservation.persistence.room.jpa.repository.RoomRepository;
+import com.seatliberator.seatliberator.reservation.persistence.seat.jpa.repository.SeatRepository;
+import com.seatliberator.seatliberator.reservation.persistence.seat.jpa.repository.SeatTimeSlotRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+
+import static com.seatliberator.seatliberator.reservation.persistence.TestSupport.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({JpaBookingDetailPersistenceAdapter.class})
+@DisplayName("BookingDetail Persistence")
+public class JpaBookingDetailPersistenceAdapterTest extends AbstractPersistenceAdapterTest {
+    @Autowired
+    BookingDetailReader reader;
+    @Autowired
+    ReservationRepository reservationRepository;
+    @Autowired
+    SeatOccupancyRepository seatOccupancyRepository;
+    @Autowired
+    RoomRepository roomRepository;
+    @Autowired
+    SeatRepository seatRepository;
+    @Autowired
+    SeatTimeSlotRepository seatTimeSlotRepository;
+
+    private Room saveRoom() {
+        return roomRepository.save(room());
+    }
+
+    private Seat saveSeat(Room room) {
+        return seatRepository.save(seat(room));
+    }
+
+    private SeatTimeSlot saveSeatTimeSlot(Seat seat, LocalTime startAt) {
+        var slotRange = SimpleDailyNanoRange.of(startAt, Duration.ofHours(2));
+        var seatTimeSlot = SeatTimeSlot.of(seat, slotRange, SeatTimeSlotStatus.ACTIVE, now());
+        setField(seatTimeSlot, "seatId", seat.getId());
+        return seatTimeSlotRepository.save(seatTimeSlot);
+    }
+
+    private Reservation saveReservation() {
+        return saveReservation(USER_ID);
+    }
+
+    private Reservation saveReservation(String userId) {
+        return reservationRepository.save(Reservation.of(userId, now()));
+    }
+
+    private SeatOccupancy saveSeatOccupancy(SeatTimeSlot slot, Reservation reservation, LocalDate occupancyDate) {
+        return seatOccupancyRepository.save(SeatOccupancy.of(
+                slot.getId(),
+                reservation.getId(),
+                occupancyDate,
+                now()
+        ));
+    }
+
+    private void assertReservation(BookingDetailResult actual, Reservation expected) {
+        assertThat(actual.reservationId()).isEqualTo(expected.getId());
+        assertThat(actual.userId()).isEqualTo(expected.getUserId());
+        assertThat(actual.reservationState().status()).isEqualTo(ReservationStatus.RESERVED);
+        assertThat(actual.reservationState().reservedAt()).isEqualTo(expected.getState().getReservedAt());
+        assertThat(actual.reservationState().usedAt()).isNull();
+        assertThat(actual.reservationState().cancelledAt()).isNull();
+        assertThat(actual.reservationState().expiredAt()).isNull();
+    }
+
+    private void assertSlot(
+            BookingDetailResult.BookingSlotResult actual,
+            SeatOccupancy expectedOccupancy,
+            SeatTimeSlot expectedSlot,
+            LocalTime expectedStartAt
+    ) {
+        assertThat(actual.seatOccupancyId()).isEqualTo(expectedOccupancy.getId());
+        assertThat(actual.seatTimeSlotId()).isEqualTo(expectedSlot.getId());
+        assertThat(actual.occupancyDate()).isEqualTo(expectedOccupancy.getOccupancyDate());
+        assertThat(actual.roomId()).isEqualTo(ROOM_ID);
+        assertThat(actual.seatId()).isEqualTo(SEAT_ID);
+        assertThat(actual.startAt()).isEqualTo(expectedStartAt);
+        assertThat(actual.duration()).isEqualTo(Duration.ofHours(2));
+        assertThat(actual.status()).isEqualTo(SeatTimeSlotStatus.ACTIVE);
+    }
+
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("테스트용 필드 설정 실패: " + fieldName, e);
+        }
+    }
+
+    @Nested
+    @DisplayName("Reader 테스트")
+    class ReaderTest {
+        @Test
+        @DisplayName("findByReservationId는 예약과 점유 슬롯 상세를 함께 반환한다")
+        void should_find_booking_detail_by_reservation_id() {
+            var room = saveRoom();
+            var seat = saveSeat(room);
+            var firstSlot = saveSeatTimeSlot(seat, LocalTime.of(9, 0));
+            var secondSlot = saveSeatTimeSlot(seat, LocalTime.of(11, 0));
+            var reservation = saveReservation();
+            var occupancyDate = LocalDate.now(fixedClock);
+            var firstOccupancy = saveSeatOccupancy(firstSlot, reservation, occupancyDate);
+            var secondOccupancy = saveSeatOccupancy(secondSlot, reservation, occupancyDate);
+            saveSeatOccupancy(firstSlot, saveReservation(OTHER_USER_ID), occupancyDate.plusDays(1));
+            flushAndClear();
+
+            var actual = reader.findByReservationId(reservation.getId());
+
+            assertThat(actual)
+                    .isPresent()
+                    .get()
+                    .satisfies(detail -> {
+                        assertReservation(detail, reservation);
+                        assertThat(detail.slots())
+                                .extracting(BookingDetailResult.BookingSlotResult::seatTimeSlotId)
+                                .containsExactly(firstSlot.getId(), secondSlot.getId());
+                        assertSlot(detail.slots().get(0), firstOccupancy, firstSlot, LocalTime.of(9, 0));
+                        assertSlot(detail.slots().get(1), secondOccupancy, secondSlot, LocalTime.of(11, 0));
+                    });
+        }
+
+        @Test
+        @DisplayName("findByReservationId는 예약이 있지만 점유 슬롯이 없으면 빈 슬롯 목록을 반환한다")
+        void should_return_empty_slots_when_reservation_has_no_occupancy() {
+            var reservation = saveReservation();
+            flushAndClear();
+
+            var actual = reader.findByReservationId(reservation.getId());
+
+            assertThat(actual)
+                    .isPresent()
+                    .get()
+                    .satisfies(detail -> {
+                        assertReservation(detail, reservation);
+                        assertThat(detail.slots()).isEmpty();
+                    });
+        }
+
+        @Test
+        @DisplayName("findByReservationId는 예약이 없으면 Optional.empty를 반환한다")
+        void should_return_empty_when_reservation_not_found() {
+            var actual = reader.findByReservationId(UUID.randomUUID());
+
+            assertThat(actual).isEmpty();
+        }
+    }
+}

--- a/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/booking/controller/BookingController.java
+++ b/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/booking/controller/BookingController.java
@@ -3,6 +3,9 @@ package com.seatliberator.seatliberator.reservation.web.booking.controller;
 import com.seatliberator.seatliberator.identity.core.actor.ActorContextHolder;
 import com.seatliberator.seatliberator.reservation.application.booking.port.in.CancelBookingUseCase;
 import com.seatliberator.seatliberator.reservation.application.booking.port.in.CreateBookingUseCase;
+import com.seatliberator.seatliberator.reservation.application.booking.port.in.FindBookingUseCase;
+import com.seatliberator.seatliberator.reservation.application.booking.port.in.query.FindBookingQuery;
+import com.seatliberator.seatliberator.reservation.application.booking.port.in.result.BookingDetailResult;
 import com.seatliberator.seatliberator.reservation.application.booking.port.in.result.BookingResult;
 import com.seatliberator.seatliberator.reservation.application.reservation.port.in.result.ReservationResult;
 import com.seatliberator.seatliberator.reservation.web.booking.request.CancelBookingRequest;
@@ -16,15 +19,33 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
 @Tag(name = "Booking", description = "스터디룸 좌석 예약 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/booking")
 public class BookingController {
+    private final FindBookingUseCase findBookingUseCase;
     private final CreateBookingUseCase createBookingUseCase;
     private final CancelBookingUseCase cancelBookingUseCase;
 
     private final ActorContextHolder actorContextHolder;
+
+    @Operation(summary = "예약 조회", description = "특정 ID의 예약을 조회합니다")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "예약 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "권한 없음")
+    })
+    @GetMapping("/{reservationId}")
+    public ResponseEntity<BookingDetailResult> findBooking(
+            @PathVariable("reservationId") UUID reservationId
+    ) {
+        var query = FindBookingQuery.of(reservationId);
+        var result = findBookingUseCase.find(query);
+        return ResponseEntity.ok(result);
+    }
 
     @Operation(summary = "예약 생성", description = "특정 좌석의 시간 슬롯에 대해서 예약을 생성합니다.")
     @ApiResponses({

--- a/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/web/reservation/ReservationControllerTest.java
+++ b/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/web/reservation/ReservationControllerTest.java
@@ -7,6 +7,7 @@ import com.seatliberator.seatliberator.reservation.application.reservation.port.
 import com.seatliberator.seatliberator.reservation.application.reservation.port.in.query.FindReservationQuery;
 import com.seatliberator.seatliberator.reservation.application.reservation.port.in.query.ListReservationQuery;
 import com.seatliberator.seatliberator.reservation.application.reservation.port.in.result.ReservationResult;
+import com.seatliberator.seatliberator.reservation.application.reservation.port.in.result.ReservationStateResult;
 import com.seatliberator.seatliberator.reservation.domain.reservation.ReservationStatus;
 import com.seatliberator.seatliberator.reservation.web.reservation.controller.ReservationQueryController;
 import org.junit.jupiter.api.DisplayName;
@@ -168,7 +169,7 @@ public class ReservationControllerTest {
         return new ReservationResult(
                 reservationId,
                 "user-1",
-                new ReservationResult.ReservationStateResult(
+                new ReservationStateResult(
                         ReservationStatus.RESERVED,
                         reservedAt,
                         null,

--- a/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/web/reservation/UseReservationControllerTest.java
+++ b/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/web/reservation/UseReservationControllerTest.java
@@ -5,6 +5,7 @@ import com.seatliberator.seatliberator.kernel.test.UuidGenerator;
 import com.seatliberator.seatliberator.reservation.application.reservation.port.in.UseReservationUseCase;
 import com.seatliberator.seatliberator.reservation.application.reservation.port.in.command.UseReservationCommand;
 import com.seatliberator.seatliberator.reservation.application.reservation.port.in.result.ReservationResult;
+import com.seatliberator.seatliberator.reservation.application.reservation.port.in.result.ReservationStateResult;
 import com.seatliberator.seatliberator.reservation.domain.reservation.ReservationStatus;
 import com.seatliberator.seatliberator.reservation.web.reservation.controller.UseReservationController;
 import org.junit.jupiter.api.DisplayName;
@@ -96,7 +97,7 @@ public class UseReservationControllerTest {
         return new ReservationResult(
                 reservationId,
                 "user-1",
-                new ReservationResult.ReservationStateResult(
+                new ReservationStateResult(
                         ReservationStatus.USED,
                         reservedAt,
                         usedAt,


### PR DESCRIPTION
## 관련 이슈
- 없음

## 변경 사항
- `ReservationResult`에서 예약 상태 표현을 `ReservationStateResult`로 분리
- `FindBookingUseCase`와 `FindBookingQuery`, `BookingDetailResult`, `BookingDetailReader`를 추가해 Booking 단건 조회 application port 구성
- `JpaBookingDetailPersistenceAdapter`와 projection row/repository를 추가해 예약 ID 기반 booking 상세 조회 지원
- `BookingController`에 예약 ID 기반 Booking 조회 API 연결
- `FindBookingService`에서 현재 `Actor`의 예약 소유권을 검증하도록 정리하고 단위 테스트 반영

## 배경 및 의도
- Booking 단건 조회 응답에서 예약 상태와 슬롯 상세를 함께 제공하기 위해 application/result와 persistence projection을 분리했습니다.
- 기존 예약 결과의 상태 표현을 재사용 가능한 `ReservationStateResult`로 분리해 Booking 상세 응답과 예약 조회 응답의 중복을 줄였습니다.
- Booking 상세 조회는 예약 소유자 또는 관리 권한이 있는 Actor만 접근할 수 있도록 `ReservationOwnershipPolicy` 흐름에 맞췄습니다.

## 후속 작업
- `reservation-persistence` 전체 테스트에서 기존 SeatTimeSlot/SeatOccupancy 케이스의 H2 제약 위반이 확인되어 별도 범위에서 정리 필요

## 검증
- `./gradlew :reservation:reservation-application:test`
- `./gradlew :reservation:reservation-application:test --tests com.seatliberator.seatliberator.reservation.application.booking.service.FindBookingUseCaseTest :reservation:reservation-persistence:test --tests com.seatliberator.seatliberator.reservation.persistence.booking.jpa.JpaBookingDetailPersistenceAdapterTest :reservation:reservation-web-mvc:test --tests com.seatliberator.seatliberator.reservation.web.reservation.ReservationControllerTest --tests com.seatliberator.seatliberator.reservation.web.reservation.UseReservationControllerTest`
- `./gradlew :reservation:reservation-application:test :reservation:reservation-persistence:test :reservation:reservation-web-mvc:test` 실행 시 `reservation-persistence`의 기존 SeatTimeSlot/SeatOccupancy 테스트 13건이 H2 제약 위반으로 실패