### PR TITLE
fix(identity-webmvc): GlobalAdvice 추가

### DIFF
--- a/identity/identity-server/identity-server-webmvc/src/main/java/com/seatliberator/seatliberator/web/shared/advice/IdentityServerGlobalControllerAdvice.java
+++ b/identity/identity-server/identity-server-webmvc/src/main/java/com/seatliberator/seatliberator/web/shared/advice/IdentityServerGlobalControllerAdvice.java
@@ -1,0 +1,138 @@
+package com.seatliberator.seatliberator.web.shared.advice;
+
+import com.seatliberator.seatliberator.identity.server.application.shared.exception.IdentityApplicationErrorCode;
+import com.seatliberator.seatliberator.identity.server.application.shared.exception.IdentityApplicationException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.net.URI;
+import java.util.Locale;
+
+@Slf4j
+@RestControllerAdvice
+public class IdentityServerGlobalControllerAdvice {
+    @ExceptionHandler(IdentityApplicationException.class)
+    public ProblemDetail handleIdentityApplicationException(
+            IdentityApplicationException exception,
+            HttpServletRequest request
+    ) {
+        var errorCode = exception.getErrorCode();
+        var status = resolveStatus(errorCode);
+
+        log.warn("Identity server application error. code={}, path={}", errorCode, request.getRequestURI());
+
+        var problem = ProblemDetail.forStatusAndDetail(status, errorCode.getMessage());
+        problem.setTitle(errorCode.name());
+        problem.setTitle(errorCode.name());
+        problem.setType(URI.create("https://seatliberator/errors/" + errorCode.name().toLowerCase(Locale.ROOT)));
+        problem.setProperty("code", errorCode.name());
+        return problem;
+    }
+
+    @ExceptionHandler({
+            MethodArgumentNotValidException.class,
+            BindException.class,
+            ConstraintViolationException.class,
+            HttpMessageNotReadableException.class,
+            MethodArgumentTypeMismatchException.class,
+            MissingServletRequestParameterException.class
+    })
+    public ProblemDetail handleBadRequest(Exception exception, HttpServletRequest request) {
+        log.warn("Bad request. type={}, path={}, message={}",
+                exception.getClass().getSimpleName(),
+                request.getRequestURI(),
+                exception.getMessage());
+
+        var problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.");
+        problem.setTitle("BAD_REQUEST");
+        problem.setType(URI.create("https://seatliberator/errors/bad-request"));
+        problem.setProperty("code", "BAD_REQUEST");
+        return problem;
+    }
+
+    @ExceptionHandler({
+            AccessDeniedException.class,
+            AuthorizationDeniedException.class
+    })
+    public ProblemDetail handelAccessDenied(Exception exception, HttpServletRequest request) {
+        log.warn("AccessDenied type={}, path={}, message={}",
+                exception.getClass().getSimpleName(),
+                request.getRequestURI(),
+                exception.getMessage());
+
+        var problem = ProblemDetail.forStatusAndDetail(HttpStatus.FORBIDDEN, "권한이 없습니다");
+        problem.setTitle("FORBIDDEN");
+        problem.setType(URI.create("https://seatliberator/errors/forbidden"));
+        problem.setProperty("code", "FORBIDDEN");
+        return problem;
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ProblemDetail handleIllegalArgument(
+            IllegalArgumentException exception,
+            HttpServletRequest request
+    ) {
+        log.warn("Illegal argument. path={}, message={}", request.getRequestURI(), exception.getMessage());
+
+        var problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "요청 값이 올바르지 않습니다.");
+        problem.setTitle("INVALID_ARGUMENT");
+        problem.setType(URI.create("https://seatliberator/errors/invalid-argument"));
+        problem.setProperty("code", "INVALID_ARGUMENT");
+        return problem;
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ProblemDetail handleIllegalState(
+            IllegalStateException exception,
+            HttpServletRequest request
+    ) {
+        log.error("Illegal state. path={}", request.getRequestURI(), exception);
+
+        var problem = ProblemDetail.forStatusAndDetail(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "요청 처리 중 오류가 발생했습니다."
+        );
+        problem.setTitle("INTERNAL_SERVER_ERROR");
+        problem.setType(URI.create("https://seatliberator/errors/internal-server-error"));
+        problem.setProperty("code", "INTERNAL_SERVER_ERROR");
+        return problem;
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ProblemDetail handleUnhandled(
+            Exception exception,
+            HttpServletRequest request
+    ) {
+        log.error("Unhandled exception. path={}", request.getRequestURI(), exception);
+
+        var problem = ProblemDetail.forStatusAndDetail(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "알 수 없는 오류가 발생했습니다."
+        );
+        problem.setTitle("UNEXPECTED_ERROR");
+        problem.setType(URI.create("https://seatliberator/errors/unexpected-error"));
+        problem.setProperty("code", "UNEXPECTED_ERROR");
+        return problem;
+    }
+
+    private HttpStatus resolveStatus(IdentityApplicationErrorCode errorCode) {
+        return switch (errorCode) {
+            case ACCOUNT_NOT_FOUND, GRANT_NOT_FOUND, USER_NOT_FOUND -> HttpStatus.NOT_FOUND;
+            case EMAIL_DUPLICATED, ACCOUNT_ALREADY_EXISTS -> HttpStatus.CONFLICT;
+            case AUTHENTICATION_FAILED -> HttpStatus.FORBIDDEN;
+            default -> HttpStatus.BAD_REQUEST;
+        };
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- 없음

## 변경 사항
- identity-server-webmvc에 `IdentityServerGlobalControllerAdvice`를 추가
- `IdentityApplicationException`의 error code를 HTTP 상태와 `ProblemDetail` code/type/title로 변환
- 요청 검증, 권한 거부, `IllegalArgumentException`/`IllegalStateException`, 미처리 예외를 공통 `ProblemDetail` 응답으로 처리

## 배경 및 의도
- identity 서버 webmvc 계층에서 예외 응답 형식을 일관되게 관리하기 위함입니다.
- application error code를 API 응답의 status/code/type에 연결해 클라이언트가 실패 원인을 구분할 수 있게 합니다.

## 후속 작업
- 없음

## 검증
- `./gradlew :identity:identity-server:identity-server-webmvc:test` (성공, 테스트 소스 없음)
