### PR TITLE
feat(board): 댓글 유스케이스 추가

### DIFF
--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/CreateCommentUseCase.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/CreateCommentUseCase.java
@@ -1,0 +1,8 @@
+package com.seatliberator.seatliberator.board.application.comment.port.in;
+
+import com.seatliberator.seatliberator.board.application.comment.port.in.command.CreateCommentCommand;
+import com.seatliberator.seatliberator.board.application.comment.port.in.result.CommentResult;
+
+public interface CreateCommentUseCase {
+    CommentResult create(CreateCommentCommand command);
+}

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/DeleteCommentUseCase.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/DeleteCommentUseCase.java
@@ -1,0 +1,7 @@
+package com.seatliberator.seatliberator.board.application.comment.port.in;
+
+import com.seatliberator.seatliberator.board.application.comment.port.in.command.DeleteCommentCommand;
+
+public interface DeleteCommentUseCase {
+    void delete(DeleteCommentCommand command);
+}

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/FindCommentUseCase.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/FindCommentUseCase.java
@@ -1,0 +1,8 @@
+package com.seatliberator.seatliberator.board.application.comment.port.in;
+
+import com.seatliberator.seatliberator.board.application.comment.port.in.query.FindCommentQuery;
+import com.seatliberator.seatliberator.board.application.comment.port.in.result.CommentResult;
+
+public interface FindCommentUseCase {
+    CommentResult find(FindCommentQuery query);
+}

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/ListPostCommentUseCase.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/ListPostCommentUseCase.java
@@ -1,0 +1,10 @@
+package com.seatliberator.seatliberator.board.application.comment.port.in;
+
+import com.seatliberator.seatliberator.board.application.comment.port.in.query.ListPostCommentQuery;
+import com.seatliberator.seatliberator.board.application.comment.port.in.result.CommentResult;
+
+import java.util.List;
+
+public interface ListPostCommentUseCase {
+    List<CommentResult> list(ListPostCommentQuery query);
+}

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/ListUserCommentUseCase.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/ListUserCommentUseCase.java
@@ -1,0 +1,10 @@
+package com.seatliberator.seatliberator.board.application.comment.port.in;
+
+import com.seatliberator.seatliberator.board.application.comment.port.in.query.ListUserCommentQuery;
+import com.seatliberator.seatliberator.board.application.comment.port.in.result.CommentResult;
+
+import java.util.List;
+
+public interface ListUserCommentUseCase {
+    List<CommentResult> list(ListUserCommentQuery query);
+}

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/UpdateCommentContentUseCase.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/UpdateCommentContentUseCase.java
@@ -1,0 +1,8 @@
+package com.seatliberator.seatliberator.board.application.comment.port.in;
+
+import com.seatliberator.seatliberator.board.application.comment.port.in.command.UpdateCommentContentCommand;
+import com.seatliberator.seatliberator.board.application.comment.port.in.result.CommentResult;
+
+public interface UpdateCommentContentUseCase {
+    CommentResult update(UpdateCommentContentCommand command);
+}

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/command/CreateCommentCommand.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/command/CreateCommentCommand.java
@@ -1,0 +1,21 @@
+package com.seatliberator.seatliberator.board.application.comment.port.in.command;
+
+import com.seatliberator.seatliberator.kernel.condition.Preconditions;
+
+import java.util.UUID;
+
+public record CreateCommentCommand(
+        UUID postId,
+        String userId,
+        String content
+) {
+    public CreateCommentCommand {
+        Preconditions.requireNonNull(postId, "postId");
+        Preconditions.requireNonBlank(userId, "userId");
+        Preconditions.requireNonBlank(content, "content");
+    }
+
+    public static CreateCommentCommand of(UUID postId, String userId, String content) {
+        return new CreateCommentCommand(postId, userId, content);
+    }
+}

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/command/DeleteCommentCommand.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/command/DeleteCommentCommand.java
@@ -1,0 +1,17 @@
+package com.seatliberator.seatliberator.board.application.comment.port.in.command;
+
+import com.seatliberator.seatliberator.kernel.condition.Preconditions;
+
+import java.util.UUID;
+
+public record DeleteCommentCommand(
+        UUID commentId
+) {
+    public DeleteCommentCommand {
+        Preconditions.requireNonNull(commentId, "commentId");
+    }
+
+    public static DeleteCommentCommand of(UUID commentId) {
+        return new DeleteCommentCommand(commentId);
+    }
+}

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/command/UpdateCommentContentCommand.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/command/UpdateCommentContentCommand.java
@@ -1,0 +1,19 @@
+package com.seatliberator.seatliberator.board.application.comment.port.in.command;
+
+import com.seatliberator.seatliberator.kernel.condition.Preconditions;
+
+import java.util.UUID;
+
+public record UpdateCommentContentCommand(
+        UUID commentId,
+        String content
+) {
+    public UpdateCommentContentCommand {
+        Preconditions.requireNonNull(commentId, "commentId");
+        Preconditions.requireNonBlank(content, "content");
+    }
+
+    public static UpdateCommentContentCommand of(UUID commentId, String content) {
+        return new UpdateCommentContentCommand(commentId, content);
+    }
+}

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/query/FindCommentQuery.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/query/FindCommentQuery.java
@@ -1,0 +1,17 @@
+package com.seatliberator.seatliberator.board.application.comment.port.in.query;
+
+import com.seatliberator.seatliberator.kernel.condition.Preconditions;
+
+import java.util.UUID;
+
+public record FindCommentQuery(
+        UUID commentId
+) {
+    public FindCommentQuery {
+        Preconditions.requireNonNull(commentId, "commentId");
+    }
+
+    public static FindCommentQuery of(UUID commentId) {
+        return new FindCommentQuery(commentId);
+    }
+}

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/query/ListPostCommentQuery.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/query/ListPostCommentQuery.java
@@ -1,0 +1,23 @@
+package com.seatliberator.seatliberator.board.application.comment.port.in.query;
+
+import com.seatliberator.seatliberator.board.application.comment.port.out.filter.CommentFilter;
+import com.seatliberator.seatliberator.kernel.condition.Preconditions;
+
+import java.util.UUID;
+
+public record ListPostCommentQuery(
+        UUID postId
+) {
+    public ListPostCommentQuery {
+        Preconditions.requireNonNull(postId, "postId");
+    }
+
+    public static ListPostCommentQuery of(UUID postId) {
+        return new ListPostCommentQuery(postId);
+    }
+
+    public CommentFilter toFilter() {
+        return CommentFilter.empty()
+                .postId(postId);
+    }
+}

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/query/ListUserCommentQuery.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/query/ListUserCommentQuery.java
@@ -1,0 +1,21 @@
+package com.seatliberator.seatliberator.board.application.comment.port.in.query;
+
+import com.seatliberator.seatliberator.board.application.comment.port.out.filter.CommentFilter;
+import com.seatliberator.seatliberator.kernel.condition.Preconditions;
+
+public record ListUserCommentQuery(
+        String userId
+) {
+    public ListUserCommentQuery {
+        Preconditions.requireNonBlank(userId, "userId");
+    }
+
+    public static ListUserCommentQuery of(String userId) {
+        return new ListUserCommentQuery(userId);
+    }
+
+    public CommentFilter toFilter() {
+        return CommentFilter.empty()
+                .userId(userId);
+    }
+}

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/result/CommentResult.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/in/result/CommentResult.java
@@ -1,0 +1,26 @@
+package com.seatliberator.seatliberator.board.application.comment.port.in.result;
+
+import com.seatliberator.seatliberator.board.domain.Comment;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record CommentResult(
+        UUID commentId,
+        UUID postId,
+        String userId,
+        String content,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static CommentResult from(Comment comment) {
+        return new CommentResult(
+                comment.getId(),
+                comment.getPostId(),
+                comment.getUserId(),
+                comment.getContent(),
+                comment.getCreatedAt(),
+                comment.getUpdatedAt()
+        );
+    }
+}

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/out/CommentReader.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/out/CommentReader.java
@@ -1,0 +1,16 @@
+package com.seatliberator.seatliberator.board.application.comment.port.out;
+
+import com.seatliberator.seatliberator.board.application.comment.port.out.filter.CommentFilter;
+import com.seatliberator.seatliberator.board.domain.Comment;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CommentReader {
+    boolean existsById(UUID id);
+
+    Optional<Comment> findById(UUID id);
+
+    List<Comment> findByFilter(CommentFilter filter);
+}

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/out/CommentStore.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/out/CommentStore.java
@@ -1,0 +1,9 @@
+package com.seatliberator.seatliberator.board.application.comment.port.out;
+
+import com.seatliberator.seatliberator.board.domain.Comment;
+
+public interface CommentStore {
+    Comment save(Comment comment);
+
+    void delete(Comment comment);
+}

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/out/filter/CommentFilter.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/port/out/filter/CommentFilter.java
@@ -1,0 +1,27 @@
+package com.seatliberator.seatliberator.board.application.comment.port.out.filter;
+
+import com.seatliberator.seatliberator.kernel.condition.Preconditions;
+import org.jspecify.annotations.Nullable;
+
+import java.util.UUID;
+
+public record CommentFilter(
+        @Nullable UUID postId,
+        @Nullable String userId
+) {
+    public static CommentFilter empty() {
+        return new CommentFilter(null, null);
+    }
+
+    public CommentFilter postId(UUID postId) {
+        Preconditions.requireNonNull(postId, "postId");
+
+        return new CommentFilter(postId, userId);
+    }
+
+    public CommentFilter userId(String userId) {
+        Preconditions.requireNonBlank(userId, "userId");
+
+        return new CommentFilter(postId, userId);
+    }
+}

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/service/CommentCommandService.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/service/CommentCommandService.java
@@ -1,0 +1,72 @@
+package com.seatliberator.seatliberator.board.application.comment.service;
+
+import com.seatliberator.seatliberator.board.application.comment.port.in.CreateCommentUseCase;
+import com.seatliberator.seatliberator.board.application.comment.port.in.DeleteCommentUseCase;
+import com.seatliberator.seatliberator.board.application.comment.port.in.UpdateCommentContentUseCase;
+import com.seatliberator.seatliberator.board.application.comment.port.in.command.CreateCommentCommand;
+import com.seatliberator.seatliberator.board.application.comment.port.in.command.DeleteCommentCommand;
+import com.seatliberator.seatliberator.board.application.comment.port.in.command.UpdateCommentContentCommand;
+import com.seatliberator.seatliberator.board.application.comment.port.in.result.CommentResult;
+import com.seatliberator.seatliberator.board.application.comment.port.out.CommentReader;
+import com.seatliberator.seatliberator.board.application.comment.port.out.CommentStore;
+import com.seatliberator.seatliberator.board.application.post.port.out.PostReader;
+import com.seatliberator.seatliberator.board.application.shared.exception.CommentNotFoundException;
+import com.seatliberator.seatliberator.board.application.shared.exception.PostNotFoundException;
+import com.seatliberator.seatliberator.board.domain.Comment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentCommandService implements
+        CreateCommentUseCase,
+        UpdateCommentContentUseCase,
+        DeleteCommentUseCase {
+
+    private final CommentReader reader;
+    private final CommentStore store;
+
+    private final PostReader postReader;
+    private final Clock clock;
+
+    @Override
+    public CommentResult create(CreateCommentCommand command) {
+        var postId = command.postId();
+        var existsPost = postReader.existsById(postId);
+        if (!existsPost) throw new PostNotFoundException(postId);
+
+        var now = clock.instant();
+        var comment = Comment.of(postId, command.userId(), command.content(), now);
+
+        var saved = store.save(comment);
+
+        return CommentResult.from(saved);
+    }
+
+    @Override
+    public CommentResult update(UpdateCommentContentCommand command) {
+        var commentId = command.commentId();
+        var comment = reader.findById(commentId)
+                .orElseThrow(() -> new CommentNotFoundException(commentId));
+
+        var now = clock.instant();
+        comment.updateContent(command.content(), now);
+
+        var saved = store.save(comment);
+
+        return CommentResult.from(saved);
+    }
+
+    @Override
+    public void delete(DeleteCommentCommand command) {
+        var commentId = command.commentId();
+        var comment = reader.findById(commentId)
+                .orElseThrow(() -> new CommentNotFoundException(commentId));
+
+        store.delete(comment);
+    }
+}

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/service/CommentQueryService.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/comment/service/CommentQueryService.java
@@ -1,0 +1,56 @@
+package com.seatliberator.seatliberator.board.application.comment.service;
+
+import com.seatliberator.seatliberator.board.application.comment.port.in.FindCommentUseCase;
+import com.seatliberator.seatliberator.board.application.comment.port.in.ListPostCommentUseCase;
+import com.seatliberator.seatliberator.board.application.comment.port.in.ListUserCommentUseCase;
+import com.seatliberator.seatliberator.board.application.comment.port.in.query.FindCommentQuery;
+import com.seatliberator.seatliberator.board.application.comment.port.in.query.ListPostCommentQuery;
+import com.seatliberator.seatliberator.board.application.comment.port.in.query.ListUserCommentQuery;
+import com.seatliberator.seatliberator.board.application.comment.port.in.result.CommentResult;
+import com.seatliberator.seatliberator.board.application.comment.port.out.CommentReader;
+import com.seatliberator.seatliberator.board.application.post.port.out.PostReader;
+import com.seatliberator.seatliberator.board.application.shared.exception.CommentNotFoundException;
+import com.seatliberator.seatliberator.board.application.shared.exception.PostNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentQueryService implements
+        FindCommentUseCase,
+        ListPostCommentUseCase,
+        ListUserCommentUseCase {
+
+    private final CommentReader reader;
+    private final PostReader postReader;
+
+    @Override
+    public CommentResult find(FindCommentQuery query) {
+        var commentId = query.commentId();
+        return reader.findById(commentId)
+                .map(CommentResult::from)
+                .orElseThrow(() -> new CommentNotFoundException(commentId));
+    }
+
+    @Override
+    public List<CommentResult> list(ListPostCommentQuery query) {
+        var postId = query.postId();
+        var existsPost = postReader.existsById(postId);
+        if (!existsPost) throw new PostNotFoundException(postId);
+
+        return reader.findByFilter(query.toFilter()).stream()
+                .map(CommentResult::from)
+                .toList();
+    }
+
+    @Override
+    public List<CommentResult> list(ListUserCommentQuery query) {
+        return reader.findByFilter(query.toFilter()).stream()
+                .map(CommentResult::from)
+                .toList();
+    }
+}

--- a/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/shared/exception/CommentNotFoundException.java
+++ b/board/board-application/src/main/java/com/seatliberator/seatliberator/board/application/shared/exception/CommentNotFoundException.java
@@ -1,0 +1,9 @@
+package com.seatliberator.seatliberator.board.application.shared.exception;
+
+import java.util.UUID;
+
+public class CommentNotFoundException extends RuntimeException {
+    public CommentNotFoundException(UUID commentId) {
+        super("Comment not found: " + commentId);
+    }
+}

--- a/board/board-domain/src/main/java/com/seatliberator/seatliberator/board/domain/Comment.java
+++ b/board/board-domain/src/main/java/com/seatliberator/seatliberator/board/domain/Comment.java
@@ -1,0 +1,64 @@
+package com.seatliberator.seatliberator.board.domain;
+
+import com.seatliberator.seatliberator.kernel.condition.Preconditions;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "comment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "post_id", nullable = false, updatable = false)
+    private UUID postId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id", nullable = false, insertable = false, updatable = false)
+    private Post post;
+
+    @Column(name = "user_id", nullable = false)
+    private String userId;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    private Comment(UUID postId, String userId, String content, Instant createdAt) {
+        this.postId = Preconditions.requireNonNull(postId, "postId");
+        this.userId = Preconditions.requireNonBlank(userId, "userId");
+        this.content = Preconditions.requireNonBlank(content, "content");
+        this.createdAt = Preconditions.requireNonNull(createdAt, "createdAt");
+    }
+
+    public static Comment of(UUID postId, String userId, String content, Instant createdAt) {
+        return new Comment(postId, userId, content, createdAt);
+    }
+
+    public void updateContent(String content, Instant updatedAt) {
+        this.updatedAt = evaluateUpdatedAt(updatedAt);
+        this.content = Preconditions.requireNonBlank(content, "content");
+    }
+
+    private Instant evaluateUpdatedAt(Instant updatedAt) {
+        Preconditions.requireNonNull(updatedAt, "updatedAt");
+
+        if (updatedAt.isBefore(createdAt))
+            throw new IllegalArgumentException("updatedAt must be after createdAt.");
+
+        return updatedAt;
+    }
+}

--- a/board/board-persistence/src/main/java/com/seatliberator/seatliberator/board/persistence/comment/JpaCommentPersistenceAdapter.java
+++ b/board/board-persistence/src/main/java/com/seatliberator/seatliberator/board/persistence/comment/JpaCommentPersistenceAdapter.java
@@ -1,0 +1,61 @@
+package com.seatliberator.seatliberator.board.persistence.comment;
+
+import com.seatliberator.seatliberator.board.application.comment.port.out.CommentReader;
+import com.seatliberator.seatliberator.board.application.comment.port.out.CommentStore;
+import com.seatliberator.seatliberator.board.application.comment.port.out.filter.CommentFilter;
+import com.seatliberator.seatliberator.board.domain.Comment;
+import com.seatliberator.seatliberator.board.persistence.comment.repository.CommentRepository;
+import com.seatliberator.seatliberator.board.persistence.shared.predicates.CommonPredicates;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class JpaCommentPersistenceAdapter implements CommentReader, CommentStore {
+    private final CommentRepository repository;
+
+    @Override
+    public boolean existsById(UUID id) {
+        return repository.existsById(id);
+    }
+
+    @Override
+    public Optional<Comment> findById(UUID id) {
+        return repository.findById(id);
+    }
+
+    @Override
+    public List<Comment> findByFilter(CommentFilter filter) {
+        var spec = createSpecificationFromFilter(filter);
+        return repository.findAll(spec);
+    }
+
+    @Override
+    public Comment save(Comment comment) {
+        return repository.save(comment);
+    }
+
+    @Override
+    public void delete(Comment comment) {
+        repository.delete(comment);
+    }
+
+    private Specification<Comment> createSpecificationFromFilter(CommentFilter filter) {
+        var spec = Specification.<Comment>unrestricted();
+
+        if (filter.postId() != null) {
+            spec = spec.and(CommonPredicates.equals(filter.postId(), from -> from.get("postId")));
+        }
+
+        if (filter.userId() != null) {
+            spec = spec.and(CommonPredicates.equals(filter.userId(), from -> from.get("userId")));
+        }
+
+        return spec;
+    }
+}

--- a/board/board-persistence/src/main/java/com/seatliberator/seatliberator/board/persistence/comment/repository/CommentRepository.java
+++ b/board/board-persistence/src/main/java/com/seatliberator/seatliberator/board/persistence/comment/repository/CommentRepository.java
@@ -1,0 +1,10 @@
+package com.seatliberator.seatliberator.board.persistence.comment.repository;
+
+import com.seatliberator.seatliberator.board.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import java.util.UUID;
+
+public interface CommentRepository extends JpaRepository<Comment, UUID>, JpaSpecificationExecutor<Comment> {
+}

--- a/board/board-web-mvc/src/main/java/com/seatliberator/seatliberator/board/web/comment/controller/CommentController.java
+++ b/board/board-web-mvc/src/main/java/com/seatliberator/seatliberator/board/web/comment/controller/CommentController.java
@@ -1,0 +1,117 @@
+package com.seatliberator.seatliberator.board.web.comment.controller;
+
+import com.seatliberator.seatliberator.board.application.comment.port.in.*;
+import com.seatliberator.seatliberator.board.application.comment.port.in.command.DeleteCommentCommand;
+import com.seatliberator.seatliberator.board.application.comment.port.in.query.FindCommentQuery;
+import com.seatliberator.seatliberator.board.application.comment.port.in.query.ListPostCommentQuery;
+import com.seatliberator.seatliberator.board.application.comment.port.in.result.CommentResult;
+import com.seatliberator.seatliberator.board.web.comment.request.CreateCommentRequest;
+import com.seatliberator.seatliberator.board.web.comment.request.UpdateCommentContentRequest;
+import com.seatliberator.seatliberator.identity.core.actor.ActorContextHolder;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@Tag(name = "Comments", description = "게시글 댓글 관리 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/board/{boardId}/posts/{postId}/comments")
+public class CommentController {
+    private final CreateCommentUseCase createCommentUseCase;
+    private final UpdateCommentContentUseCase updateCommentContentUseCase;
+    private final DeleteCommentUseCase deleteCommentUseCase;
+
+    private final FindCommentUseCase findCommentUseCase;
+    private final ListPostCommentUseCase listPostCommentUseCase;
+
+    private final ActorContextHolder actorContextHolder;
+
+    @Operation(summary = "게시글 댓글 목록 조회", description = "특정 게시글의 댓글 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "게시글 없음")
+    })
+    @GetMapping
+    public ResponseEntity<List<CommentResult>> listComment(
+            @Parameter(description = "게시글 ID", example = "00000000-0000-0000-000000000001")
+            @PathVariable("postId") UUID postId
+    ) {
+        var query = ListPostCommentQuery.of(postId);
+        var result = listPostCommentUseCase.list(query);
+        return ResponseEntity.ok(result);
+    }
+
+    @Operation(summary = "게시글 댓글 단건 조회", description = "특정 게시글의 댓글 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "댓글 없음")
+    })
+    @GetMapping("/{commentId}")
+    public ResponseEntity<CommentResult> findComment(
+            @Parameter(description = "댓글 ID", example = "00000000-0000-0000-000000000001")
+            @PathVariable("commentId") UUID commentId
+    ) {
+        var query = FindCommentQuery.of(commentId);
+        var result = findCommentUseCase.find(query);
+        return ResponseEntity.ok(result);
+    }
+
+    @Operation(summary = "댓글 생성", description = "특정 게시글에 댓글을 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "게시글 없음")
+    })
+    @PostMapping
+    public ResponseEntity<CommentResult> createComment(
+            @Parameter(description = "게시글 ID", example = "00000000-0000-0000-000000000001")
+            @PathVariable("postId") UUID postId,
+            @RequestBody @Valid CreateCommentRequest request
+    ) {
+        var actor = actorContextHolder.getActor();
+        var command = request.toCommand(postId, actor.subject());
+        var result = createCommentUseCase.create(command);
+        return ResponseEntity.ok(result);
+    }
+
+    @Operation(summary = "댓글 본문 변경", description = "특정 댓글 본문을 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "변경 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "댓글 없음")
+    })
+    @PatchMapping("/{commentId}/content")
+    public ResponseEntity<CommentResult> updateCommentContent(
+            @Parameter(description = "댓글 ID", example = "00000000-0000-0000-000000000001")
+            @PathVariable("commentId") UUID commentId,
+            @RequestBody @Valid UpdateCommentContentRequest request
+    ) {
+        var command = request.toCommand(commentId);
+        var result = updateCommentContentUseCase.update(command);
+        return ResponseEntity.ok(result);
+    }
+
+    @Operation(summary = "댓글 삭제", description = "특정 댓글을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "댓글 없음")
+    })
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> deleteComment(
+            @Parameter(description = "댓글 ID", example = "00000000-0000-0000-000000000001")
+            @PathVariable("commentId") UUID commentId
+    ) {
+        var command = DeleteCommentCommand.of(commentId);
+        deleteCommentUseCase.delete(command);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/board/board-web-mvc/src/main/java/com/seatliberator/seatliberator/board/web/comment/controller/UserCommentController.java
+++ b/board/board-web-mvc/src/main/java/com/seatliberator/seatliberator/board/web/comment/controller/UserCommentController.java
@@ -1,0 +1,42 @@
+package com.seatliberator.seatliberator.board.web.comment.controller;
+
+import com.seatliberator.seatliberator.board.application.comment.port.in.ListUserCommentUseCase;
+import com.seatliberator.seatliberator.board.application.comment.port.in.query.ListUserCommentQuery;
+import com.seatliberator.seatliberator.board.application.comment.port.in.result.CommentResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Comments", description = "게시글 댓글 관리 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserCommentController {
+
+    private final ListUserCommentUseCase listUserCommentUseCase;
+
+    @Operation(summary = "사용자 댓글 목록 조회", description = "특정 사용자의 댓글 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+    })
+    @GetMapping("/{userId}")
+    public ResponseEntity<List<CommentResult>> listUserComment(
+            @Parameter(description = "사용자 Id", example = "test_user")
+            @PathVariable("userId") String userId
+    ) {
+        var query = ListUserCommentQuery.of(userId);
+        var result = listUserCommentUseCase.list(query);
+        return ResponseEntity.ok(result);
+    }
+
+}

--- a/board/board-web-mvc/src/main/java/com/seatliberator/seatliberator/board/web/comment/request/CreateCommentRequest.java
+++ b/board/board-web-mvc/src/main/java/com/seatliberator/seatliberator/board/web/comment/request/CreateCommentRequest.java
@@ -1,0 +1,17 @@
+package com.seatliberator.seatliberator.board.web.comment.request;
+
+import com.seatliberator.seatliberator.board.application.comment.port.in.command.CreateCommentCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.UUID;
+
+@Schema(description = "댓글 생성 요청")
+public record CreateCommentRequest(
+        @Schema(description = "댓글 본문", example = "안녕하세요")
+        @NotBlank String content
+) {
+    public CreateCommentCommand toCommand(UUID postId, String userId) {
+        return CreateCommentCommand.of(postId, userId, content);
+    }
+}

--- a/board/board-web-mvc/src/main/java/com/seatliberator/seatliberator/board/web/comment/request/UpdateCommentContentRequest.java
+++ b/board/board-web-mvc/src/main/java/com/seatliberator/seatliberator/board/web/comment/request/UpdateCommentContentRequest.java
@@ -1,0 +1,17 @@
+package com.seatliberator.seatliberator.board.web.comment.request;
+
+import com.seatliberator.seatliberator.board.application.comment.port.in.command.UpdateCommentContentCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.UUID;
+
+@Schema(description = "댓글 본문 변경 요청")
+public record UpdateCommentContentRequest(
+        @Schema(description = "댓글 본문", example = "안녕하세요")
+        @NotBlank String content
+) {
+    public UpdateCommentContentCommand toCommand(UUID commentId) {
+        return UpdateCommentContentCommand.of(commentId, content);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- 없음

## 변경 사항
- Comment 도메인을 추가하고 Post와 연결되는 댓글 모델을 정의
- Comment CRUD, 게시글별/사용자별 댓글 조회 유스케이스와 result DTO 추가
- Comment Reader/Store port와 JPA persistence adapter/repository 구현
- 댓글 생성, 수정, 삭제, 단건/목록 조회를 위한 board web API 추가

## 배경 및 의도
- 게시글에 대한 댓글 작성과 조회 흐름을 board application port 중심으로 열었습니다.
- board-refactor에서 정리한 도메인별 유스케이스 구조에 맞춰 Comment 기능도 domain/application/persistence/web 계층으로 분리했습니다.

## 후속 작업
- 없음

## 검증
- `./gradlew :board:board-domain:test :board:board-application:test :board:board-persistence:test :board:board-web-mvc:test`