### PR TITLE
fix: 서비스 API 버저닝 추가

### DIFF
--- a/board/board-web-mvc/src/main/java/com/seatliberator/seatliberator/board/web/board/controller/BoardController.java
+++ b/board/board-web-mvc/src/main/java/com/seatliberator/seatliberator/board/web/board/controller/BoardController.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Tag(name = "Boards", description = "게시판 관리 API")
-@RequestMapping("/board")
+@RequestMapping("/api/v1/board")
 @RestController
 @RequiredArgsConstructor
 public class BoardController {

--- a/board/board-web-mvc/src/main/java/com/seatliberator/seatliberator/board/web/category/controller/CategoryController.java
+++ b/board/board-web-mvc/src/main/java/com/seatliberator/seatliberator/board/web/category/controller/CategoryController.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Tag(name = "Categories", description = "게시판 카테고리 관리 API")
-@RequestMapping("/board/{boardId}/categories")
+@RequestMapping("/api/v1/board/{boardId}/categories")
 @RestController
 @RequiredArgsConstructor
 public class CategoryController {

--- a/board/board-web-mvc/src/main/java/com/seatliberator/seatliberator/board/web/comment/controller/CommentController.java
+++ b/board/board-web-mvc/src/main/java/com/seatliberator/seatliberator/board/web/comment/controller/CommentController.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 @Tag(name = "Comments", description = "게시글 댓글 관리 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/board/{boardId}/posts/{postId}/comments")
+@RequestMapping("/api/v1/board/{boardId}/posts/{postId}/comments")
 public class CommentController {
     private final CreateCommentUseCase createCommentUseCase;
     private final UpdateCommentContentUseCase updateCommentContentUseCase;

--- a/board/board-web-mvc/src/main/java/com/seatliberator/seatliberator/board/web/post/controller/PostController.java
+++ b/board/board-web-mvc/src/main/java/com/seatliberator/seatliberator/board/web/post/controller/PostController.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Tag(name = "Posts", description = "게시판 게시글 관리 API")
-@RequestMapping("/board/{boardId}/posts")
+@RequestMapping("/api/v1/board/{boardId}/posts")
 @RestController
 @RequiredArgsConstructor
 public class PostController {
@@ -57,7 +57,7 @@ public class PostController {
         return ResponseEntity.ok(result);
     }
 
-    // GET /board/{boardId}/posts/{postId}
+    // GET /api/v1/board/{boardId}/posts/{postId}
     // 특정 게시판 안의 특정 게시글 1건을 조회
     // boardId와 postId를 함께 받는 이유는 어떤 게시판의 게시글인지 명확히 알기 이ㅜ해 <- ??
     @Operation(summary = "게시글 단건 조회", description = "특정 게시판 안의 게시글 정보를 조회합니다.")
@@ -75,7 +75,7 @@ public class PostController {
         return ResponseEntity.ok(result);
     }
 
-    // POST /board/{boardId}/posts
+    // POST /api/v1/board/{boardId}/posts
     // 요청 JSON을 서비스가 이해하는 커맨드로 변환해서 전달
     // 생성 성공하면 201 Created + Location 헤더를 반환
     @Operation(summary = "게시글 생성", description = "특정 게시판에 새 게시글을 생성합니다.")
@@ -96,7 +96,7 @@ public class PostController {
         return ResponseEntity.ok(result);
     }
 
-    // PATCH /board/{boardId}/posts/{postId}/title
+    // PATCH /api/v1/board/{boardId}/posts/{postId}/title
     @Operation(summary = "게시글 제목 변경", description = "특정 게시판 안의 게시글 제목을 변경합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "변경 성공"),
@@ -114,7 +114,7 @@ public class PostController {
         return ResponseEntity.ok(result);
     }
 
-    // PATCH /board/{boardId}/posts/{postId}/content
+    // PATCH /api/v1/board/{boardId}/posts/{postId}/content
     @Operation(summary = "게시글 내용 변경", description = "특정 게시판 안의 게시글 내용을 변경합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "변경 성공"),
@@ -132,7 +132,7 @@ public class PostController {
         return ResponseEntity.ok(result);
     }
 
-    // PATCH /board/{boardId}/posts/{postId}/category
+    // PATCH /api/v1/board/{boardId}/posts/{postId}/category
     @Operation(summary = "게시글 카테고리 변경", description = "특정 게시판 안의 게시글 카테고리를 변경합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "변경 성공"),
@@ -150,7 +150,7 @@ public class PostController {
         return ResponseEntity.ok(result);
     }
 
-    // DELETE /board/{boardId}/posts/{postId}
+    // DELETE /api/v1/board/{boardId}/posts/{postId}
     // 삭제 성공 시 응답 없이 204 No Content 반환함
     @Operation(summary = "게시글 삭제", description = "특정 게시판 안의 게시글을 삭제합니다.")
     @ApiResponses({

--- a/board/board-web-mvc/src/main/java/com/seatliberator/seatliberator/board/web/shared/security/SecurityConfiguration.java
+++ b/board/board-web-mvc/src/main/java/com/seatliberator/seatliberator/board/web/shared/security/SecurityConfiguration.java
@@ -14,10 +14,10 @@ public class SecurityConfiguration {
     @Bean
     HttpSecurityCustomizer authorizeCustomizer() {
         return httpSecurity -> httpSecurity.authorizeHttpRequests(registry -> registry
-                .requestMatchers(HttpMethod.POST, "/board/*/categories").hasAuthority(CATEGORY_MANAGE.scope())
-                .requestMatchers(HttpMethod.PATCH, "/board/*/categories/*").hasAuthority(CATEGORY_MANAGE.scope())
-                .requestMatchers(HttpMethod.DELETE, "/board/*/categories/*").hasAuthority(CATEGORY_MANAGE.scope())
-                .requestMatchers(HttpMethod.POST, "/board/*/posts").hasAuthority(POST_CREATE.scope())
+                .requestMatchers(HttpMethod.POST, "/api/v1/board/*/categories").hasAuthority(CATEGORY_MANAGE.scope())
+                .requestMatchers(HttpMethod.PATCH, "/api/v1/board/*/categories/*").hasAuthority(CATEGORY_MANAGE.scope())
+                .requestMatchers(HttpMethod.DELETE, "/api/v1/board/*/categories/*").hasAuthority(CATEGORY_MANAGE.scope())
+                .requestMatchers(HttpMethod.POST, "/api/v1/board/*/posts").hasAuthority(POST_CREATE.scope())
         );
     }
 }

--- a/board/board-web-mvc/src/main/java/com/seatliberator/seatliberator/board/web/user/controller/UserController.java
+++ b/board/board-web-mvc/src/main/java/com/seatliberator/seatliberator/board/web/user/controller/UserController.java
@@ -23,7 +23,7 @@ import java.util.List;
 @Tag(name = "User", description = "사용자 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/users")
+@RequestMapping("/api/v1/board/users")
 public class UserController {
     private final ListUserPostUseCase listUserPostUseCase;
     private final ListUserCommentUseCase listUserCommentUseCase;

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -33,8 +33,6 @@ spring:
               uri: http://localhost:8082
               predicates:
                 - Path=/api/v1/reservations/**,/api/v1/rooms/**,/api/v1/booking/**,/api/v1/waitlist/**
-              filters:
-                - RewritePath=/api/v1/?(?<segment>.*), /$\{segment}
 
             - id: board-service-route
               uri: http://localhost:8083

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -16,13 +16,11 @@ spring:
               uri: http://localhost:8081
               predicates:
                 - Path=/api/v1/auth/**,/api/v1/oauth2/**,/api/v1/users/**,/api/v1/roles/**,/api/v1/accounts/**
-              filters:
-                - RewritePath=/api/v1/?(?<segment>.*), /$\{segment}
 
             - id: identity-oauth2-authentication
               uri: http://localhost:8081
               predicates:
-                - Path=/login/**
+                - Path=/api/v1/login/**
 
             - id: identity-jwks
               uri: http://localhost:8081

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -41,5 +41,3 @@ spring:
               uri: http://localhost:8084
               predicates:
                 - Path=/api/v1/notification/**
-              filters:
-                - RewritePath=/api/v1/?(?<segment>.*), /$\{segment}

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -38,8 +38,6 @@ spring:
               uri: http://localhost:8083
               predicates:
                 - Path=/api/v1/board/**
-              filters:
-                - RewritePath=/api/v1/?(?<segment>.*), /$\{segment}
 
             - id: notification-service-route
               uri: http://localhost:8084

--- a/gateway/src/test/java/com/seatliberator/seatliberator/GatewayRouteAlignmentTest.java
+++ b/gateway/src/test/java/com/seatliberator/seatliberator/GatewayRouteAlignmentTest.java
@@ -102,7 +102,7 @@ class GatewayRouteAlignmentTest {
     @Test
     void notificationControllerEntrypointsAreCoveredByGatewayRoutes() throws IOException {
         var patterns = gatewayPathPatterns();
-        assertCovered(patterns, controllerPaths(NotificationController.class), true);
+        assertCovered(patterns, controllerPaths(NotificationController.class), false);
     }
 
     private static void assertCovered(Set<String> gatewayPatterns, Set<String> downstreamPaths, boolean rewriteApiV1Prefix) {

--- a/gateway/src/test/java/com/seatliberator/seatliberator/GatewayRouteAlignmentTest.java
+++ b/gateway/src/test/java/com/seatliberator/seatliberator/GatewayRouteAlignmentTest.java
@@ -2,7 +2,9 @@ package com.seatliberator.seatliberator;
 
 import com.seatliberator.seatliberator.board.web.board.controller.BoardController;
 import com.seatliberator.seatliberator.board.web.category.controller.CategoryController;
+import com.seatliberator.seatliberator.board.web.comment.controller.CommentController;
 import com.seatliberator.seatliberator.board.web.post.controller.PostController;
+import com.seatliberator.seatliberator.board.web.user.controller.UserController;
 import com.seatliberator.seatliberator.notification.infrastructure.web.controller.NotificationController;
 import com.seatliberator.seatliberator.reservation.web.booking.controller.AvailabilityQueryController;
 import com.seatliberator.seatliberator.reservation.web.booking.controller.BookingController;
@@ -47,7 +49,7 @@ class GatewayRouteAlignmentTest {
                         SeatCommandController.class,
                         WaitlistController.class
                 ),
-                true
+                false
         );
     }
 
@@ -59,9 +61,11 @@ class GatewayRouteAlignmentTest {
                 controllerPaths(
                         BoardController.class,
                         CategoryController.class,
-                        PostController.class
+                        PostController.class,
+                        CommentController.class,
+                        UserController.class
                 ),
-                true
+                false
         );
     }
 

--- a/gateway/src/test/java/com/seatliberator/seatliberator/GatewayRouteAlignmentTest.java
+++ b/gateway/src/test/java/com/seatliberator/seatliberator/GatewayRouteAlignmentTest.java
@@ -12,7 +12,11 @@ import com.seatliberator.seatliberator.reservation.web.reservation.controller.Re
 import com.seatliberator.seatliberator.reservation.web.reservation.controller.UseReservationController;
 import com.seatliberator.seatliberator.reservation.web.seat.controller.SeatCommandController;
 import com.seatliberator.seatliberator.reservation.web.waitlist.controller.WaitlistController;
+import com.seatliberator.seatliberator.web.authentication.controller.AuthenticationController;
+import com.seatliberator.seatliberator.web.credential.controller.CredentialAccountController;
 import com.seatliberator.seatliberator.web.jwks.controller.JwksController;
+import com.seatliberator.seatliberator.web.role.controller.RoleController;
+import com.seatliberator.seatliberator.web.user.controller.UserRoleController;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.server.PathContainer;
@@ -33,7 +37,33 @@ class GatewayRouteAlignmentTest {
     @Test
     void identityControllerEntrypointsAreCoveredByGatewayRoutes() throws IOException {
         var patterns = gatewayPathPatterns();
-        assertCovered(patterns, controllerPaths(JwksController.class), false);
+        assertCovered(
+                patterns,
+                controllerPaths(
+                        JwksController.class,
+                        AuthenticationController.class,
+                        CredentialAccountController.class,
+                        RoleController.class,
+                        com.seatliberator.seatliberator.web.user.controller.UserController.class,
+                        UserRoleController.class
+                ),
+                false
+        );
+    }
+
+    @Test
+    void identitySecurityEntrypointsAreCoveredByGatewayRoutes() throws IOException {
+        var patterns = gatewayPathPatterns();
+        assertCovered(
+                patterns,
+                Set.of(
+                        "/api/v1/auth/sign-up",
+                        "/api/v1/auth/sign-in",
+                        "/api/v1/oauth2/authorization/github",
+                        "/api/v1/login/oauth2/code/github"
+                ),
+                false
+        );
     }
 
     @Test

--- a/identity/identity-server/identity-server-security/src/main/java/com/seatliberator/seatliberator/identity/server/security/authentication/method/credential/config/CredentialAuthenticationConfiguration.java
+++ b/identity/identity-server/identity-server-security/src/main/java/com/seatliberator/seatliberator/identity/server/security/authentication/method/credential/config/CredentialAuthenticationConfiguration.java
@@ -35,7 +35,7 @@ public class CredentialAuthenticationConfiguration {
     ) {
         return httpSecurity -> httpSecurity
                 .authorizeHttpRequests(registry -> registry
-                        .requestMatchers("/.well-known/jwks.json", "/auth/**")
+                        .requestMatchers("/.well-known/jwks.json", "/api/v1/auth/**")
                         .permitAll()
                 )
                 .addFilterBefore(jsonCredentialSignInProcessingFilter, UsernamePasswordAuthenticationFilter.class)
@@ -49,7 +49,7 @@ public class CredentialAuthenticationConfiguration {
             CredentialAuthenticationFailureHandler failureHandler,
             ObjectMapper objectMapper
     ) {
-        var matcher = PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, "/auth/sign-up");
+        var matcher = PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, "/api/v1/auth/sign-up");
         var filter = new JsonCredentialSignUpProcessingFilter(matcher, objectMapper);
 
         filter.setAuthenticationManager(credentialAuthenticationManager);
@@ -66,7 +66,7 @@ public class CredentialAuthenticationConfiguration {
             CredentialAuthenticationFailureHandler failureHandler,
             ObjectMapper objectMapper
     ) {
-        var matcher = PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, "/auth/sign-in");
+        var matcher = PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, "/api/v1/auth/sign-in");
         var filter = new JsonCredentialSignInProcessingFilter(matcher, objectMapper);
 
         filter.setAuthenticationManager(credentialAuthenticationManager);

--- a/identity/identity-server/identity-server-security/src/main/java/com/seatliberator/seatliberator/identity/server/security/authentication/method/credential/config/CredentialAuthenticationOpenApiConfiguration.java
+++ b/identity/identity-server/identity-server-security/src/main/java/com/seatliberator/seatliberator/identity/server/security/authentication/method/credential/config/CredentialAuthenticationOpenApiConfiguration.java
@@ -1,8 +1,8 @@
 package com.seatliberator.seatliberator.identity.server.security.authentication.method.credential.config;
 
-import com.nimbusds.oauth2.sdk.TokenResponse;
 import com.seatliberator.seatliberator.identity.server.security.authentication.method.credential.filter.CredentialSignInRequest;
 import com.seatliberator.seatliberator.identity.server.security.authentication.method.credential.filter.CredentialSignUpRequest;
+import com.seatliberator.seatliberator.identity.server.security.shared.response.TokenPayload;
 import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.oas.models.*;
 import io.swagger.v3.oas.models.media.Content;
@@ -21,7 +21,7 @@ import java.util.List;
 public class CredentialAuthenticationOpenApiConfiguration {
     private final static String SIGN_IN_SCHEMA_KEY = "CredentialSignInRequest";
     private final static String SIGN_UP_SCHEMA_KEY = "CredentialSignUpRequest";
-    private final static String TOKEN_SCHEMA_KEY = "IssuedTokenResponse";
+    private final static String TOKEN_SCHEMA_KEY = "TokenPayload";
 
     private final static List<ApiOperation> CREDENTIAL_OPERATIONS = List.of(
             new ApiOperation("/api/v1/auth/sign-in", "이메일 로그인", "이메일과 비밀번호로 로그인하고 토큰을 발급합니다.", SIGN_IN_SCHEMA_KEY),
@@ -79,12 +79,12 @@ public class CredentialAuthenticationOpenApiConfiguration {
     private void applySchema(OpenAPI openApi) {
         var credentialSignInSchema = resolveSchema(CredentialSignInRequest.class);
         var credentialSignUpSchema = resolveSchema(CredentialSignUpRequest.class);
-        var issuedTokenResponseSchema = resolveSchema(TokenResponse.class);
+        var tokenPayloadSchema = resolveSchema(TokenPayload.class);
 
         getComponents(openApi)
                 .addSchemas(SIGN_IN_SCHEMA_KEY, credentialSignInSchema)
                 .addSchemas(SIGN_UP_SCHEMA_KEY, credentialSignUpSchema)
-                .addSchemas(TOKEN_SCHEMA_KEY, issuedTokenResponseSchema);
+                .addSchemas(TOKEN_SCHEMA_KEY, tokenPayloadSchema);
     }
 
     private Schema<?> resolveSchema(Class<?> schema) {

--- a/identity/identity-server/identity-server-security/src/main/java/com/seatliberator/seatliberator/identity/server/security/authentication/method/credential/config/CredentialAuthenticationOpenApiConfiguration.java
+++ b/identity/identity-server/identity-server-security/src/main/java/com/seatliberator/seatliberator/identity/server/security/authentication/method/credential/config/CredentialAuthenticationOpenApiConfiguration.java
@@ -24,8 +24,8 @@ public class CredentialAuthenticationOpenApiConfiguration {
     private final static String TOKEN_SCHEMA_KEY = "IssuedTokenResponse";
 
     private final static List<ApiOperation> CREDENTIAL_OPERATIONS = List.of(
-            new ApiOperation("/auth/sign-in", "이메일 로그인", "이메일과 비밀번호로 로그인하고 토큰을 발급합니다.", SIGN_IN_SCHEMA_KEY),
-            new ApiOperation("/auth/sign-up", "이메일 회원가입", "닉네임, 이메일, 비밀번호로 계정을 생성하고 토큰을 발급합니다.", SIGN_UP_SCHEMA_KEY)
+            new ApiOperation("/api/v1/auth/sign-in", "이메일 로그인", "이메일과 비밀번호로 로그인하고 토큰을 발급합니다.", SIGN_IN_SCHEMA_KEY),
+            new ApiOperation("/api/v1/auth/sign-up", "이메일 회원가입", "닉네임, 이메일, 비밀번호로 계정을 생성하고 토큰을 발급합니다.", SIGN_UP_SCHEMA_KEY)
     );
 
     @Bean

--- a/identity/identity-server/identity-server-security/src/main/java/com/seatliberator/seatliberator/identity/server/security/authentication/method/federated/config/FederatedAuthenticationConfiguration.java
+++ b/identity/identity-server/identity-server-security/src/main/java/com/seatliberator/seatliberator/identity/server/security/authentication/method/federated/config/FederatedAuthenticationConfiguration.java
@@ -26,10 +26,16 @@ public class FederatedAuthenticationConfiguration {
     ) {
         return httpSecurity -> httpSecurity
                 .authorizeHttpRequests(registry -> registry
-                        .requestMatchers("/oauth2/**", "/login/**")
+                        .requestMatchers("/api/v1/oauth2/**", "/api/v1/login/**")
                         .permitAll()
                 )
                 .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(config -> config
+                                .baseUri("/api/v1/oauth2/authorization")
+                        )
+                        .redirectionEndpoint(config -> config
+                                .baseUri("/api/v1/login/oauth2/code/*")
+                        )
                         .userInfoEndpoint(config -> config
                                 .oidcUserService(customOidcUserService)
                                 .userService(customOAuth2UserService)

--- a/identity/identity-server/identity-server-webmvc/src/main/java/com/seatliberator/seatliberator/web/authentication/controller/AuthenticationController.java
+++ b/identity/identity-server/identity-server-webmvc/src/main/java/com/seatliberator/seatliberator/web/authentication/controller/AuthenticationController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Authentication", description = "인증 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/auth")
+@RequestMapping("/api/v1/auth")
 public class AuthenticationController {
     private final RefreshAccessTokenUseCase refreshAccessTokenUseCase;
 

--- a/identity/identity-server/identity-server-webmvc/src/main/java/com/seatliberator/seatliberator/web/credential/controller/CredentialAccountController.java
+++ b/identity/identity-server/identity-server-webmvc/src/main/java/com/seatliberator/seatliberator/web/credential/controller/CredentialAccountController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Account", description = "계정 관리 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/accounts")
+@RequestMapping("/api/v1/accounts")
 public class CredentialAccountController {
     private final UpdatePasswordUseCase updatePasswordUseCase;
 

--- a/identity/identity-server/identity-server-webmvc/src/main/java/com/seatliberator/seatliberator/web/role/controller/RoleController.java
+++ b/identity/identity-server/identity-server-webmvc/src/main/java/com/seatliberator/seatliberator/web/role/controller/RoleController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Role", description = "역할 관리 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/roles")
+@RequestMapping("/api/v1/roles")
 public class RoleController {
     private final GrantRoleUseCase grantRoleUseCase;
     private final RevokeRoleUseCase revokeRoleUseCase;

--- a/identity/identity-server/identity-server-webmvc/src/main/java/com/seatliberator/seatliberator/web/user/controller/UserController.java
+++ b/identity/identity-server/identity-server-webmvc/src/main/java/com/seatliberator/seatliberator/web/user/controller/UserController.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 @Tag(name = "User", description = "사용자 관리 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/users")
+@RequestMapping("/api/v1/users")
 public class UserController {
     private final UpdateNicknameUseCase updateNicknameUseCase;
 

--- a/identity/identity-server/identity-server-webmvc/src/main/java/com/seatliberator/seatliberator/web/user/controller/UserRoleController.java
+++ b/identity/identity-server/identity-server-webmvc/src/main/java/com/seatliberator/seatliberator/web/user/controller/UserRoleController.java
@@ -20,7 +20,7 @@ import java.util.UUID;
 @Tag(name = "User", description = "사용자 관리 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/users")
+@RequestMapping("/api/v1/users")
 public class UserRoleController {
     private final FindUserGrantedSummaryUseCase findUserGrantedSummaryUseCase;
 

--- a/identity/identity-server/identity-server-webmvc/src/main/resources/application.yml
+++ b/identity/identity-server/identity-server-webmvc/src/main/resources/application.yml
@@ -27,12 +27,12 @@ spring:
             client-id: ${GITHUB_CLIENT_ID}
             client-secret: ${GITHUB_CLIENT_SECRET}
             scope: read:user, user:email
-            redirect-uri: "{baseUrl}/login/oauth2/code/github"
+            redirect-uri: "{baseUrl}/api/v1/login/oauth2/code/github"
             client-name: GitHub
           google:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
             authorization-grant-type: authorization_code
             scope: openid, profile, email
-            redirect-uri: "{baseUrl}/login/oauth2/code/google"
+            redirect-uri: "{baseUrl}/api/v1/login/oauth2/code/google"
             client-name: Google

--- a/notification/notification-application/src/main/java/com/seatliberator/seatliberator/notification/infrastructure/web/controller/NotificationController.java
+++ b/notification/notification-application/src/main/java/com/seatliberator/seatliberator/notification/infrastructure/web/controller/NotificationController.java
@@ -9,11 +9,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Notifications", description = "사용자 알림 조회 API")
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1/notification")
 public class NotificationController {
     private final NotificationReader notificationReader;
     private final ActorContextHolder actorContextHolder;
@@ -23,7 +25,7 @@ public class NotificationController {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "401", description = "권한 없음")
     })
-    @GetMapping("/notification")
+    @GetMapping
     public ResponseEntity<?> getNotification() {
         var userId = actorContextHolder.getActor().subject();
         var result = notificationReader.readByTargetUserId(userId);

--- a/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/booking/controller/AvailabilityQueryController.java
+++ b/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/booking/controller/AvailabilityQueryController.java
@@ -12,22 +12,19 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-@Tag(name = "Seat Availability", description = "스터디룸 좌석 가용 상태 조회 API")
+@Tag(name = "Booking", description = "스터디룸 좌석 예약 관련 API")
+@RequestMapping("/api/v1/booking")
 @RestController
-@RequestMapping("/booking")
 @RequiredArgsConstructor
 public class AvailabilityQueryController {
+
     private final FindAvailableSlotsBySeatUseCase findAvailableSlotsBySeatUseCase;
 
     @Operation(summary = "좌석 예약 가능 슬롯 조회", description = "특정 좌석의 날짜별 예약 가능한 시간 슬롯 목록을 조회합니다.")

--- a/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/booking/controller/BookingController.java
+++ b/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/booking/controller/BookingController.java
@@ -22,10 +22,11 @@ import org.springframework.web.bind.annotation.*;
 import java.util.UUID;
 
 @Tag(name = "Booking", description = "스터디룸 좌석 예약 관련 API")
+@RequestMapping("/api/v1/booking")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/booking")
 public class BookingController {
+
     private final FindBookingUseCase findBookingUseCase;
     private final CreateBookingUseCase createBookingUseCase;
     private final CancelBookingUseCase cancelBookingUseCase;

--- a/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/reservation/controller/ReservationQueryController.java
+++ b/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/reservation/controller/ReservationQueryController.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -25,10 +24,9 @@ import java.util.List;
 import java.util.UUID;
 
 @Tag(name = "Reservations", description = "스터디룸 좌석 예약 관련 API")
-@Slf4j
+@RequestMapping("/api/v1/reservations")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/reservations")
 public class ReservationQueryController {
 
     private final ListReservationUseCase listReservationUseCase;

--- a/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/reservation/controller/UseReservationController.java
+++ b/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/reservation/controller/UseReservationController.java
@@ -22,8 +22,9 @@ import java.util.UUID;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/reservations")
+@RequestMapping("/api/v1/reservations")
 public class UseReservationController {
+
     private final UseReservationUseCase useReservationUseCase;
 
     @Operation(summary = "예약 사용", description = "특정 예약을 사용 처리 합니다.")

--- a/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/room/controller/RoomCommandController.java
+++ b/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/room/controller/RoomCommandController.java
@@ -17,7 +17,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -25,12 +24,12 @@ import org.springframework.web.bind.annotation.*;
 import java.util.UUID;
 
 @Tag(name = "Rooms", description = "스터디룸 방 관련 관리 API")
-@Slf4j
+@RequestMapping("/api/v1/rooms")
 @RestController
-@RequestMapping("/rooms")
 @RequiredArgsConstructor
 @PreAuthorize("hasAuthority('room.manage')")
 public class RoomCommandController {
+
     private final CreateRoomUseCase createRoomUseCase;
     private final UpdateRoomCodeUseCase updateRoomCodeUseCase;
     private final DeleteRoomUseCase deleteRoomUseCase;

--- a/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/room/controller/RoomQueryController.java
+++ b/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/room/controller/RoomQueryController.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,11 +21,11 @@ import java.util.List;
 import java.util.UUID;
 
 @Tag(name = "Rooms", description = "스터디룸 방 조회 관리 API")
-@Slf4j
+@RequestMapping("/api/v1/rooms")
 @RestController
-@RequestMapping("/rooms")
 @RequiredArgsConstructor
 public class RoomQueryController {
+
     private final ListRoomUseCase listRoomUseCase;
     private final FindRoomUseCase findRoomUseCase;
 

--- a/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/seat/controller/SeatCommandController.java
+++ b/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/seat/controller/SeatCommandController.java
@@ -14,17 +14,15 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
 @Tag(name = "Seats", description = "스터디룸 좌석 관련 관리 API")
-@Slf4j
+@RequestMapping("/api/v1/rooms")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/rooms")
 public class SeatCommandController {
 
     private final CreateSeatUseCase createSeatUseCase;

--- a/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/seat/controller/SeatQueryController.java
+++ b/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/seat/controller/SeatQueryController.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,11 +22,11 @@ import java.util.List;
 import java.util.UUID;
 
 @Tag(name = "Seats", description = "스터디룸 좌석 조회 관리 API")
-@Slf4j
+@RequestMapping("/api/v1/rooms")
 @RestController
-@RequestMapping("/rooms")
 @RequiredArgsConstructor
 public class SeatQueryController {
+
     private final ListSeatUseCase listSeatUseCase;
     private final FindSeatUseCase findSeatUseCase;
 

--- a/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/seat/controller/SeatTimeSlotCommandController.java
+++ b/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/seat/controller/SeatTimeSlotCommandController.java
@@ -14,17 +14,15 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
 @Tag(name = "Seats", description = "스터디룸 좌석 관련 관리 API")
-@Slf4j
+@RequestMapping("/api/v1/rooms")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/rooms")
 public class SeatTimeSlotCommandController {
 
     private final CreateSeatTimeSlotUseCase createSeatTimeSlotUseCase;

--- a/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/seat/controller/SeatTimeSlotQueryController.java
+++ b/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/seat/controller/SeatTimeSlotQueryController.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,9 +21,8 @@ import java.util.List;
 import java.util.UUID;
 
 @Tag(name = "Seats", description = "스터디룸 좌석 조회 관리 API")
-@Slf4j
+@RequestMapping("/api/v1/rooms")
 @RestController
-@RequestMapping("/rooms")
 @RequiredArgsConstructor
 public class SeatTimeSlotQueryController {
 

--- a/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/waitlist/controller/WaitlistController.java
+++ b/reservation/reservation-web-mvc/src/main/java/com/seatliberator/seatliberator/reservation/web/waitlist/controller/WaitlistController.java
@@ -18,9 +18,9 @@ import org.springframework.web.bind.annotation.*;
 import java.util.UUID;
 
 @Tag(name = "Waitlist", description = "좌석 대기열 요청 관련 API")
+@RequestMapping("/api/v1/waitlist")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/waitlist")
 public class WaitlistController {
 
     private final CreateWaitlistUseCase createWaitlistUseCase;

--- a/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/web/booking/AvailabilityQueryControllerTest.java
+++ b/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/web/booking/AvailabilityQueryControllerTest.java
@@ -59,7 +59,7 @@ public class AvailabilityQueryControllerTest {
                 .willReturn(Map.of());
 
         // when
-        mockMvc.perform(get("/booking/seats/{seatId}/available-slots", seatId)
+        mockMvc.perform(get("/api/v1/booking/seats/{seatId}/available-slots", seatId)
                         .queryParam("start", startAt.toString())
                         .queryParam("end", endAt.toString()))
                 .andExpect(status().isOk());
@@ -86,7 +86,7 @@ public class AvailabilityQueryControllerTest {
                 .willReturn(result);
 
         // when & then
-        mockMvc.perform(get("/booking/seats/{seatId}/available-slots", seatId)
+        mockMvc.perform(get("/api/v1/booking/seats/{seatId}/available-slots", seatId)
                         .queryParam("start", startAt.toString())
                         .queryParam("end", endAt.toString())
                         .accept(MediaType.APPLICATION_JSON))
@@ -98,7 +98,7 @@ public class AvailabilityQueryControllerTest {
     @DisplayName("seatId path variable 형식이 잘못되면 400 Bad Request를 반환한다")
     void find_available_slots_returns_bad_request_when_seat_id_is_invalid() throws Exception {
         // when & then
-        mockMvc.perform(get("/booking/seats/{seatId}/available-slots", "not-a-uuid")
+        mockMvc.perform(get("/api/v1/booking/seats/{seatId}/available-slots", "not-a-uuid")
                         .queryParam("start", "2026-05-18")
                         .queryParam("end", "2026-05-20"))
                 .andExpect(status().isBadRequest());
@@ -110,7 +110,7 @@ public class AvailabilityQueryControllerTest {
     @DisplayName("날짜 요청 파라미터 형식이 잘못되면 400 Bad Request를 반환한다")
     void find_available_slots_returns_bad_request_when_date_is_invalid() throws Exception {
         // when & then
-        mockMvc.perform(get("/booking/seats/{seatId}/available-slots", uuid.generate())
+        mockMvc.perform(get("/api/v1/booking/seats/{seatId}/available-slots", uuid.generate())
                         .queryParam("start", "not-a-date")
                         .queryParam("end", "2026-05-20"))
                 .andExpect(status().isBadRequest());

--- a/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/web/reservation/ReservationControllerTest.java
+++ b/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/web/reservation/ReservationControllerTest.java
@@ -60,7 +60,7 @@ public class ReservationControllerTest {
                 .willReturn(List.of());
 
         // when
-        mockMvc.perform(get("/reservations")
+        mockMvc.perform(get("/api/v1/reservations")
                         .queryParam("userId", userId)
                         .queryParam("status", status.name())
                         .queryParam("start", startAt.toString())
@@ -88,7 +88,7 @@ public class ReservationControllerTest {
                 .willReturn(List.of());
 
         // when
-        mockMvc.perform(get("/reservations")
+        mockMvc.perform(get("/api/v1/reservations")
                         .queryParam("userId", userId)
                         .queryParam("status", status.name()))
                 .andExpect(status().isOk());
@@ -117,7 +117,7 @@ public class ReservationControllerTest {
                 .willReturn(result);
 
         // when & then
-        mockMvc.perform(get("/reservations")
+        mockMvc.perform(get("/api/v1/reservations")
                         .queryParam("userId", userId)
                         .queryParam("status", status.name())
                         .queryParam("start", startAt.toString())
@@ -131,7 +131,7 @@ public class ReservationControllerTest {
     @DisplayName("예약 목록 조회 요청 파라미터가 누락되면 400 Bad Request를 반환한다")
     void list_returns_bad_request_when_required_parameter_is_missing() throws Exception {
         // when & then
-        mockMvc.perform(get("/reservations")
+        mockMvc.perform(get("/api/v1/reservations")
                         .queryParam("userId", "user-1")
                         .queryParam("start", "2026-04-14T00:00:00Z")
                         .queryParam("end", "2026-04-15T00:00:00Z"))
@@ -144,7 +144,7 @@ public class ReservationControllerTest {
     @DisplayName("상태 시각 요청 파라미터가 한쪽만 전달되면 400 Bad Request를 반환한다")
     void list_returns_bad_request_when_status_range_parameter_is_partial() throws Exception {
         // when & then
-        mockMvc.perform(get("/reservations")
+        mockMvc.perform(get("/api/v1/reservations")
                         .queryParam("userId", "user-1")
                         .queryParam("status", ReservationStatus.RESERVED.name())
                         .queryParam("start", "2026-04-14T00:00:00Z"))
@@ -157,7 +157,7 @@ public class ReservationControllerTest {
     @DisplayName("status 요청 파라미터 형식이 잘못되면 400 Bad Request를 반환한다")
     void list_returns_bad_request_when_status_is_invalid() throws Exception {
         // when & then
-        mockMvc.perform(get("/reservations")
+        mockMvc.perform(get("/api/v1/reservations")
                         .queryParam("userId", "user-1")
                         .queryParam("status", "not-a-status")
                         .queryParam("start", "2026-04-14T00:00:00Z")
@@ -171,7 +171,7 @@ public class ReservationControllerTest {
     @DisplayName("상태 시각 요청 파라미터 형식이 잘못되면 400 Bad Request를 반환한다")
     void list_returns_bad_request_when_status_range_is_invalid() throws Exception {
         // when & then
-        mockMvc.perform(get("/reservations")
+        mockMvc.perform(get("/api/v1/reservations")
                         .queryParam("userId", "user-1")
                         .queryParam("status", ReservationStatus.RESERVED.name())
                         .queryParam("start", "not-an-instant")
@@ -192,7 +192,7 @@ public class ReservationControllerTest {
                 .willReturn(result);
 
         // when
-        mockMvc.perform(get("/reservations/{reservationId}", reservationId))
+        mockMvc.perform(get("/api/v1/reservations/{reservationId}", reservationId))
                 .andExpect(status().isOk());
 
         // then
@@ -214,7 +214,7 @@ public class ReservationControllerTest {
                 .willReturn(result);
 
         // when & then
-        mockMvc.perform(get("/reservations/{reservationId}", reservationId)
+        mockMvc.perform(get("/api/v1/reservations/{reservationId}", reservationId)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(result)));
@@ -224,7 +224,7 @@ public class ReservationControllerTest {
     @DisplayName("reservationId path variable 형식이 잘못되면 400 Bad Request를 반환한다")
     void find_returns_bad_request_when_reservation_id_is_invalid() throws Exception {
         // when & then
-        mockMvc.perform(get("/reservations/{reservationId}", "not-a-uuid"))
+        mockMvc.perform(get("/api/v1/reservations/{reservationId}", "not-a-uuid"))
                 .andExpect(status().isBadRequest());
 
         verifyNoInteractions(findReservationUseCase);

--- a/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/web/reservation/UseReservationControllerTest.java
+++ b/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/web/reservation/UseReservationControllerTest.java
@@ -52,7 +52,7 @@ public class UseReservationControllerTest {
                 .willReturn(result);
 
         // when
-        mockMvc.perform(post("/reservations/{reservationId}", reservationId))
+        mockMvc.perform(post("/api/v1/reservations/{reservationId}", reservationId))
                 .andExpect(status().isOk());
 
         // then
@@ -74,7 +74,7 @@ public class UseReservationControllerTest {
                 .willReturn(result);
 
         // when & then
-        mockMvc.perform(post("/reservations/{reservationId}", reservationId)
+        mockMvc.perform(post("/api/v1/reservations/{reservationId}", reservationId)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(result)));
@@ -84,7 +84,7 @@ public class UseReservationControllerTest {
     @DisplayName("reservationId path variable 형식이 잘못되면 400 Bad Request를 반환한다")
     void use_returns_bad_request_when_reservation_id_is_invalid() throws Exception {
         // when & then
-        mockMvc.perform(post("/reservations/{reservationId}", "not-a-uuid"))
+        mockMvc.perform(post("/api/v1/reservations/{reservationId}", "not-a-uuid"))
                 .andExpect(status().isBadRequest());
 
         verifyNoInteractions(useReservationUseCase);

--- a/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/web/room/RoomCommandControllerMvcTest.java
+++ b/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/web/room/RoomCommandControllerMvcTest.java
@@ -116,7 +116,7 @@ public class RoomCommandControllerMvcTest {
         void create_room_unauthenticated() throws Exception {
             var request = new CreateRoomRequest("study-room-1");
 
-            mockMvc.perform(post("/rooms")
+            mockMvc.perform(post("/api/v1/rooms")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isUnauthorized());
@@ -128,7 +128,7 @@ public class RoomCommandControllerMvcTest {
         void create_room_forbidden() throws Exception {
             var request = new CreateRoomRequest("study-room-1");
 
-            mockMvc.perform(post("/rooms")
+            mockMvc.perform(post("/api/v1/rooms")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isForbidden());
@@ -143,7 +143,7 @@ public class RoomCommandControllerMvcTest {
 
             when(createRoomUseCase.create(any(CreateRoomCommand.class))).thenReturn(result);
 
-            mockMvc.perform(post("/rooms")
+            mockMvc.perform(post("/api/v1/rooms")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())
@@ -165,7 +165,7 @@ public class RoomCommandControllerMvcTest {
         void unauthorized() throws Exception {
             var request = new UpdateRoomCodeRequest("new-room-1");
 
-            mockMvc.perform(put("/rooms/{roomId}", roomId)
+            mockMvc.perform(put("/api/v1/rooms/{roomId}", roomId)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isUnauthorized());
@@ -177,7 +177,7 @@ public class RoomCommandControllerMvcTest {
         void forbidden() throws Exception {
             var request = new UpdateRoomCodeRequest("new-room-1");
 
-            mockMvc.perform(put("/rooms/{roomId}", roomId)
+            mockMvc.perform(put("/api/v1/rooms/{roomId}", roomId)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isForbidden());
@@ -195,7 +195,7 @@ public class RoomCommandControllerMvcTest {
             when(updateRoomCodeUseCase.update(any(UpdateRoomCodeCommand.class)))
                     .thenReturn(result);
 
-            mockMvc.perform(put("/rooms/{roomId}", roomId)
+            mockMvc.perform(put("/api/v1/rooms/{roomId}", roomId)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())
@@ -220,7 +220,7 @@ public class RoomCommandControllerMvcTest {
         void unauthorized() throws Exception {
             var request = updateRoomOperationPolicyRequest();
 
-            mockMvc.perform(put("/rooms/{roomId}/policy", roomId)
+            mockMvc.perform(put("/api/v1/rooms/{roomId}/policy", roomId)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isUnauthorized());
@@ -232,7 +232,7 @@ public class RoomCommandControllerMvcTest {
         void forbidden() throws Exception {
             var request = updateRoomOperationPolicyRequest();
 
-            mockMvc.perform(put("/rooms/{roomId}/policy", roomId)
+            mockMvc.perform(put("/api/v1/rooms/{roomId}/policy", roomId)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isForbidden());
@@ -255,7 +255,7 @@ public class RoomCommandControllerMvcTest {
             when(updateRoomOperationPolicyUseCase.update(any(UpdateRoomOperationPolicyCommand.class)))
                     .thenReturn(result);
 
-            mockMvc.perform(put("/rooms/{roomId}/policy", roomId)
+            mockMvc.perform(put("/api/v1/rooms/{roomId}/policy", roomId)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())
@@ -305,7 +305,7 @@ public class RoomCommandControllerMvcTest {
         @Test
         @DisplayName("인증되지 않으면 401")
         void unauthorized() throws Exception {
-            mockMvc.perform(delete("/rooms/{roomId}", roomId))
+            mockMvc.perform(delete("/api/v1/rooms/{roomId}", roomId))
                     .andExpect(status().isUnauthorized());
         }
 
@@ -313,7 +313,7 @@ public class RoomCommandControllerMvcTest {
         @WithMockUser(authorities = "other.permission")
         @DisplayName("room.manage 권한이 없으면 403")
         void forbidden() throws Exception {
-            mockMvc.perform(delete("/rooms/{roomId}", roomId))
+            mockMvc.perform(delete("/api/v1/rooms/{roomId}", roomId))
                     .andExpect(status().isForbidden());
 
             verify(deleteRoomUseCase, never()).delete(any());
@@ -323,7 +323,7 @@ public class RoomCommandControllerMvcTest {
         @WithMockUser(authorities = "room.manage")
         @DisplayName("권한이 있으면 path variable로 삭제 command를 만들어 유스케이스를 호출한다")
         void delete_room() throws Exception {
-            mockMvc.perform(delete("/rooms/{roomId}", roomId))
+            mockMvc.perform(delete("/api/v1/rooms/{roomId}", roomId))
                     .andExpect(status().isNoContent());
 
             var captor = ArgumentCaptor.forClass(DeleteRoomCommand.class);

--- a/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/web/room/RoomQueryControllerMvcTest.java
+++ b/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/web/room/RoomQueryControllerMvcTest.java
@@ -91,7 +91,7 @@ public class RoomQueryControllerMvcTest {
         @Test
         @DisplayName("인증되지 않으면 401")
         void unauthorized() throws Exception {
-            mockMvc.perform(get("/rooms"))
+            mockMvc.perform(get("/api/v1/rooms"))
                     .andExpect(status().isUnauthorized());
         }
 
@@ -99,7 +99,7 @@ public class RoomQueryControllerMvcTest {
         @WithMockUser(authorities = "other.permission")
         @DisplayName("room.list 권한이 없으면 403")
         void forbidden() throws Exception {
-            mockMvc.perform(get("/rooms"))
+            mockMvc.perform(get("/api/v1/rooms"))
                     .andExpect(status().isForbidden());
 
             verify(listRoomUseCase, never()).list();
@@ -112,7 +112,7 @@ public class RoomQueryControllerMvcTest {
             var result = List.of(new RoomResult(roomId, "study-room-1", null, now));
             when(listRoomUseCase.list()).thenReturn(result);
 
-            mockMvc.perform(get("/rooms"))
+            mockMvc.perform(get("/api/v1/rooms"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$[0].roomId").value(roomId.toString()))
                     .andExpect(jsonPath("$[0].code").value("study-room-1"));
@@ -127,7 +127,7 @@ public class RoomQueryControllerMvcTest {
         @Test
         @DisplayName("인증되지 않으면 401")
         void unauthorized() throws Exception {
-            mockMvc.perform(get("/rooms/{roomId}", roomId))
+            mockMvc.perform(get("/api/v1/rooms/{roomId}", roomId))
                     .andExpect(status().isUnauthorized());
         }
 
@@ -135,7 +135,7 @@ public class RoomQueryControllerMvcTest {
         @WithMockUser(authorities = "other.permission")
         @DisplayName("room.read 권한이 없으면 403")
         void forbidden() throws Exception {
-            mockMvc.perform(get("/rooms/{roomId}", roomId))
+            mockMvc.perform(get("/api/v1/rooms/{roomId}", roomId))
                     .andExpect(status().isForbidden());
 
             verify(findRoomUseCase, never()).find(any());
@@ -148,7 +148,7 @@ public class RoomQueryControllerMvcTest {
             when(findRoomUseCase.find(any(FindRoomQuery.class)))
                     .thenReturn(new RoomResult(roomId, "study-room-1", null, now));
 
-            mockMvc.perform(get("/rooms/{roomId}", roomId))
+            mockMvc.perform(get("/api/v1/rooms/{roomId}", roomId))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.roomId").value(roomId.toString()))
                     .andExpect(jsonPath("$.code").value("study-room-1"));

--- a/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/web/seat/SeatQueryControllerMvcTest.java
+++ b/reservation/reservation-web-mvc/src/test/java/com/seatliberator/seatliberator/reservation/web/seat/SeatQueryControllerMvcTest.java
@@ -95,7 +95,7 @@ public class SeatQueryControllerMvcTest {
         @Test
         @DisplayName("인증되지 않으면 401")
         void unauthorized() throws Exception {
-            mockMvc.perform(get("/rooms/{roomId}/seats", roomId))
+            mockMvc.perform(get("/api/v1/rooms/{roomId}/seats", roomId))
                     .andExpect(status().isUnauthorized());
         }
 
@@ -103,7 +103,7 @@ public class SeatQueryControllerMvcTest {
         @WithMockUser(authorities = "other.permission")
         @DisplayName("seat.list 권한이 없으면 403")
         void forbidden() throws Exception {
-            mockMvc.perform(get("/rooms/{roomId}/seats", roomId))
+            mockMvc.perform(get("/api/v1/rooms/{roomId}/seats", roomId))
                     .andExpect(status().isForbidden());
 
             verify(listSeatUseCase, never()).list(any());
@@ -116,7 +116,7 @@ public class SeatQueryControllerMvcTest {
             var result = List.of(new SeatResult(seatId, "seat-a", now, SeatStatus.ACTIVE, null, null));
             when(listSeatUseCase.list(any(ListSeatQuery.class))).thenReturn(result);
 
-            mockMvc.perform(get("/rooms/{roomId}/seats", roomId))
+            mockMvc.perform(get("/api/v1/rooms/{roomId}/seats", roomId))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$[0].seatId").value(seatId.toString()))
                     .andExpect(jsonPath("$[0].code").value("seat-a"));
@@ -133,7 +133,7 @@ public class SeatQueryControllerMvcTest {
         @Test
         @DisplayName("인증되지 않으면 401")
         void unauthorized() throws Exception {
-            mockMvc.perform(get("/rooms/{roomId}/seats/{seatId}", roomId, seatId))
+            mockMvc.perform(get("/api/v1/rooms/{roomId}/seats/{seatId}", roomId, seatId))
                     .andExpect(status().isUnauthorized());
         }
 
@@ -141,7 +141,7 @@ public class SeatQueryControllerMvcTest {
         @WithMockUser(authorities = "other.permission")
         @DisplayName("seat.read 권한이 없으면 403")
         void forbidden() throws Exception {
-            mockMvc.perform(get("/rooms/{roomId}/seats/{seatId}", roomId, seatId))
+            mockMvc.perform(get("/api/v1/rooms/{roomId}/seats/{seatId}", roomId, seatId))
                     .andExpect(status().isForbidden());
 
             verify(findSeatUseCase, never()).find(any());
@@ -154,7 +154,7 @@ public class SeatQueryControllerMvcTest {
             when(findSeatUseCase.find(any(FindSeatQuery.class)))
                     .thenReturn(new SeatResult(seatId, "seat-a", now, SeatStatus.ACTIVE, null, null));
 
-            mockMvc.perform(get("/rooms/{roomId}/seats/{seatId}", roomId, seatId))
+            mockMvc.perform(get("/api/v1/rooms/{roomId}/seats/{seatId}", roomId, seatId))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.seatId").value(seatId.toString()))
                     .andExpect(jsonPath("$.code").value("seat-a"));


### PR DESCRIPTION
## 관련 이슈
- 없음

## 변경 사항
- reservation-web-mvc 컨트롤러와 테스트를 `/api/v1` 경로 기준으로 정렬
- board web-mvc 컨트롤러와 보안 matcher를 `/api/v1/board/**` 기준으로 정렬
- identity-server REST 컨트롤러, credential 인증, OAuth2 client 진입점과 redirect URI를 `/api/v1` 기준으로 정렬
- notification 엔드포인트를 `/api/v1/notification`으로 변경하고 gateway rewrite 제거
- gateway route alignment 테스트에 컨트롤러 및 security 진입점 커버리지 보강

## 배경 및 의도
- gateway가 `/api/v1` prefix를 rewrite하던 구조를 줄이고 각 애플리케이션 web 진입점이 API 버전을 직접 표기하도록 맞췄습니다.
- identity-server는 web-mvc 컨트롤러 외에도 credential filter와 OAuth2 client entrypoint가 있어 동일한 외부 경로 정책을 security 설정까지 확장했습니다.
- JWKS `/.well-known/jwks.json`은 표준 discovery 경로라 버저닝 대상에서 제외했습니다.

## 후속 작업
- README 등 문서 업데이트는 별도 PR에서 일괄 반영 예정입니다.

## 검증
- `./gradlew :reservation:reservation-web-mvc:test`
- `./gradlew :gateway:test :reservation:reservation-web-mvc:test`
- `./gradlew :board:board-web-mvc:test :gateway:test`
- `./gradlew :identity:identity-server:identity-server-webmvc:compileJava :identity:identity-server:identity-server-security:compileJava :gateway:test`
- `./gradlew :identity:identity-server:identity-server-webmvc:test :identity:identity-server:identity-server-security:test`
- `./gradlew :notification:notification-application:test :gateway:test`