### PR TITLE
application-starter properties prefix 테스트 정렬

### DIFF
--- a/starter/application-starter/src/test/java/com/seatliberator/seatliberator/starter/application/ApplicationAutoConfigurationTest.java
+++ b/starter/application-starter/src/test/java/com/seatliberator/seatliberator/starter/application/ApplicationAutoConfigurationTest.java
@@ -27,7 +27,7 @@ public class ApplicationAutoConfigurationTest {
     @DisplayName("timezone 설정으로 Clock zone을 구성한다")
     void configures_clock_zone_from_property() {
         contextRunner
-                .withPropertyValues("seatliberator.bootstrap.application.timezone=Asia/Seoul")
+                .withPropertyValues("seatliberator.starter.application.timezone=Asia/Seoul")
                 .run(context -> assertThat(context.getBean(Clock.class).getZone())
                         .isEqualTo(ZoneId.of("Asia/Seoul")));
     }
@@ -45,10 +45,10 @@ public class ApplicationAutoConfigurationTest {
     }
 
     @Test
-    @DisplayName("seatliberator.bootstrap.application.enabled가 false이면 자동 설정하지 않는다")
+    @DisplayName("seatliberator.starter.application.enabled가 false이면 자동 설정하지 않는다")
     void does_not_register_beans_when_application_starter_is_disabled() {
         contextRunner
-                .withPropertyValues("seatliberator.bootstrap.application.enabled=false")
+                .withPropertyValues("seatliberator.starter.application.enabled=false")
                 .run(context -> {
                     assertThat(context).doesNotHaveBean(Clock.class);
                 });


### PR DESCRIPTION
## 관련 이슈
- 없음

## 변경 사항
- `ApplicationAutoConfigurationTest`의 timezone 설정 property key를 `seatliberator.starter.application.timezone`으로 변경
- 자동 설정 비활성화 테스트의 property key와 표시 이름을 `seatliberator.starter.application.enabled` 기준으로 정렬

## 배경 및 의도
- application-starter 설정 prefix가 `seatliberator.bootstrap.application`에서 `seatliberator.starter.application`으로 변경됐지만 테스트 입력이 이전 prefix를 사용하고 있었습니다.
- 실제 자동 설정 조건과 테스트 스펙을 같은 property prefix로 맞춰 회귀 검증이 현재 설정 계약을 바라보도록 정리했습니다.

## 후속 작업
- 없음

## 검증
- `./gradlew :starter:application-starter:test`
- `git diff --check main..HEAD`